### PR TITLE
Add document deletion from UI

### DIFF
--- a/frontend/e2e/documents.spec.ts
+++ b/frontend/e2e/documents.spec.ts
@@ -47,7 +47,23 @@ test('delete document from detail page', async ({ page }) => {
 
   await expect(page).toHaveURL(/\/$/)
   await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible()
+  await expect(page.getByText('Loading documents...')).toHaveCount(0)
   await expect(page.locator(`main a[href="/document/${documentId}"]`)).toHaveCount(0)
+})
+
+test('cancel document delete keeps detail page', async ({ page }) => {
+  await loginAsUser(page)
+  await uploadFixture(page, 'sample.txt')
+
+  const documentURL = page.url()
+  const documentId = documentURL.match(/\/document\/([^/?#]+)/)?.[1]
+  expect(documentId).toBeTruthy()
+
+  page.once('dialog', (dialog) => dialog.dismiss())
+  await page.getByRole('button', { name: 'Delete' }).click()
+
+  await expect(page).toHaveURL(new RegExp(`/document/${documentId}`))
+  await expect(page.getByRole('button', { name: 'Delete' })).toBeEnabled()
 })
 
 test('reject duplicate file upload', async ({ page }) => {

--- a/frontend/e2e/documents.spec.ts
+++ b/frontend/e2e/documents.spec.ts
@@ -34,6 +34,22 @@ test('edit document title on detail page', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'E2E Edited Title' })).toBeVisible()
 })
 
+test('delete document from detail page', async ({ page }) => {
+  await loginAsUser(page)
+  await uploadFixture(page, 'sample.txt')
+
+  const documentURL = page.url()
+  const documentId = documentURL.match(/\/document\/([^/?#]+)/)?.[1]
+  expect(documentId).toBeTruthy()
+
+  page.once('dialog', (dialog) => dialog.accept())
+  await page.getByRole('button', { name: 'Delete' }).click()
+
+  await expect(page).toHaveURL(/\/$/)
+  await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible()
+  await expect(page.locator(`main a[href="/document/${documentId}"]`)).toHaveCount(0)
+})
+
 test('reject duplicate file upload', async ({ page }) => {
   await loginAsUser(page)
 

--- a/frontend/src/routes/document.$documentId.tsx
+++ b/frontend/src/routes/document.$documentId.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useEffect, useState } from 'react'
-import { Link, useParams } from '@tanstack/react-router'
+import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import {
   defaultReprocessSteps,
   ensureAuth,
@@ -18,6 +18,7 @@ import {
 
 export function DocumentDetailPage() {
   const { documentId } = useParams({ from: '/document/$documentId' })
+  const navigate = useNavigate()
   const [document, setDocument] = useState<DocumentRecord | null>(null)
   const [job, setJob] = useState<ProcessingJobRecord | null>(null)
   const [tagInput, setTagInput] = useState('')
@@ -27,6 +28,7 @@ export function DocumentDetailPage() {
   const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
   const [reprocessing, setReprocessing] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [reprocessSteps, setReprocessSteps] = useState<ProcessingStep[]>([])
   const [showProcessingJob, setShowProcessingJob] = useState(false)
   const [error, setError] = useState('')
@@ -166,6 +168,31 @@ export function DocumentDetailPage() {
       setError(err instanceof Error ? err.message : 'Failed to reprocess document')
     } finally {
       setReprocessing(false)
+    }
+  }
+
+  async function onDelete() {
+    if (!document || deleting) {
+      return
+    }
+
+    const title = document.title?.trim() || 'Untitled document'
+    const confirmed = window.confirm(
+      `Delete "${title}"?\n\nThis permanently removes the document and cannot be undone.`,
+    )
+    if (!confirmed) {
+      return
+    }
+
+    try {
+      setDeleting(true)
+      setMessage('')
+      setError('')
+      await pb.collection('documents').delete(document.id)
+      await navigate({ to: '/' })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete document')
+      setDeleting(false)
     }
   }
 
@@ -329,6 +356,14 @@ export function DocumentDetailPage() {
               Open file
             </a>
           )}
+          <button
+            type="button"
+            onClick={() => void onDelete()}
+            disabled={deleting}
+            className="rounded-md border border-red-300 bg-red-50 px-4 py-2 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </button>
           {job ? (
             <button
               type="button"

--- a/frontend/src/routes/document.$documentId.tsx
+++ b/frontend/src/routes/document.$documentId.tsx
@@ -74,7 +74,10 @@ export function DocumentDetailPage() {
 
     let unsubscribe: (() => void) | undefined
 
-    void pb.collection('documents').subscribe(documentId, () => {
+    void pb.collection('documents').subscribe(documentId, (event) => {
+      if (event.action === 'delete') {
+        return
+      }
       load()
     }).then((fn) => {
       unsubscribe = fn
@@ -189,11 +192,13 @@ export function DocumentDetailPage() {
       setMessage('')
       setError('')
       await pb.collection('documents').delete(document.id)
-      await navigate({ to: '/' })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete document')
       setDeleting(false)
+      return
     }
+
+    await navigate({ to: '/' })
   }
 
   async function onSave(event: FormEvent) {


### PR DESCRIPTION
## Summary
- Add a Delete button on the document detail page with confirm, PocketBase delete, and navigate home
- Cover the flow with a Playwright e2e test

Fixes #8

## Test plan
- [x] `./scripts/test-all.sh` (unit + API e2e + Playwright)
- [ ] Manually: open a document → Delete → confirm → land on Documents list without that item
- [ ] Manually: open a document → Delete → cancel → stay on detail page