### PR TITLE
Import from Paperless-ngx (#12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,24 +17,68 @@ Do not consider the issue resolved until the PR exists and verification has pass
 
 When the user asks to review a GitHub pull request:
 
-1. Read the PR and its diff (`gh pr view <number|url> --json title,body,files,commits` and `gh pr diff <number|url>`).
+1. Read the PR and its diff (`gh pr view <number|url> --json title,body,files,commits` and `gh pr diff <number|url>`). Resolve `OWNER`, `REPO`, `PULL_NUMBER`, and the head `commit_id` (SHA) from that metadata.
 2. Perform the review (code quality, correctness, tests, and anything the user asked for).
-3. Post the results as a GitHub PR review with `gh pr review`, not only in chat. Include a clear summary and concrete findings.
+3. Post the results on GitHub, not only in chat. Prefer inline comments on the changed lines (via `gh api`); use a top-level-only `gh pr review` only when there are no line-specific findings.
 
-Use `gh pr review` with an appropriate event (`--comment`, `--request-changes`, or `--approve`) and a HEREDOC body, for example:
+`gh pr review` supports only review-level actions (`--approve`, `--comment`, `--request-changes`, `--body` / `--body-file`). It cannot attach `path` / `line` / `side` / `start_line` inline comments. Use the REST API via `gh api` instead.
+
+### Submitted review with grouped inline comments (preferred for a full review)
 
 ```bash
-gh pr review <number|url> --comment --body "$(cat <<'EOF'
-## Review
-
-- Finding 1
-- Finding 2
-
+gh api repos/OWNER/REPO/pulls/PULL_NUMBER/reviews \
+  --method POST \
+  --input - <<'EOF'
+{
+  "commit_id": "<HEAD_SHA>",
+  "event": "COMMENT",
+  "body": "## Review\n\nSummary of findings.",
+  "comments": [
+    {
+      "path": "backend/api/handler.go",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "Concrete finding on this line."
+    }
+  ]
+}
 EOF
-)"
 ```
 
-Do not approve or request changes unless the user asked for that outcome; default to `--comment` when posting findings. `gh pr review` posts one top-level review body and cannot attach inline comments, so cite locations as text (e.g. `backend/api/handler.go:42`) next to each finding. Leave merging to the user.
+- `event`: `COMMENT` by default; use `REQUEST_CHANGES` or `APPROVE` only when the user asked for that outcome.
+- `line` / `side` refer to the diff on the PR head commit (`RIGHT` for the new file side). For a multi-line range in a review comment object, also set `start_line` and `start_side`.
+
+### Individual inline comments (direct comments endpoint)
+
+For one-off inline comments without a review summary, POST to the pull request comments endpoint:
+
+Single-line:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
+  --method POST \
+  -f body='Inline comment body' \
+  -f commit_id='<HEAD_SHA>' \
+  -f path='backend/api/handler.go' \
+  -F line=42 \
+  -f side='RIGHT'
+```
+
+Multi-line range:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
+  --method POST \
+  -f body='Inline comment body' \
+  -f commit_id='<HEAD_SHA>' \
+  -f path='backend/api/handler.go' \
+  -F start_line=40 \
+  -f start_side='RIGHT' \
+  -F line=42 \
+  -f side='RIGHT'
+```
+
+Line coordinates must land on the PR diff; if GitHub rejects them, fix the path/line/side (or use a multi-line range) and retry. Leave merging to the user.
 
 ## Verification (required)
 

--- a/backend/e2e/import_ngx_test.go
+++ b/backend/e2e/import_ngx_test.go
@@ -1,0 +1,159 @@
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestImportNgxForbiddenForUser(t *testing.T) {
+	h := StartShared(t)
+	token := h.userToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     "http://example.com",
+		"api_key": "x",
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", status, raw)
+	}
+}
+
+func TestImportNgxValidation(t *testing.T) {
+	h := StartShared(t)
+	token := h.adminUserToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     "",
+		"api_key": "x",
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", status, raw)
+	}
+	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     "http://example.com",
+		"api_key": "",
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", status, raw)
+	}
+}
+
+func TestImportNgxFromRemote(t *testing.T) {
+	h := StartShared(t)
+
+	corrID := 2
+	typeID := 3
+	payload := []byte("imported-file-body-" + t.Name())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
+		assertToken(t, r, "remote-token")
+		writeNgxPage(w, []map[string]any{{"id": 1, "name": "ImportedTag"}})
+	})
+	mux.HandleFunc("/api/correspondents/", func(w http.ResponseWriter, r *http.Request) {
+		writeNgxPage(w, []map[string]any{{"id": corrID, "name": "ImportedCorp"}})
+	})
+	mux.HandleFunc("/api/document_types/", func(w http.ResponseWriter, r *http.Request) {
+		writeNgxPage(w, []map[string]any{{"id": typeID, "name": "ImportedType"}})
+	})
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Disposition", `attachment; filename="note.txt"`)
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(payload)
+			return
+		}
+		writeNgxPage(w, []map[string]any{{
+			"id":                 42,
+			"title":              "RemoteInvoice",
+			"content":            "Imported OCR content for AI",
+			"tags":               []int{1},
+			"correspondent":      corrID,
+			"document_type":      typeID,
+			"created_date":       "2024-06-15",
+			"original_file_name": "note.txt",
+		}})
+	})
+	remote := httptest.NewServer(mux)
+	t.Cleanup(remote.Close)
+
+	token := h.adminUserToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     remote.URL,
+		"api_key": "remote-token",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode: %v body %s", err, raw)
+	}
+	if intFromAny(result["imported"]) != 1 {
+		t.Fatalf("imported=%v body=%s", result["imported"], raw)
+	}
+	if intFromAny(result["tags_upserted"]) != 1 {
+		t.Fatalf("tags_upserted=%v", result["tags_upserted"])
+	}
+	if intFromAny(result["failed"]) != 0 {
+		t.Fatalf("failed=%v errors=%v", result["failed"], result["errors"])
+	}
+
+	// Second import of same bytes should skip as duplicate.
+	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     remote.URL,
+		"api_key": "remote-token",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if intFromAny(result["imported"]) != 0 || intFromAny(result["skipped_duplicates"]) != 1 {
+		t.Fatalf("second import result=%s", raw)
+	}
+
+	docsStatus, docsRaw := h.doJSON(t, http.MethodGet,
+		`/api/collections/documents/records?filter=title~"RemoteInvoice"&perPage=50`, token, nil)
+	requireStatus(t, docsStatus, http.StatusOK, docsRaw)
+	var docs struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(docsRaw), &docs); err != nil {
+		t.Fatalf("decode docs: %v", err)
+	}
+	if len(docs.Items) != 1 {
+		t.Fatalf("expected 1 document, got %d: %s", len(docs.Items), docsRaw)
+	}
+	ocr, _ := docs.Items[0]["ocr_text"].(string)
+	if ocr != "Imported OCR content for AI" {
+		t.Fatalf("ocr_text=%q", ocr)
+	}
+}
+
+func assertToken(t *testing.T, r *http.Request, want string) {
+	t.Helper()
+	got := r.Header.Get("Authorization")
+	if got != "Token "+want {
+		t.Fatalf("Authorization=%q", got)
+	}
+}
+
+func writeNgxPage(w http.ResponseWriter, results []map[string]any) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"count":    len(results),
+		"next":     nil,
+		"previous": nil,
+		"results":  results,
+	})
+}
+
+func intFromAny(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return -1
+	}
+}

--- a/backend/e2e/import_ngx_test.go
+++ b/backend/e2e/import_ngx_test.go
@@ -1,11 +1,14 @@
 package e2e
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestImportNgxForbiddenForUser(t *testing.T) {
@@ -53,6 +56,7 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	corrID := 2
 	typeID := 3
 	payload := []byte("imported-file-body-" + t.Name())
+	checksum := sha256Hex(payload)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
@@ -87,19 +91,9 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	t.Cleanup(remote.Close)
 
 	token := h.adminUserToken(t)
-	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
-		"url":     remote.URL,
-		"api_key": "remote-token",
-		"mode":    "preserve",
-	})
-	requireStatus(t, status, http.StatusOK, raw)
-
-	var result map[string]any
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		t.Fatalf("decode: %v body %s", err, raw)
-	}
+	result := runImportNgx(t, h, token, remote.URL, "remote-token", "preserve")
 	if intFromAny(result["imported"]) != 1 {
-		t.Fatalf("imported=%v body=%s", result["imported"], raw)
+		t.Fatalf("imported=%v body=%v", result["imported"], result)
 	}
 	if intFromAny(result["tags_upserted"]) != 1 {
 		t.Fatalf("tags_upserted=%v", result["tags_upserted"])
@@ -109,21 +103,16 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	}
 
 	// Second import of same bytes should skip as duplicate.
-	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
-		"url":     remote.URL,
-		"api_key": "remote-token",
-		"mode":    "preserve",
-	})
-	requireStatus(t, status, http.StatusOK, raw)
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	result = runImportNgx(t, h, token, remote.URL, "remote-token", "preserve")
 	if intFromAny(result["imported"]) != 0 || intFromAny(result["skipped_duplicates"]) != 1 {
-		t.Fatalf("second import result=%s", raw)
+		t.Fatalf("second import result=%v", result)
+	}
+	if intFromAny(result["tags_upserted"]) != 0 {
+		t.Fatalf("second import should not count existing tags as upserted: %v", result["tags_upserted"])
 	}
 
 	docsStatus, docsRaw := h.doJSON(t, http.MethodGet,
-		`/api/collections/documents/records?filter=title="RemoteInvoice"&perPage=50`, token, nil)
+		`/api/collections/documents/records?filter=checksum="`+checksum+`"&perPage=50`, token, nil)
 	requireStatus(t, docsStatus, http.StatusOK, docsRaw)
 	var docs struct {
 		Items []map[string]any `json:"items"`
@@ -157,6 +146,7 @@ func TestImportNgxReprocessFilesOnly(t *testing.T) {
 	h := StartShared(t)
 
 	payload := []byte("imported-reprocess-body-" + t.Name())
+	checksum := sha256Hex(payload)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
 		writeNgxPage(w, []map[string]any{{"id": 1, "name": "ShouldNotImport"}})
@@ -191,28 +181,18 @@ func TestImportNgxReprocessFilesOnly(t *testing.T) {
 	t.Cleanup(remote.Close)
 
 	token := h.adminUserToken(t)
-	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
-		"url":     remote.URL,
-		"api_key": "remote-token",
-		"mode":    "reprocess",
-	})
-	requireStatus(t, status, http.StatusOK, raw)
-
-	var result map[string]any
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		t.Fatalf("decode: %v body %s", err, raw)
-	}
+	result := runImportNgx(t, h, token, remote.URL, "remote-token", "reprocess")
 	if intFromAny(result["imported"]) != 1 {
-		t.Fatalf("imported=%v body=%s", result["imported"], raw)
+		t.Fatalf("imported=%v body=%v", result["imported"], result)
 	}
 	if intFromAny(result["tags_upserted"]) != 0 ||
 		intFromAny(result["correspondents_upserted"]) != 0 ||
 		intFromAny(result["document_types_upserted"]) != 0 {
-		t.Fatalf("reprocess should not upsert taxonomy: %s", raw)
+		t.Fatalf("reprocess should not upsert taxonomy: %v", result)
 	}
 
 	docsStatus, docsRaw := h.doJSON(t, http.MethodGet,
-		`/api/collections/documents/records?filter=file~"reprocess"&perPage=50&sort=-created`, token, nil)
+		`/api/collections/documents/records?filter=checksum="`+checksum+`"&perPage=50`, token, nil)
 	requireStatus(t, docsStatus, http.StatusOK, docsRaw)
 	var docs struct {
 		Items []map[string]any `json:"items"`
@@ -230,6 +210,53 @@ func TestImportNgxReprocessFilesOnly(t *testing.T) {
 	if ocr, _ := doc["ocr_text"].(string); ocr == "ShouldNotKeepOCR" {
 		t.Fatalf("reprocess mode should not keep ngx OCR text, got %q", ocr)
 	}
+}
+
+func runImportNgx(t *testing.T, h *Harness, token, url, apiKey, mode string) map[string]any {
+	t.Helper()
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     url,
+		"api_key": apiKey,
+		"mode":    mode,
+	})
+	requireStatus(t, status, http.StatusAccepted, raw)
+
+	var start map[string]any
+	if err := json.Unmarshal([]byte(raw), &start); err != nil {
+		t.Fatalf("decode start: %v body %s", err, raw)
+	}
+	jobID, _ := start["job_id"].(string)
+	if jobID == "" {
+		t.Fatalf("missing job_id in %s", raw)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		status, raw = h.doJSON(t, http.MethodGet, "/api/app/import/ngx/status?job_id="+jobID, token, nil)
+		requireStatus(t, status, http.StatusOK, raw)
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+			t.Fatalf("decode status: %v body %s", err, raw)
+		}
+		switch payload["status"] {
+		case "completed":
+			result, _ := payload["result"].(map[string]any)
+			if result == nil {
+				t.Fatalf("completed without result: %s", raw)
+			}
+			return result
+		case "failed":
+			t.Fatalf("import failed: %s", raw)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("import timed out for job %s", jobID)
+	return nil
+}
+
+func sha256Hex(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
 }
 
 func assertToken(t *testing.T, r *http.Request, want string) {

--- a/backend/e2e/import_ngx_test.go
+++ b/backend/e2e/import_ngx_test.go
@@ -37,9 +37,17 @@ func TestImportNgxValidation(t *testing.T) {
 	if status != http.StatusBadRequest {
 		t.Fatalf("status=%d body=%s", status, raw)
 	}
+	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     "http://example.com",
+		"api_key": "x",
+		"mode":    "nope",
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("invalid mode status=%d body=%s", status, raw)
+	}
 }
 
-func TestImportNgxFromRemote(t *testing.T) {
+func TestImportNgxPreserveMetadata(t *testing.T) {
 	h := StartShared(t)
 
 	corrID := 2
@@ -82,6 +90,7 @@ func TestImportNgxFromRemote(t *testing.T) {
 	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
 		"url":     remote.URL,
 		"api_key": "remote-token",
+		"mode":    "preserve",
 	})
 	requireStatus(t, status, http.StatusOK, raw)
 
@@ -103,6 +112,7 @@ func TestImportNgxFromRemote(t *testing.T) {
 	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
 		"url":     remote.URL,
 		"api_key": "remote-token",
+		"mode":    "preserve",
 	})
 	requireStatus(t, status, http.StatusOK, raw)
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
@@ -113,7 +123,7 @@ func TestImportNgxFromRemote(t *testing.T) {
 	}
 
 	docsStatus, docsRaw := h.doJSON(t, http.MethodGet,
-		`/api/collections/documents/records?filter=title~"RemoteInvoice"&perPage=50`, token, nil)
+		`/api/collections/documents/records?filter=title="RemoteInvoice"&perPage=50`, token, nil)
 	requireStatus(t, docsStatus, http.StatusOK, docsRaw)
 	var docs struct {
 		Items []map[string]any `json:"items"`
@@ -124,9 +134,101 @@ func TestImportNgxFromRemote(t *testing.T) {
 	if len(docs.Items) != 1 {
 		t.Fatalf("expected 1 document, got %d: %s", len(docs.Items), docsRaw)
 	}
-	ocr, _ := docs.Items[0]["ocr_text"].(string)
+	doc := docs.Items[0]
+	ocr, _ := doc["ocr_text"].(string)
 	if ocr != "Imported OCR content for AI" {
 		t.Fatalf("ocr_text=%q", ocr)
+	}
+	if title, _ := doc["title"].(string); title != "RemoteInvoice" {
+		t.Fatalf("title=%q", title)
+	}
+	if date, _ := doc["document_date"].(string); !strings.HasPrefix(date, "2024-06-15") {
+		t.Fatalf("document_date=%q", date)
+	}
+	if corr, _ := doc["correspondent"].(string); corr == "" {
+		t.Fatal("expected correspondent to be set")
+	}
+	if dtype, _ := doc["document_type"].(string); dtype == "" {
+		t.Fatal("expected document_type to be set")
+	}
+}
+
+func TestImportNgxReprocessFilesOnly(t *testing.T) {
+	h := StartShared(t)
+
+	payload := []byte("imported-reprocess-body-" + t.Name())
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
+		writeNgxPage(w, []map[string]any{{"id": 1, "name": "ShouldNotImport"}})
+	})
+	mux.HandleFunc("/api/correspondents/", func(w http.ResponseWriter, r *http.Request) {
+		writeNgxPage(w, []map[string]any{{"id": 2, "name": "ShouldNotImportCorp"}})
+	})
+	mux.HandleFunc("/api/document_types/", func(w http.ResponseWriter, r *http.Request) {
+		writeNgxPage(w, []map[string]any{{"id": 3, "name": "ShouldNotImportType"}})
+	})
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Disposition", `attachment; filename="reprocess.txt"`)
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(payload)
+			return
+		}
+		corr := 2
+		dtype := 3
+		writeNgxPage(w, []map[string]any{{
+			"id":                 99,
+			"title":              "ShouldNotKeepTitle",
+			"content":            "ShouldNotKeepOCR",
+			"tags":               []int{1},
+			"correspondent":      corr,
+			"document_type":      dtype,
+			"created_date":       "2023-01-01",
+			"original_file_name": "reprocess.txt",
+		}})
+	})
+	remote := httptest.NewServer(mux)
+	t.Cleanup(remote.Close)
+
+	token := h.adminUserToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     remote.URL,
+		"api_key": "remote-token",
+		"mode":    "reprocess",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode: %v body %s", err, raw)
+	}
+	if intFromAny(result["imported"]) != 1 {
+		t.Fatalf("imported=%v body=%s", result["imported"], raw)
+	}
+	if intFromAny(result["tags_upserted"]) != 0 ||
+		intFromAny(result["correspondents_upserted"]) != 0 ||
+		intFromAny(result["document_types_upserted"]) != 0 {
+		t.Fatalf("reprocess should not upsert taxonomy: %s", raw)
+	}
+
+	docsStatus, docsRaw := h.doJSON(t, http.MethodGet,
+		`/api/collections/documents/records?filter=file~"reprocess"&perPage=50&sort=-created`, token, nil)
+	requireStatus(t, docsStatus, http.StatusOK, docsRaw)
+	var docs struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(docsRaw), &docs); err != nil {
+		t.Fatalf("decode docs: %v", err)
+	}
+	if len(docs.Items) < 1 {
+		t.Fatalf("expected imported document, got %s", docsRaw)
+	}
+	doc := docs.Items[0]
+	if title, _ := doc["title"].(string); title == "ShouldNotKeepTitle" {
+		t.Fatalf("reprocess mode should not keep ngx title, got %q", title)
+	}
+	if ocr, _ := doc["ocr_text"].(string); ocr == "ShouldNotKeepOCR" {
+		t.Fatalf("reprocess mode should not keep ngx OCR text, got %q", ocr)
 	}
 }
 

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -23,6 +23,7 @@ func Register(app core.App, rt *config.Runtime) {
 			g.GET("/settings", bindAdmin(handleGetSettings(app, rt)))
 			g.PATCH("/settings", bindAdmin(handlePatchSettings(app, rt)))
 			g.POST("/duplicates/scan", bindAdmin(handlePostDuplicatesScan(app, rt)))
+			g.POST("/import/ngx", handlePostImportNgx(app))
 			return e.Next()
 		},
 	})

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -23,7 +23,8 @@ func Register(app core.App, rt *config.Runtime) {
 			g.GET("/settings", bindAdmin(handleGetSettings(app, rt)))
 			g.PATCH("/settings", bindAdmin(handlePatchSettings(app, rt)))
 			g.POST("/duplicates/scan", bindAdmin(handlePostDuplicatesScan(app, rt)))
-			g.POST("/import/ngx", handlePostImportNgx(app))
+			g.POST("/import/ngx", bindAdmin(handlePostImportNgx(app)))
+			g.GET("/import/ngx/status", bindAdmin(handleGetImportNgxStatus(app)))
 			return e.Next()
 		},
 	})

--- a/backend/internal/appapi/import_ngx.go
+++ b/backend/internal/appapi/import_ngx.go
@@ -14,6 +14,7 @@ import (
 type importNgxRequest struct {
 	URL    string `json:"url"`
 	APIKey string `json:"api_key"`
+	Mode   string `json:"mode"`
 }
 
 func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
@@ -28,13 +29,17 @@ func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
 		if strings.TrimSpace(req.APIKey) == "" {
 			return writeError(e, http.StatusBadRequest, "API key is required.")
 		}
+		mode, err := ngximport.ParseMode(req.Mode)
+		if err != nil {
+			return writeError(e, http.StatusBadRequest, err.Error())
+		}
 
 		ownerID, err := resolveImportOwnerID(app, e)
 		if err != nil {
 			return writeError(e, http.StatusBadRequest, err.Error())
 		}
 
-		result, err := ngximport.Run(app, ownerID, req.URL, req.APIKey)
+		result, err := ngximport.Run(app, ownerID, req.URL, req.APIKey, mode)
 		if errors.Is(err, ngximport.ErrImportInProgress) {
 			return writeError(e, http.StatusConflict, "An import is already in progress.")
 		}

--- a/backend/internal/appapi/import_ngx.go
+++ b/backend/internal/appapi/import_ngx.go
@@ -18,7 +18,7 @@ type importNgxRequest struct {
 }
 
 func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
-	return bindAdmin(func(e *core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
 		var req importNgxRequest
 		if err := json.NewDecoder(e.Request.Body).Decode(&req); err != nil {
 			return writeError(e, http.StatusBadRequest, "Invalid request body.")
@@ -39,15 +39,43 @@ func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
 			return writeError(e, http.StatusBadRequest, err.Error())
 		}
 
-		result, err := ngximport.Run(app, ownerID, req.URL, req.APIKey, mode)
+		jobID, err := ngximport.Start(app, ownerID, req.URL, req.APIKey, mode)
 		if errors.Is(err, ngximport.ErrImportInProgress) {
 			return writeError(e, http.StatusConflict, "An import is already in progress.")
 		}
 		if err != nil {
-			return writeError(e, http.StatusBadRequest, "Import failed: "+err.Error())
+			return writeError(e, http.StatusBadRequest, "Import failed to start: "+err.Error())
 		}
-		return writeJSON(e, http.StatusOK, result)
-	})
+		return writeJSON(e, http.StatusAccepted, map[string]any{
+			"job_id": jobID,
+			"status": ngximport.JobStatusRunning,
+		})
+	}
+}
+
+func handleGetImportNgxStatus(app core.App) func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		_ = app
+		jobID := strings.TrimSpace(e.Request.URL.Query().Get("job_id"))
+		if jobID == "" {
+			return writeError(e, http.StatusBadRequest, "job_id is required.")
+		}
+		job, ok := ngximport.GetJob(jobID)
+		if !ok {
+			return writeError(e, http.StatusNotFound, "Import job not found.")
+		}
+		payload := map[string]any{
+			"job_id": job.ID,
+			"status": job.Status,
+		}
+		if job.Error != "" {
+			payload["error"] = job.Error
+		}
+		if job.Result != nil {
+			payload["result"] = job.Result
+		}
+		return writeJSON(e, http.StatusOK, payload)
+	}
 }
 
 func resolveImportOwnerID(app core.App, e *core.RequestEvent) (string, error) {

--- a/backend/internal/appapi/import_ngx.go
+++ b/backend/internal/appapi/import_ngx.go
@@ -1,0 +1,67 @@
+package appapi
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/pocketbase/pocketbase/core"
+	"paperless-go/backend/internal/ngximport"
+)
+
+type importNgxRequest struct {
+	URL    string `json:"url"`
+	APIKey string `json:"api_key"`
+}
+
+func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
+	return bindAdmin(func(e *core.RequestEvent) error {
+		var req importNgxRequest
+		if err := json.NewDecoder(e.Request.Body).Decode(&req); err != nil {
+			return writeError(e, http.StatusBadRequest, "Invalid request body.")
+		}
+		if strings.TrimSpace(req.URL) == "" {
+			return writeError(e, http.StatusBadRequest, "URL is required.")
+		}
+		if strings.TrimSpace(req.APIKey) == "" {
+			return writeError(e, http.StatusBadRequest, "API key is required.")
+		}
+
+		ownerID, err := resolveImportOwnerID(app, e)
+		if err != nil {
+			return writeError(e, http.StatusBadRequest, err.Error())
+		}
+
+		result, err := ngximport.Run(app, ownerID, req.URL, req.APIKey)
+		if errors.Is(err, ngximport.ErrImportInProgress) {
+			return writeError(e, http.StatusConflict, "An import is already in progress.")
+		}
+		if err != nil {
+			return writeError(e, http.StatusBadRequest, "Import failed: "+err.Error())
+		}
+		return writeJSON(e, http.StatusOK, result)
+	})
+}
+
+func resolveImportOwnerID(app core.App, e *core.RequestEvent) (string, error) {
+	if e.Auth == nil {
+		return "", errors.New("Authentication required.")
+	}
+	if e.Auth.Collection().Name == "users" {
+		return e.Auth.Id, nil
+	}
+	email := strings.TrimSpace(e.Auth.Email())
+	if email == "" {
+		return "", errors.New("Admin account has no email; cannot resolve document owner.")
+	}
+	user, err := app.FindAuthRecordByEmail("users", email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", errors.New("No paired users account for this admin; sign in with the admin user account.")
+		}
+		return "", err
+	}
+	return user.Id, nil
+}

--- a/backend/internal/duplicates/checksum.go
+++ b/backend/internal/duplicates/checksum.go
@@ -99,6 +99,34 @@ func ErrDuplicateFromSaveConflict(app core.App, record *core.Record, saveErr err
 	}
 }
 
+// DuplicateOfFromError extracts an ExistingID from a PocketBase ApiError that
+// carries {"duplicate_of": id} in its raw data (as returned by the documents create hook).
+// Returns "" when err is not such an ApiError.
+func DuplicateOfFromError(err error) string {
+	type rawDataCarrier interface {
+		RawData() any
+	}
+	var carrier rawDataCarrier
+	if !errors.As(err, &carrier) {
+		return ""
+	}
+	data, ok := carrier.RawData().(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := data["duplicate_of"].(string)
+	return strings.TrimSpace(id)
+}
+
+// ErrDuplicateFromAPIError maps a create-hook ApiError with duplicate_of into ErrDuplicate.
+func ErrDuplicateFromAPIError(err error) *ErrDuplicate {
+	id := DuplicateOfFromError(err)
+	if id == "" {
+		return nil
+	}
+	return &ErrDuplicate{ExistingID: id}
+}
+
 // AssignChecksumFromUpload hashes the unsaved upload, sets checksum, and rejects duplicates.
 // Callers should still handle unique-constraint failures from Save via ErrDuplicateFromSaveConflict
 // so concurrent uploads cannot both succeed.

--- a/backend/internal/models/steps.go
+++ b/backend/internal/models/steps.go
@@ -1,16 +1,19 @@
 package models
 
 const (
-	StepPreview           = "preview"
-	StepOCR               = "ocr"
-	StepDetectDuplicates  = "detect_duplicates"
-	StepExtractMetadata   = "extract_metadata"
-	StepApplyMetadata     = "apply_metadata"
+	StepPreview          = "preview"
+	StepOCR              = "ocr"
+	StepDetectDuplicates = "detect_duplicates"
+	StepExtractMetadata  = "extract_metadata"
+	StepApplyMetadata    = "apply_metadata"
 )
 
 var (
 	FullPipelineSteps       = []string{StepPreview, StepOCR, StepDetectDuplicates, StepExtractMetadata, StepApplyMetadata}
 	ExtractionPipelineSteps = []string{StepExtractMetadata, StepApplyMetadata}
+	// ImportPreserveSteps runs preview/OCR/near-dup detection without AI metadata
+	// overwrite, so ngx title/tags/correspondent/type survive import.
+	ImportPreserveSteps = []string{StepPreview, StepOCR, StepDetectDuplicates}
 )
 
 const (

--- a/backend/internal/ngximport/client.go
+++ b/backend/internal/ngximport/client.go
@@ -1,0 +1,240 @@
+package ngximport
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultPageSize = 100
+
+// Client talks to a remote Paperless-ngx REST API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL, apiKey string, httpClient *http.Client) (*Client, error) {
+	normalized, err := NormalizeBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &Client{
+		baseURL:    normalized,
+		apiKey:     strings.TrimSpace(apiKey),
+		httpClient: httpClient,
+	}, nil
+}
+
+// NormalizeBaseURL trims trailing slashes and an optional /api suffix.
+func NormalizeBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("url is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("url must use http or https")
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("url must include a host")
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.Path = strings.TrimSuffix(u.Path, "/api")
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+type namedEntity struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type ngxDocument struct {
+	ID                 int    `json:"id"`
+	Title              string `json:"title"`
+	Content            string `json:"content"`
+	Tags               []int  `json:"tags"`
+	DocumentType       *int   `json:"document_type"`
+	Correspondent      *int   `json:"correspondent"`
+	Created            string `json:"created"`
+	CreatedDate        string `json:"created_date"`
+	OriginalFileName   string `json:"original_file_name"`
+	ArchivedFileName   string `json:"archived_file_name"`
+}
+
+type page[T any] struct {
+	Count    int     `json:"count"`
+	Next     *string `json:"next"`
+	Previous *string `json:"previous"`
+	Results  []T     `json:"results"`
+}
+
+func (c *Client) ListTags() ([]namedEntity, error) {
+	return listAll[namedEntity](c, "/api/tags/")
+}
+
+func (c *Client) ListCorrespondents() ([]namedEntity, error) {
+	return listAll[namedEntity](c, "/api/correspondents/")
+}
+
+func (c *Client) ListDocumentTypes() ([]namedEntity, error) {
+	return listAll[namedEntity](c, "/api/document_types/")
+}
+
+func (c *Client) ListDocuments() ([]ngxDocument, error) {
+	return listAll[ngxDocument](c, "/api/documents/")
+}
+
+type downloadedFile struct {
+	Name string
+	Data []byte
+}
+
+func (c *Client) DownloadDocument(id int) (downloadedFile, error) {
+	rel := fmt.Sprintf("/api/documents/%d/download/?original=true", id)
+	req, err := c.newRequest(http.MethodGet, rel, nil)
+	if err != nil {
+		return downloadedFile{}, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return downloadedFile{}, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return downloadedFile{}, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return downloadedFile{}, fmt.Errorf("download document %d: status %d: %s", id, resp.StatusCode, truncate(string(body), 200))
+	}
+	name := filenameFromDisposition(resp.Header.Get("Content-Disposition"))
+	if name == "" {
+		name = fmt.Sprintf("document-%d.bin", id)
+	}
+	return downloadedFile{Name: name, Data: body}, nil
+}
+
+func listAll[T any](c *Client, apiPath string) ([]T, error) {
+	var all []T
+	next := apiPath
+	if !strings.Contains(next, "?") {
+		next += "?page=1&page_size=" + strconv.Itoa(defaultPageSize)
+	}
+	for next != "" {
+		var p page[T]
+		if err := c.getJSON(next, &p); err != nil {
+			return nil, err
+		}
+		all = append(all, p.Results...)
+		if p.Next == nil || strings.TrimSpace(*p.Next) == "" {
+			break
+		}
+		nextURL := strings.TrimSpace(*p.Next)
+		if strings.HasPrefix(nextURL, "http://") || strings.HasPrefix(nextURL, "https://") {
+			u, err := url.Parse(nextURL)
+			if err != nil {
+				return nil, fmt.Errorf("parse next url: %w", err)
+			}
+			next = u.RequestURI()
+		} else {
+			next = nextURL
+		}
+	}
+	return all, nil
+}
+
+func (c *Client) getJSON(relOrPath string, dest any) error {
+	req, err := c.newRequest(http.MethodGet, relOrPath, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("GET %s: status %d: %s", relOrPath, resp.StatusCode, truncate(string(body), 200))
+	}
+	if err := json.Unmarshal(body, dest); err != nil {
+		return fmt.Errorf("decode %s: %w", relOrPath, err)
+	}
+	return nil
+}
+
+func (c *Client) newRequest(method, relOrPath string, body io.Reader) (*http.Request, error) {
+	full, err := joinURL(c.baseURL, relOrPath)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, full, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiKey)
+	req.Header.Set("Accept", "application/json; version=9")
+	return req, nil
+}
+
+func joinURL(base, relOrPath string) (string, error) {
+	if strings.HasPrefix(relOrPath, "http://") || strings.HasPrefix(relOrPath, "https://") {
+		return relOrPath, nil
+	}
+	if _, err := url.Parse(base); err != nil {
+		return "", err
+	}
+	if _, err := url.Parse(relOrPath); err != nil {
+		return "", err
+	}
+	base = strings.TrimRight(base, "/")
+	if !strings.HasPrefix(relOrPath, "/") {
+		relOrPath = "/" + relOrPath
+	}
+	return base + relOrPath, nil
+}
+
+func filenameFromDisposition(header string) string {
+	if header == "" {
+		return ""
+	}
+	_, params, err := mime.ParseMediaType(header)
+	if err != nil {
+		return ""
+	}
+	if name := strings.TrimSpace(params["filename"]); name != "" {
+		return path.Base(name)
+	}
+	return ""
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/backend/internal/ngximport/client.go
+++ b/backend/internal/ngximport/client.go
@@ -13,13 +13,21 @@ import (
 	"time"
 )
 
-const defaultPageSize = 100
+const (
+	defaultPageSize   = 100
+	documentPageSize  = 25
+	maxDownloadBytes  = 32 << 20
+	maxJSONErrorBytes = 8 << 20
+	listTimeout       = 60 * time.Second
+	downloadTimeout   = 5 * time.Minute
+)
 
 // Client talks to a remote Paperless-ngx REST API.
 type Client struct {
-	baseURL    string
-	apiKey     string
-	httpClient *http.Client
+	baseURL         string
+	apiKey          string
+	httpClient      *http.Client
+	downloadClient  *http.Client
 }
 
 func NewClient(baseURL, apiKey string, httpClient *http.Client) (*Client, error) {
@@ -31,12 +39,23 @@ func NewClient(baseURL, apiKey string, httpClient *http.Client) (*Client, error)
 		return nil, fmt.Errorf("api key is required")
 	}
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 60 * time.Second}
+		httpClient = &http.Client{Timeout: listTimeout}
+	}
+	downloadClient := httpClient
+	if httpClient.Timeout != 0 && httpClient.Timeout < downloadTimeout {
+		// Clone transport settings but allow a longer body transfer for downloads.
+		downloadClient = &http.Client{
+			Transport:     httpClient.Transport,
+			CheckRedirect: httpClient.CheckRedirect,
+			Jar:           httpClient.Jar,
+			Timeout:       downloadTimeout,
+		}
 	}
 	return &Client{
-		baseURL:    normalized,
-		apiKey:     strings.TrimSpace(apiKey),
-		httpClient: httpClient,
+		baseURL:        normalized,
+		apiKey:         strings.TrimSpace(apiKey),
+		httpClient:     httpClient,
+		downloadClient: downloadClient,
 	}, nil
 }
 
@@ -70,16 +89,16 @@ type namedEntity struct {
 }
 
 type ngxDocument struct {
-	ID                 int    `json:"id"`
-	Title              string `json:"title"`
-	Content            string `json:"content"`
-	Tags               []int  `json:"tags"`
-	DocumentType       *int   `json:"document_type"`
-	Correspondent      *int   `json:"correspondent"`
-	Created            string `json:"created"`
-	CreatedDate        string `json:"created_date"`
-	OriginalFileName   string `json:"original_file_name"`
-	ArchivedFileName   string `json:"archived_file_name"`
+	ID               int    `json:"id"`
+	Title            string `json:"title"`
+	Content          string `json:"content"`
+	Tags             []int  `json:"tags"`
+	DocumentType     *int   `json:"document_type"`
+	Correspondent    *int   `json:"correspondent"`
+	Created          string `json:"created"`
+	CreatedDate      string `json:"created_date"`
+	OriginalFileName string `json:"original_file_name"`
+	ArchivedFileName string `json:"archived_file_name"`
 }
 
 type page[T any] struct {
@@ -90,19 +109,25 @@ type page[T any] struct {
 }
 
 func (c *Client) ListTags() ([]namedEntity, error) {
-	return listAll[namedEntity](c, "/api/tags/")
+	return listAll[namedEntity](c, "/api/tags/", defaultPageSize)
 }
 
 func (c *Client) ListCorrespondents() ([]namedEntity, error) {
-	return listAll[namedEntity](c, "/api/correspondents/")
+	return listAll[namedEntity](c, "/api/correspondents/", defaultPageSize)
 }
 
 func (c *Client) ListDocumentTypes() ([]namedEntity, error) {
-	return listAll[namedEntity](c, "/api/document_types/")
+	return listAll[namedEntity](c, "/api/document_types/", defaultPageSize)
 }
 
+// ListDocuments fetches all remote documents (for tests). Prefer ForEachDocuments for imports.
 func (c *Client) ListDocuments() ([]ngxDocument, error) {
-	return listAll[ngxDocument](c, "/api/documents/")
+	return listAll[ngxDocument](c, "/api/documents/", documentPageSize)
+}
+
+// ForEachDocuments invokes fn for each page of remote documents.
+func (c *Client) ForEachDocuments(fn func([]ngxDocument) error) error {
+	return forEachPage[ngxDocument](c, "/api/documents/", documentPageSize, fn)
 }
 
 type downloadedFile struct {
@@ -116,14 +141,17 @@ func (c *Client) DownloadDocument(id int) (downloadedFile, error) {
 	if err != nil {
 		return downloadedFile{}, err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.downloadClient.Do(req)
 	if err != nil {
 		return downloadedFile{}, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadBytes+1))
 	if err != nil {
 		return downloadedFile{}, err
+	}
+	if len(body) > maxDownloadBytes {
+		return downloadedFile{}, fmt.Errorf("document %d exceeds %d bytes", id, maxDownloadBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return downloadedFile{}, fmt.Errorf("download document %d: status %d: %s", id, resp.StatusCode, truncate(string(body), 200))
@@ -135,18 +163,30 @@ func (c *Client) DownloadDocument(id int) (downloadedFile, error) {
 	return downloadedFile{Name: name, Data: body}, nil
 }
 
-func listAll[T any](c *Client, apiPath string) ([]T, error) {
+func listAll[T any](c *Client, apiPath string, pageSize int) ([]T, error) {
 	var all []T
+	if err := forEachPage[T](c, apiPath, pageSize, func(results []T) error {
+		all = append(all, results...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return all, nil
+}
+
+func forEachPage[T any](c *Client, apiPath string, pageSize int, fn func([]T) error) error {
 	next := apiPath
 	if !strings.Contains(next, "?") {
-		next += "?page=1&page_size=" + strconv.Itoa(defaultPageSize)
+		next += "?page=1&page_size=" + strconv.Itoa(pageSize)
 	}
 	for next != "" {
 		var p page[T]
 		if err := c.getJSON(next, &p); err != nil {
-			return nil, err
+			return err
 		}
-		all = append(all, p.Results...)
+		if err := fn(p.Results); err != nil {
+			return err
+		}
 		if p.Next == nil || strings.TrimSpace(*p.Next) == "" {
 			break
 		}
@@ -154,14 +194,14 @@ func listAll[T any](c *Client, apiPath string) ([]T, error) {
 		if strings.HasPrefix(nextURL, "http://") || strings.HasPrefix(nextURL, "https://") {
 			u, err := url.Parse(nextURL)
 			if err != nil {
-				return nil, fmt.Errorf("parse next url: %w", err)
+				return fmt.Errorf("parse next url: %w", err)
 			}
 			next = u.RequestURI()
 		} else {
 			next = nextURL
 		}
 	}
-	return all, nil
+	return nil
 }
 
 func (c *Client) getJSON(relOrPath string, dest any) error {
@@ -174,14 +214,11 @@ func (c *Client) getJSON(relOrPath string, dest any) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
-	if err != nil {
-		return err
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxJSONErrorBytes))
 		return fmt.Errorf("GET %s: status %d: %s", relOrPath, resp.StatusCode, truncate(string(body), 200))
 	}
-	if err := json.Unmarshal(body, dest); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
 		return fmt.Errorf("decode %s: %w", relOrPath, err)
 	}
 	return nil

--- a/backend/internal/ngximport/client_test.go
+++ b/backend/internal/ngximport/client_test.go
@@ -145,6 +145,71 @@ func TestClientPagination(t *testing.T) {
 	}
 }
 
+func TestDownloadRejectsOversized(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/download") {
+			http.NotFound(w, r)
+			return
+		}
+		// One byte over the limit.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, maxDownloadBytes+1))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "k", srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.DownloadDocument(1)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected exceeds error, got %v", err)
+	}
+}
+
+func TestForEachDocumentsPages(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			next := "/api/documents/?page=2&page_size=25"
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"count":    2,
+				"next":     next,
+				"previous": nil,
+				"results":  []ngxDocument{{ID: 1, Title: "A"}},
+			})
+			return
+		}
+		writePage(w, []ngxDocument{{ID: 2, Title: "B"}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "k", srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []int
+	if err := client.ForEachDocuments(func(docs []ngxDocument) error {
+		for _, d := range docs {
+			ids = append(ids, d.ID)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("ids=%v", ids)
+	}
+}
+
 func TestDocumentDate(t *testing.T) {
 	t.Parallel()
 	corr := 1

--- a/backend/internal/ngximport/client_test.go
+++ b/backend/internal/ngximport/client_test.go
@@ -158,6 +158,38 @@ func TestDocumentDate(t *testing.T) {
 	}
 }
 
+func TestParseMode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", ModePreserve, false},
+		{"preserve", ModePreserve, false},
+		{"Preserve", ModePreserve, false},
+		{"reprocess", ModeReprocess, false},
+		{"REPROCESS", ModeReprocess, false},
+		{"full", "", true},
+		{"other", "", true},
+	}
+	for _, tc := range cases {
+		got, err := ParseMode(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("ParseMode(%q) expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("ParseMode(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseMode(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func writePage[T any](w http.ResponseWriter, results []T) {
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"count":    len(results),

--- a/backend/internal/ngximport/client_test.go
+++ b/backend/internal/ngximport/client_test.go
@@ -1,0 +1,168 @@
+package ngximport
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"https://ngx.example.com", "https://ngx.example.com", false},
+		{"https://ngx.example.com/", "https://ngx.example.com", false},
+		{"https://ngx.example.com/api", "https://ngx.example.com", false},
+		{"https://ngx.example.com/api/", "https://ngx.example.com", false},
+		{"http://127.0.0.1:8000/paperless/api", "http://127.0.0.1:8000/paperless", false},
+		{"", "", true},
+		{"ftp://x", "", true},
+		{"not-a-url", "", true},
+	}
+	for _, tc := range cases {
+		got, err := NormalizeBaseURL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("NormalizeBaseURL(%q) expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("NormalizeBaseURL(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("NormalizeBaseURL(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestClientListAndDownload(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Token secret-key" {
+			t.Fatalf("Authorization=%q", got)
+		}
+		writePage(w, []namedEntity{{ID: 1, Name: "Invoice"}})
+	})
+	mux.HandleFunc("/api/correspondents/", func(w http.ResponseWriter, r *http.Request) {
+		writePage(w, []namedEntity{{ID: 2, Name: "Acme"}})
+	})
+	mux.HandleFunc("/api/document_types/", func(w http.ResponseWriter, r *http.Request) {
+		writePage(w, []namedEntity{{ID: 3, Name: "Receipt"}})
+	})
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Disposition", `attachment; filename="invoice.txt"`)
+			_, _ = w.Write([]byte("hello invoice"))
+			return
+		}
+		corr := 2
+		dtype := 3
+		writePage(w, []ngxDocument{{
+			ID:               10,
+			Title:            "Invoice 1",
+			Content:          "OCR text here",
+			Tags:             []int{1},
+			Correspondent:    &corr,
+			DocumentType:     &dtype,
+			CreatedDate:      "2024-05-01",
+			OriginalFileName: "invoice.txt",
+		}})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "secret-key", srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tags, err := client.ListTags()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 1 || tags[0].Name != "Invoice" {
+		t.Fatalf("tags=%v", tags)
+	}
+
+	docs, err := client.ListDocuments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 1 || docs[0].Content != "OCR text here" {
+		t.Fatalf("docs=%v", docs)
+	}
+
+	file, err := client.DownloadDocument(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file.Name != "invoice.txt" || string(file.Data) != "hello invoice" {
+		t.Fatalf("file=%+v", file)
+	}
+}
+
+func TestClientPagination(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			next := "/api/tags/?page=2&page_size=100"
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"count":    2,
+				"next":     next,
+				"previous": nil,
+				"results":  []namedEntity{{ID: 1, Name: "A"}},
+			})
+			return
+		}
+		writePage(w, []namedEntity{{ID: 2, Name: "B"}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL+"/api", "k", srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags, err := client.ListTags()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("len=%d", len(tags))
+	}
+}
+
+func TestDocumentDate(t *testing.T) {
+	t.Parallel()
+	corr := 1
+	got := documentDate(ngxDocument{CreatedDate: "2024-01-15", Correspondent: &corr})
+	if got != "2024-01-15" {
+		t.Fatalf("got %q", got)
+	}
+	got = documentDate(ngxDocument{Created: "2024-02-03T10:00:00Z"})
+	if got != "2024-02-03" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func writePage[T any](w http.ResponseWriter, results []T) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"count":    len(results),
+		"next":     nil,
+		"previous": nil,
+		"results":  results,
+	})
+}

--- a/backend/internal/ngximport/import.go
+++ b/backend/internal/ngximport/import.go
@@ -62,6 +62,30 @@ func Run(app core.App, ownerUserID, baseURL, apiKey, mode string) (Result, error
 
 // RunWithClient is like Run but accepts a prebuilt client (for tests).
 func RunWithClient(app core.App, ownerUserID, baseURL, apiKey, mode string, client *Client) (Result, error) {
+	if err := acquireImport(); err != nil {
+		return Result{}, err
+	}
+	defer releaseImport()
+	return runImport(app, ownerUserID, baseURL, apiKey, mode, client)
+}
+
+func acquireImport() error {
+	importMu.Lock()
+	defer importMu.Unlock()
+	if importBusy {
+		return ErrImportInProgress
+	}
+	importBusy = true
+	return nil
+}
+
+func releaseImport() {
+	importMu.Lock()
+	importBusy = false
+	importMu.Unlock()
+}
+
+func runImport(app core.App, ownerUserID, baseURL, apiKey, mode string, client *Client) (Result, error) {
 	if strings.TrimSpace(ownerUserID) == "" {
 		return Result{}, fmt.Errorf("owner user id is required")
 	}
@@ -69,19 +93,6 @@ func RunWithClient(app core.App, ownerUserID, baseURL, apiKey, mode string, clie
 	if err != nil {
 		return Result{}, err
 	}
-
-	importMu.Lock()
-	if importBusy {
-		importMu.Unlock()
-		return Result{}, ErrImportInProgress
-	}
-	importBusy = true
-	importMu.Unlock()
-	defer func() {
-		importMu.Lock()
-		importBusy = false
-		importMu.Unlock()
-	}()
 
 	if client == nil {
 		client, err = NewClient(baseURL, apiKey, nil)
@@ -112,23 +123,24 @@ func RunWithClient(app core.App, ownerUserID, baseURL, apiKey, mode string, clie
 		tagMap, corrMap, typeMap = map[int]string{}, map[int]string{}, map[int]string{}
 	}
 
-	docs, err := client.ListDocuments()
-	if err != nil {
-		return result, fmt.Errorf("list documents: %w", err)
-	}
-
-	for _, doc := range docs {
-		if err := importOneDocument(app, client, ownerUserID, parsedMode, doc, tagMap, corrMap, typeMap); err != nil {
-			var dup *duplicates.ErrDuplicate
-			if errors.As(err, &dup) {
-				result.SkippedDuplicates++
+	err = client.ForEachDocuments(func(docs []ngxDocument) error {
+		for _, doc := range docs {
+			if err := importOneDocument(app, client, ownerUserID, parsedMode, doc, tagMap, corrMap, typeMap); err != nil {
+				var dup *duplicates.ErrDuplicate
+				if errors.As(err, &dup) {
+					result.SkippedDuplicates++
+					continue
+				}
+				result.Failed++
+				appendError(&result, fmt.Sprintf("document %d (%s): %v", doc.ID, strings.TrimSpace(doc.Title), err))
 				continue
 			}
-			result.Failed++
-			appendError(&result, fmt.Sprintf("document %d (%s): %v", doc.ID, strings.TrimSpace(doc.Title), err))
-			continue
+			result.Imported++
 		}
-		result.Imported++
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("list documents: %w", err)
 	}
 
 	return result, nil
@@ -140,67 +152,37 @@ func importNamedEntities(app core.App, collection string, list func() ([]namedEn
 		return nil, 0, err
 	}
 	idMap := make(map[int]string, len(entities))
-	upserted := 0
+	createdCount := 0
 	for _, entity := range entities {
 		name := strings.TrimSpace(entity.Name)
 		if entity.ID == 0 || name == "" {
 			continue
 		}
-		localID, err := ensureNamed(app, collection, name)
+		localID, created, err := ensureNamed(app, collection, name)
 		if err != nil {
-			return nil, upserted, err
+			return nil, createdCount, err
 		}
 		idMap[entity.ID] = localID
-		upserted++
+		if created {
+			createdCount++
+		}
 	}
-	return idMap, upserted, nil
+	return idMap, createdCount, nil
 }
 
-func ensureNamed(app core.App, collection, name string) (string, error) {
+func ensureNamed(app core.App, collection, name string) (id string, created bool, err error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", nil
+		return "", false, nil
 	}
-
-	existing, err := app.FindRecordsByFilter(
-		collection,
-		"name = {:name}",
-		"",
-		1,
-		0,
-		map[string]any{"name": name},
-	)
-	if err != nil {
-		return "", err
+	switch collection {
+	case "tags":
+		return worker.EnsureTag(app, name)
+	case "correspondents", "document_types":
+		return worker.EnsureNamedEntity(app, collection, name, name)
+	default:
+		return "", false, fmt.Errorf("unsupported collection %q", collection)
 	}
-	if len(existing) > 0 {
-		return existing[0].Id, nil
-	}
-
-	coll, err := app.FindCollectionByNameOrId(collection)
-	if err != nil {
-		return "", err
-	}
-	record := core.NewRecord(coll)
-	record.Set("name", name)
-	if collection == "correspondents" || collection == "document_types" {
-		record.Set("name_original", name)
-	}
-	if err := app.Save(record); err != nil {
-		existing, findErr := app.FindRecordsByFilter(
-			collection,
-			"name = {:name}",
-			"",
-			1,
-			0,
-			map[string]any{"name": name},
-		)
-		if findErr == nil && len(existing) > 0 {
-			return existing[0].Id, nil
-		}
-		return "", err
-	}
-	return record.Id, nil
 }
 
 func importOneDocument(
@@ -295,11 +277,11 @@ func importOneDocument(
 		if errors.As(err, &dup) {
 			return dup
 		}
-		if dup := duplicates.ErrDuplicateFromSaveConflict(app, record, err); dup != nil {
+		if dup := duplicates.ErrDuplicateFromAPIError(err); dup != nil {
 			return dup
 		}
-		if strings.Contains(err.Error(), "document already exists") {
-			return &duplicates.ErrDuplicate{}
+		if dup := duplicates.ErrDuplicateFromSaveConflict(app, record, err); dup != nil {
+			return dup
 		}
 		return err
 	}

--- a/backend/internal/ngximport/import.go
+++ b/backend/internal/ngximport/import.go
@@ -12,9 +12,16 @@ import (
 	"github.com/pocketbase/pocketbase/tools/filesystem"
 	"paperless-go/backend/internal/duplicates"
 	"paperless-go/backend/internal/models"
+	"paperless-go/backend/internal/worker"
 )
 
 const maxReportedErrors = 25
+
+// Import mode values accepted by the API.
+const (
+	ModePreserve  = "preserve"
+	ModeReprocess = "reprocess"
+)
 
 var (
 	importMu   sync.Mutex
@@ -35,16 +42,32 @@ type Result struct {
 	Errors                 []string `json:"errors"`
 }
 
+// ParseMode validates an import mode; empty defaults to preserve.
+func ParseMode(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", ModePreserve:
+		return ModePreserve, nil
+	case ModeReprocess:
+		return ModeReprocess, nil
+	default:
+		return "", fmt.Errorf("mode must be %q or %q", ModePreserve, ModeReprocess)
+	}
+}
+
 // Run imports taxonomy and documents from a remote Paperless-ngx instance.
 // Only one import may run at a time.
-func Run(app core.App, ownerUserID, baseURL, apiKey string) (Result, error) {
-	return RunWithClient(app, ownerUserID, baseURL, apiKey, nil)
+func Run(app core.App, ownerUserID, baseURL, apiKey, mode string) (Result, error) {
+	return RunWithClient(app, ownerUserID, baseURL, apiKey, mode, nil)
 }
 
 // RunWithClient is like Run but accepts a prebuilt client (for tests).
-func RunWithClient(app core.App, ownerUserID, baseURL, apiKey string, client *Client) (Result, error) {
+func RunWithClient(app core.App, ownerUserID, baseURL, apiKey, mode string, client *Client) (Result, error) {
 	if strings.TrimSpace(ownerUserID) == "" {
 		return Result{}, fmt.Errorf("owner user id is required")
+	}
+	parsedMode, err := ParseMode(mode)
+	if err != nil {
+		return Result{}, err
 	}
 
 	importMu.Lock()
@@ -60,7 +83,6 @@ func RunWithClient(app core.App, ownerUserID, baseURL, apiKey string, client *Cl
 		importMu.Unlock()
 	}()
 
-	var err error
 	if client == nil {
 		client, err = NewClient(baseURL, apiKey, nil)
 		if err != nil {
@@ -70,23 +92,25 @@ func RunWithClient(app core.App, ownerUserID, baseURL, apiKey string, client *Cl
 
 	result := Result{Errors: []string{}}
 
-	tagMap, n, err := importNamedEntities(app, "tags", client.ListTags)
-	if err != nil {
-		return result, fmt.Errorf("import tags: %w", err)
-	}
-	result.TagsUpserted = n
+	var tagMap, corrMap, typeMap map[int]string
+	if parsedMode == ModePreserve {
+		tagMap, result.TagsUpserted, err = importNamedEntities(app, "tags", client.ListTags)
+		if err != nil {
+			return result, fmt.Errorf("import tags: %w", err)
+		}
 
-	corrMap, n, err := importNamedEntities(app, "correspondents", client.ListCorrespondents)
-	if err != nil {
-		return result, fmt.Errorf("import correspondents: %w", err)
-	}
-	result.CorrespondentsUpserted = n
+		corrMap, result.CorrespondentsUpserted, err = importNamedEntities(app, "correspondents", client.ListCorrespondents)
+		if err != nil {
+			return result, fmt.Errorf("import correspondents: %w", err)
+		}
 
-	typeMap, n, err := importNamedEntities(app, "document_types", client.ListDocumentTypes)
-	if err != nil {
-		return result, fmt.Errorf("import document types: %w", err)
+		typeMap, result.DocumentTypesUpserted, err = importNamedEntities(app, "document_types", client.ListDocumentTypes)
+		if err != nil {
+			return result, fmt.Errorf("import document types: %w", err)
+		}
+	} else {
+		tagMap, corrMap, typeMap = map[int]string{}, map[int]string{}, map[int]string{}
 	}
-	result.DocumentTypesUpserted = n
 
 	docs, err := client.ListDocuments()
 	if err != nil {
@@ -94,7 +118,7 @@ func RunWithClient(app core.App, ownerUserID, baseURL, apiKey string, client *Cl
 	}
 
 	for _, doc := range docs {
-		if err := importOneDocument(app, client, ownerUserID, doc, tagMap, corrMap, typeMap); err != nil {
+		if err := importOneDocument(app, client, ownerUserID, parsedMode, doc, tagMap, corrMap, typeMap); err != nil {
 			var dup *duplicates.ErrDuplicate
 			if errors.As(err, &dup) {
 				result.SkippedDuplicates++
@@ -183,6 +207,7 @@ func importOneDocument(
 	app core.App,
 	client *Client,
 	ownerUserID string,
+	mode string,
 	doc ngxDocument,
 	tagMap, corrMap, typeMap map[int]string,
 ) error {
@@ -229,35 +254,40 @@ func importOneDocument(
 	record.Set("user", ownerUserID)
 	record.Set("file", fsFile)
 	record.Set("processing_status", models.DocStatusPending)
-	if title := strings.TrimSpace(doc.Title); title != "" {
-		record.Set("title", title)
-	}
-	if ocr := strings.TrimSpace(doc.Content); ocr != "" {
-		record.Set("ocr_text", ocr)
-	}
-	if date := documentDate(doc); date != "" {
-		record.Set("document_date", date)
-	}
-	if doc.Correspondent != nil {
-		if id := corrMap[*doc.Correspondent]; id != "" {
-			record.Set("correspondent", id)
+
+	if mode == ModePreserve {
+		if title := strings.TrimSpace(doc.Title); title != "" {
+			record.Set("title", title)
 		}
-	}
-	if doc.DocumentType != nil {
-		if id := typeMap[*doc.DocumentType]; id != "" {
-			record.Set("document_type", id)
+		if ocr := strings.TrimSpace(doc.Content); ocr != "" {
+			record.Set("ocr_text", ocr)
 		}
-	}
-	if len(doc.Tags) > 0 {
-		tagIDs := make([]string, 0, len(doc.Tags))
-		for _, ngxTagID := range doc.Tags {
-			if id := tagMap[ngxTagID]; id != "" {
-				tagIDs = append(tagIDs, id)
+		if date := documentDate(doc); date != "" {
+			record.Set("document_date", date)
+		}
+		if doc.Correspondent != nil {
+			if id := corrMap[*doc.Correspondent]; id != "" {
+				record.Set("correspondent", id)
 			}
 		}
-		if len(tagIDs) > 0 {
-			record.Set("tags", tagIDs)
+		if doc.DocumentType != nil {
+			if id := typeMap[*doc.DocumentType]; id != "" {
+				record.Set("document_type", id)
+			}
 		}
+		if len(doc.Tags) > 0 {
+			tagIDs := make([]string, 0, len(doc.Tags))
+			for _, ngxTagID := range doc.Tags {
+				if id := tagMap[ngxTagID]; id != "" {
+					tagIDs = append(tagIDs, id)
+				}
+			}
+			if len(tagIDs) > 0 {
+				record.Set("tags", tagIDs)
+			}
+		}
+		worker.RegisterCreateStepsForChecksum(checksum, models.ImportPreserveSteps)
+		defer worker.ClearCreateStepsForChecksum(checksum)
 	}
 
 	if err := app.Save(record); err != nil {

--- a/backend/internal/ngximport/import.go
+++ b/backend/internal/ngximport/import.go
@@ -1,0 +1,317 @@
+package ngximport
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+	"paperless-go/backend/internal/duplicates"
+	"paperless-go/backend/internal/models"
+)
+
+const maxReportedErrors = 25
+
+var (
+	importMu   sync.Mutex
+	importBusy bool
+)
+
+// ErrImportInProgress is returned when another import is already running.
+var ErrImportInProgress = errors.New("an import is already in progress")
+
+// Result summarizes a completed import run.
+type Result struct {
+	Imported               int      `json:"imported"`
+	SkippedDuplicates      int      `json:"skipped_duplicates"`
+	Failed                 int      `json:"failed"`
+	TagsUpserted           int      `json:"tags_upserted"`
+	CorrespondentsUpserted int      `json:"correspondents_upserted"`
+	DocumentTypesUpserted  int      `json:"document_types_upserted"`
+	Errors                 []string `json:"errors"`
+}
+
+// Run imports taxonomy and documents from a remote Paperless-ngx instance.
+// Only one import may run at a time.
+func Run(app core.App, ownerUserID, baseURL, apiKey string) (Result, error) {
+	return RunWithClient(app, ownerUserID, baseURL, apiKey, nil)
+}
+
+// RunWithClient is like Run but accepts a prebuilt client (for tests).
+func RunWithClient(app core.App, ownerUserID, baseURL, apiKey string, client *Client) (Result, error) {
+	if strings.TrimSpace(ownerUserID) == "" {
+		return Result{}, fmt.Errorf("owner user id is required")
+	}
+
+	importMu.Lock()
+	if importBusy {
+		importMu.Unlock()
+		return Result{}, ErrImportInProgress
+	}
+	importBusy = true
+	importMu.Unlock()
+	defer func() {
+		importMu.Lock()
+		importBusy = false
+		importMu.Unlock()
+	}()
+
+	var err error
+	if client == nil {
+		client, err = NewClient(baseURL, apiKey, nil)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	result := Result{Errors: []string{}}
+
+	tagMap, n, err := importNamedEntities(app, "tags", client.ListTags)
+	if err != nil {
+		return result, fmt.Errorf("import tags: %w", err)
+	}
+	result.TagsUpserted = n
+
+	corrMap, n, err := importNamedEntities(app, "correspondents", client.ListCorrespondents)
+	if err != nil {
+		return result, fmt.Errorf("import correspondents: %w", err)
+	}
+	result.CorrespondentsUpserted = n
+
+	typeMap, n, err := importNamedEntities(app, "document_types", client.ListDocumentTypes)
+	if err != nil {
+		return result, fmt.Errorf("import document types: %w", err)
+	}
+	result.DocumentTypesUpserted = n
+
+	docs, err := client.ListDocuments()
+	if err != nil {
+		return result, fmt.Errorf("list documents: %w", err)
+	}
+
+	for _, doc := range docs {
+		if err := importOneDocument(app, client, ownerUserID, doc, tagMap, corrMap, typeMap); err != nil {
+			var dup *duplicates.ErrDuplicate
+			if errors.As(err, &dup) {
+				result.SkippedDuplicates++
+				continue
+			}
+			result.Failed++
+			appendError(&result, fmt.Sprintf("document %d (%s): %v", doc.ID, strings.TrimSpace(doc.Title), err))
+			continue
+		}
+		result.Imported++
+	}
+
+	return result, nil
+}
+
+func importNamedEntities(app core.App, collection string, list func() ([]namedEntity, error)) (map[int]string, int, error) {
+	entities, err := list()
+	if err != nil {
+		return nil, 0, err
+	}
+	idMap := make(map[int]string, len(entities))
+	upserted := 0
+	for _, entity := range entities {
+		name := strings.TrimSpace(entity.Name)
+		if entity.ID == 0 || name == "" {
+			continue
+		}
+		localID, err := ensureNamed(app, collection, name)
+		if err != nil {
+			return nil, upserted, err
+		}
+		idMap[entity.ID] = localID
+		upserted++
+	}
+	return idMap, upserted, nil
+}
+
+func ensureNamed(app core.App, collection, name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", nil
+	}
+
+	existing, err := app.FindRecordsByFilter(
+		collection,
+		"name = {:name}",
+		"",
+		1,
+		0,
+		map[string]any{"name": name},
+	)
+	if err != nil {
+		return "", err
+	}
+	if len(existing) > 0 {
+		return existing[0].Id, nil
+	}
+
+	coll, err := app.FindCollectionByNameOrId(collection)
+	if err != nil {
+		return "", err
+	}
+	record := core.NewRecord(coll)
+	record.Set("name", name)
+	if collection == "correspondents" || collection == "document_types" {
+		record.Set("name_original", name)
+	}
+	if err := app.Save(record); err != nil {
+		existing, findErr := app.FindRecordsByFilter(
+			collection,
+			"name = {:name}",
+			"",
+			1,
+			0,
+			map[string]any{"name": name},
+		)
+		if findErr == nil && len(existing) > 0 {
+			return existing[0].Id, nil
+		}
+		return "", err
+	}
+	return record.Id, nil
+}
+
+func importOneDocument(
+	app core.App,
+	client *Client,
+	ownerUserID string,
+	doc ngxDocument,
+	tagMap, corrMap, typeMap map[int]string,
+) error {
+	file, err := client.DownloadDocument(doc.ID)
+	if err != nil {
+		return err
+	}
+	filename := strings.TrimSpace(doc.OriginalFileName)
+	if filename == "" {
+		filename = strings.TrimSpace(doc.ArchivedFileName)
+	}
+	if filename == "" {
+		filename = file.Name
+	}
+	filename = pathBase(filename)
+	if filename == "" {
+		filename = fmt.Sprintf("document-%d.bin", doc.ID)
+	}
+
+	checksum, err := duplicates.SHA256Reader(bytes.NewReader(file.Data))
+	if err != nil {
+		return fmt.Errorf("hash file: %w", err)
+	}
+	if existing, err := duplicates.FindByChecksum(app, ownerUserID, checksum, ""); err != nil {
+		return err
+	} else if existing != nil {
+		return &duplicates.ErrDuplicate{
+			ExistingID:    existing.Id,
+			ExistingTitle: existing.GetString("title"),
+		}
+	}
+
+	fsFile, err := filesystem.NewFileFromBytes(file.Data, filename)
+	if err != nil {
+		return fmt.Errorf("prepare file: %w", err)
+	}
+
+	collection, err := app.FindCollectionByNameOrId("documents")
+	if err != nil {
+		return err
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("user", ownerUserID)
+	record.Set("file", fsFile)
+	record.Set("processing_status", models.DocStatusPending)
+	if title := strings.TrimSpace(doc.Title); title != "" {
+		record.Set("title", title)
+	}
+	if ocr := strings.TrimSpace(doc.Content); ocr != "" {
+		record.Set("ocr_text", ocr)
+	}
+	if date := documentDate(doc); date != "" {
+		record.Set("document_date", date)
+	}
+	if doc.Correspondent != nil {
+		if id := corrMap[*doc.Correspondent]; id != "" {
+			record.Set("correspondent", id)
+		}
+	}
+	if doc.DocumentType != nil {
+		if id := typeMap[*doc.DocumentType]; id != "" {
+			record.Set("document_type", id)
+		}
+	}
+	if len(doc.Tags) > 0 {
+		tagIDs := make([]string, 0, len(doc.Tags))
+		for _, ngxTagID := range doc.Tags {
+			if id := tagMap[ngxTagID]; id != "" {
+				tagIDs = append(tagIDs, id)
+			}
+		}
+		if len(tagIDs) > 0 {
+			record.Set("tags", tagIDs)
+		}
+	}
+
+	if err := app.Save(record); err != nil {
+		var dup *duplicates.ErrDuplicate
+		if errors.As(err, &dup) {
+			return dup
+		}
+		if dup := duplicates.ErrDuplicateFromSaveConflict(app, record, err); dup != nil {
+			return dup
+		}
+		if strings.Contains(err.Error(), "document already exists") {
+			return &duplicates.ErrDuplicate{}
+		}
+		return err
+	}
+	return nil
+}
+
+func documentDate(doc ngxDocument) string {
+	if d := strings.TrimSpace(doc.CreatedDate); len(d) >= 10 {
+		return d[:10]
+	}
+	created := strings.TrimSpace(doc.Created)
+	if created == "" {
+		return ""
+	}
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.999999Z",
+		"2006-01-02 15:04:05.000Z",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, created); err == nil {
+			return t.Format("2006-01-02")
+		}
+	}
+	if len(created) >= 10 {
+		return created[:10]
+	}
+	return ""
+}
+
+func pathBase(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	return strings.TrimSpace(name)
+}
+
+func appendError(result *Result, msg string) {
+	if len(result.Errors) >= maxReportedErrors {
+		return
+	}
+	result.Errors = append(result.Errors, msg)
+}

--- a/backend/internal/ngximport/job.go
+++ b/backend/internal/ngximport/job.go
@@ -1,0 +1,96 @@
+package ngximport
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Job statuses for in-memory async imports.
+const (
+	JobStatusRunning   = "running"
+	JobStatusCompleted = "completed"
+	JobStatusFailed    = "failed"
+)
+
+// Job is an in-memory import run snapshot (lost on process restart).
+type Job struct {
+	ID        string    `json:"job_id"`
+	Status    string    `json:"status"`
+	Result    *Result   `json:"result,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+var (
+	jobsMu sync.Mutex
+	jobs   = map[string]*Job{}
+)
+
+// Start begins an import in a background goroutine and returns the job id.
+// Only one import may run at a time.
+func Start(app core.App, ownerUserID, baseURL, apiKey, mode string) (string, error) {
+	if err := acquireImport(); err != nil {
+		return "", err
+	}
+
+	id, err := newJobID()
+	if err != nil {
+		releaseImport()
+		return "", err
+	}
+	job := &Job{
+		ID:        id,
+		Status:    JobStatusRunning,
+		UpdatedAt: time.Now().UTC(),
+	}
+	jobsMu.Lock()
+	jobs[id] = job
+	jobsMu.Unlock()
+
+	go func() {
+		defer releaseImport()
+		result, runErr := runImport(app, ownerUserID, baseURL, apiKey, mode, nil)
+		jobsMu.Lock()
+		defer jobsMu.Unlock()
+		job.UpdatedAt = time.Now().UTC()
+		if runErr != nil {
+			job.Status = JobStatusFailed
+			job.Error = runErr.Error()
+			job.Result = &result
+			return
+		}
+		job.Status = JobStatusCompleted
+		job.Result = &result
+	}()
+
+	return id, nil
+}
+
+// GetJob returns a copy of the in-memory job, or false if unknown.
+func GetJob(id string) (Job, bool) {
+	jobsMu.Lock()
+	defer jobsMu.Unlock()
+	job, ok := jobs[id]
+	if !ok || job == nil {
+		return Job{}, false
+	}
+	out := *job
+	if job.Result != nil {
+		copied := *job.Result
+		out.Result = &copied
+	}
+	return out, true
+}
+
+func newJobID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate job id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/backend/internal/worker/create_steps.go
+++ b/backend/internal/worker/create_steps.go
@@ -1,0 +1,44 @@
+package worker
+
+import (
+	"sync"
+
+	"paperless-go/backend/internal/models"
+)
+
+// createStepsByChecksum lets a caller (e.g. ngx import) request non-default
+// pipeline steps for the next document create with that checksum. The create
+// hook consumes the entry with LoadAndDelete so concurrent uploads with other
+// checksums are unaffected.
+var createStepsByChecksum sync.Map
+
+// RegisterCreateStepsForChecksum schedules custom processing steps for the
+// next OnRecordCreate of a document whose checksum matches. Callers should
+// ClearCreateStepsForChecksum if Save fails before the hook runs.
+func RegisterCreateStepsForChecksum(checksum string, steps []string) {
+	if checksum == "" || len(steps) == 0 {
+		return
+	}
+	copied := append([]string(nil), steps...)
+	createStepsByChecksum.Store(checksum, copied)
+}
+
+// ClearCreateStepsForChecksum drops a pending registration (e.g. after a failed Save).
+func ClearCreateStepsForChecksum(checksum string) {
+	if checksum == "" {
+		return
+	}
+	createStepsByChecksum.Delete(checksum)
+}
+
+func takeCreateStepsForChecksum(checksum string) []string {
+	if checksum == "" {
+		return models.FullPipelineSteps
+	}
+	if v, ok := createStepsByChecksum.LoadAndDelete(checksum); ok {
+		if steps, ok := v.([]string); ok && len(steps) > 0 {
+			return steps
+		}
+	}
+	return models.FullPipelineSteps
+}

--- a/backend/internal/worker/create_steps_test.go
+++ b/backend/internal/worker/create_steps_test.go
@@ -1,0 +1,34 @@
+package worker
+
+import (
+	"slices"
+	"testing"
+
+	"paperless-go/backend/internal/models"
+)
+
+func TestTakeCreateStepsForChecksum(t *testing.T) {
+	t.Parallel()
+
+	checksum := "abc123-create-steps-test"
+	ClearCreateStepsForChecksum(checksum)
+
+	if got := takeCreateStepsForChecksum(checksum); !slices.Equal(got, models.FullPipelineSteps) {
+		t.Fatalf("default steps=%v", got)
+	}
+
+	RegisterCreateStepsForChecksum(checksum, models.ImportPreserveSteps)
+	got := takeCreateStepsForChecksum(checksum)
+	if !slices.Equal(got, models.ImportPreserveSteps) {
+		t.Fatalf("registered steps=%v", got)
+	}
+	if got := takeCreateStepsForChecksum(checksum); !slices.Equal(got, models.FullPipelineSteps) {
+		t.Fatalf("second take should default, got %v", got)
+	}
+
+	RegisterCreateStepsForChecksum(checksum, models.ImportPreserveSteps)
+	ClearCreateStepsForChecksum(checksum)
+	if got := takeCreateStepsForChecksum(checksum); !slices.Equal(got, models.FullPipelineSteps) {
+		t.Fatalf("cleared steps=%v", got)
+	}
+}

--- a/backend/internal/worker/entities.go
+++ b/backend/internal/worker/entities.go
@@ -6,40 +6,49 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func ensureNamedEntity(app core.App, collection, displayName, originalName string) (string, error) {
+// EnsureNamedEntity finds or creates a named entity (correspondent / document type).
+// Lookup prefers name_original, then name. created is true only when a new record is inserted.
+func EnsureNamedEntity(app core.App, collection, displayName, originalName string) (id string, created bool, err error) {
 	displayName = strings.TrimSpace(displayName)
 	originalName = strings.TrimSpace(originalName)
 	if displayName == "" {
-		return "", nil
+		return "", false, nil
 	}
 	if originalName == "" {
 		originalName = displayName
 	}
 
-	if id, err := findNamedEntity(app, collection, "name_original", originalName); err != nil {
-		return "", err
-	} else if id != "" {
-		return updateNamedEntity(app, collection, id, displayName, originalName)
+	if existingID, err := findNamedEntity(app, collection, "name_original", originalName); err != nil {
+		return "", false, err
+	} else if existingID != "" {
+		id, err := updateNamedEntity(app, collection, existingID, displayName, originalName)
+		return id, false, err
 	}
 
-	if id, err := findNamedEntity(app, collection, "name", displayName); err != nil {
-		return "", err
-	} else if id != "" {
-		return updateNamedEntity(app, collection, id, displayName, originalName)
+	if existingID, err := findNamedEntity(app, collection, "name", displayName); err != nil {
+		return "", false, err
+	} else if existingID != "" {
+		id, err := updateNamedEntity(app, collection, existingID, displayName, originalName)
+		return id, false, err
 	}
 
 	coll, err := app.FindCollectionByNameOrId(collection)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	record := core.NewRecord(coll)
 	record.Set("name", displayName)
 	record.Set("name_original", originalName)
 	if err := app.Save(record); err != nil {
-		return "", err
+		return "", false, err
 	}
-	return record.Id, nil
+	return record.Id, true, nil
+}
+
+func ensureNamedEntity(app core.App, collection, displayName, originalName string) (string, error) {
+	id, _, err := EnsureNamedEntity(app, collection, displayName, originalName)
+	return id, err
 }
 
 func findNamedEntity(app core.App, collection, field, value string) (string, error) {
@@ -127,4 +136,50 @@ func ensureTags(app core.App, names []string) ([]string, error) {
 	}
 
 	return tagIDs, nil
+}
+
+// EnsureTag finds or creates a tag by exact name. created is true only when inserted.
+func EnsureTag(app core.App, name string) (id string, created bool, err error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false, nil
+	}
+
+	existing, err := app.FindRecordsByFilter(
+		"tags",
+		"name = {:name}",
+		"",
+		1,
+		0,
+		map[string]any{"name": name},
+	)
+	if err != nil {
+		return "", false, err
+	}
+	if len(existing) > 0 {
+		return existing[0].Id, false, nil
+	}
+
+	tagsCollection, err := app.FindCollectionByNameOrId("tags")
+	if err != nil {
+		return "", false, err
+	}
+	tag := core.NewRecord(tagsCollection)
+	tag.Set("name", name)
+	if err := app.Save(tag); err != nil {
+		// Race: another create may have won; re-find.
+		existing, findErr := app.FindRecordsByFilter(
+			"tags",
+			"name = {:name}",
+			"",
+			1,
+			0,
+			map[string]any{"name": name},
+		)
+		if findErr == nil && len(existing) > 0 {
+			return existing[0].Id, false, nil
+		}
+		return "", false, err
+	}
+	return tag.Id, true, nil
 }

--- a/backend/internal/worker/processor.go
+++ b/backend/internal/worker/processor.go
@@ -62,7 +62,8 @@ func (p *Processor) registerHooks() {
 			return err
 		}
 
-		_, err := createProcessingJob(e.App, record.Id, models.FullPipelineSteps, nil)
+		steps := takeCreateStepsForChecksum(record.GetString("checksum"))
+		_, err := createProcessingJob(e.App, record.Id, steps, nil)
 		return err
 	})
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -203,6 +203,16 @@ Compatibility is intentionally partial: common read/write flows work, but not ev
 
 API versions 9 and 10 are accepted via the `Accept` header (`application/json; version=9`).
 
+### Importing from Paperless-ngx
+
+Admins can migrate an existing Paperless-ngx library into Paperless Go:
+
+1. Open **Import** in the More menu (or go to `/import`).
+2. Enter the remote Paperless-ngx base URL and an API token from that instance’s profile.
+3. Start the import. Tags, correspondents, and document types are upserted by name; documents are downloaded with their OCR `content` and then queued for the normal AI pipeline (OCR is skipped when text is already present).
+
+The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "..." }`. The API key is not persisted. Exact file duplicates (same checksum) are skipped.
+
 ### swift-paperless (iOS)
 
 [swift-paperless](https://github.com/paulgessinger/swift-paperless) is the main mobile client exercised against this API. Browsing documents, viewing details, and uploading generally work. Some paperless-ngx-specific settings or advanced features may be missing or no-ops because Paperless Go does not implement the full paperless-ngx surface area.

--- a/docs/development.md
+++ b/docs/development.md
@@ -214,7 +214,7 @@ Admins can migrate an existing Paperless-ngx library into Paperless Go:
    - **Import files only and reprocess** (`reprocess`): downloads only the original files and queues the full OCR + AI pipeline as for a new upload.
 4. Start the import. Exact file duplicates (same checksum) are skipped.
 
-The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "...", "mode": "preserve" | "reprocess" }`. `mode` defaults to `preserve`. The API key is not persisted.
+The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "...", "mode": "preserve" | "reprocess" }`. The request returns `202 Accepted` with `{ "job_id", "status": "running" }`. Poll `GET /api/app/import/ngx/status?job_id=...` until `status` is `completed` (with `result`) or `failed` (with `error`). Job state is kept in memory for the running process only. `mode` defaults to `preserve`. The API key is not persisted.
 
 ### swift-paperless (iOS)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -209,9 +209,12 @@ Admins can migrate an existing Paperless-ngx library into Paperless Go:
 
 1. Open **Import** in the More menu (or go to `/import`).
 2. Enter the remote Paperless-ngx base URL and an API token from that instance’s profile.
-3. Start the import. Tags, correspondents, and document types are upserted by name; documents are downloaded with their OCR `content` and then queued for the normal AI pipeline (OCR is skipped when text is already present).
+3. Choose an import mode:
+   - **Keep Paperless-ngx metadata** (`preserve`): upserts tags, correspondents, and document types by name; downloads each document with its OCR `content`, title, date, and taxonomy links. Preview and duplicate detection still run; AI metadata extraction is skipped so remote metadata is kept.
+   - **Import files only and reprocess** (`reprocess`): downloads only the original files and queues the full OCR + AI pipeline as for a new upload.
+4. Start the import. Exact file duplicates (same checksum) are skipped.
 
-The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "..." }`. The API key is not persisted. Exact file duplicates (same checksum) are skipped.
+The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "...", "mode": "preserve" | "reprocess" }`. `mode` defaults to `preserve`. The API key is not persisted.
 
 ### swift-paperless (iOS)
 

--- a/frontend/e2e/import.spec.ts
+++ b/frontend/e2e/import.spec.ts
@@ -17,5 +17,7 @@ test('superuser can open import page', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Import from Paperless-ngx' })).toBeVisible()
   await expect(page.getByLabel('Paperless-ngx URL')).toBeVisible()
   await expect(page.getByLabel('API key')).toBeVisible()
+  await expect(page.getByRole('radio', { name: /Keep Paperless-ngx metadata/i })).toBeChecked()
+  await expect(page.getByRole('radio', { name: /Import files only and reprocess/i })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Start import' })).toBeVisible()
 })

--- a/frontend/e2e/import.spec.ts
+++ b/frontend/e2e/import.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { loginAsSuper, loginAsUser, openMoreMenu } from './helpers/auth'
+
+test('regular user cannot open import', async ({ page }) => {
+  await loginAsUser(page)
+  await openMoreMenu(page)
+  await expect(page.getByRole('menuitem', { name: 'Import' })).toHaveCount(0)
+  await page.goto('/import')
+  await expect(page.getByRole('heading', { name: 'Import from Paperless-ngx' })).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible()
+})
+
+test('superuser can open import page', async ({ page }) => {
+  await loginAsSuper(page)
+  await openMoreMenu(page)
+  await page.getByRole('menuitem', { name: 'Import' }).click()
+  await expect(page.getByRole('heading', { name: 'Import from Paperless-ngx' })).toBeVisible()
+  await expect(page.getByLabel('Paperless-ngx URL')).toBeVisible()
+  await expect(page.getByLabel('API key')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Start import' })).toBeVisible()
+})

--- a/frontend/src/components/RootLayout.tsx
+++ b/frontend/src/components/RootLayout.tsx
@@ -68,8 +68,9 @@ function MoreNavMenu({ admin }: { admin: boolean }) {
   const rootRef = useRef<HTMLDivElement>(null)
   const matchRoute = useMatchRoute()
   const settingsActive = Boolean(matchRoute({ to: '/settings' }))
+  const importActive = Boolean(matchRoute({ to: '/import' }))
   const ocrTestActive = Boolean(matchRoute({ to: '/ocr-test' }))
-  const menuActive = settingsActive || ocrTestActive
+  const menuActive = settingsActive || importActive || ocrTestActive
 
   useEffect(() => {
     if (!open) return
@@ -120,6 +121,16 @@ function MoreNavMenu({ admin }: { admin: boolean }) {
           >
             OCR test
           </Link>
+          {admin && (
+            <Link
+              to="/import"
+              role="menuitem"
+              className={`${menuItemClass} ${importActive ? navLinkActiveClass : ''}`}
+              onClick={() => setOpen(false)}
+            >
+              Import
+            </Link>
+          )}
           {admin && (
             <Link
               to="/settings"

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -547,6 +547,38 @@ export async function scanDuplicates() {
   return data as DuplicateScanResult
 }
 
+export type NgxImportResult = {
+  imported: number
+  skipped_duplicates: number
+  failed: number
+  tags_upserted: number
+  correspondents_upserted: number
+  document_types_upserted: number
+  errors: string[]
+}
+
+export async function importFromNgx(url: string, apiKey: string) {
+  await ensureAuth()
+
+  const response = await fetch(`${pbUrl}/api/app/import/ngx`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: pb.authStore.token,
+    },
+    body: JSON.stringify({ url, api_key: apiKey }),
+  })
+
+  const data = (await response.json()) as NgxImportResult & { detail?: string }
+  if (!response.ok) {
+    throw new Error(data.detail ?? 'Import failed')
+  }
+  return {
+    ...data,
+    errors: data.errors ?? [],
+  } as NgxImportResult
+}
+
 export function parseDuplicateOfId(message: string): string | null {
   const match = message.match(/duplicate of ([a-z0-9]{15})/i)
   return match?.[1] ?? null

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -559,10 +559,27 @@ export type NgxImportResult = {
   errors: string[]
 }
 
+type NgxImportJobStart = {
+  job_id: string
+  status: string
+  detail?: string
+}
+
+type NgxImportJobStatus = {
+  job_id: string
+  status: 'running' | 'completed' | 'failed' | string
+  error?: string
+  result?: NgxImportResult
+  detail?: string
+}
+
+const importPollIntervalMs = 500
+const importPollMaxAttempts = 600
+
 export async function importFromNgx(url: string, apiKey: string, mode: NgxImportMode = 'preserve') {
   await ensureAuth()
 
-  const response = await fetch(`${pbUrl}/api/app/import/ngx`, {
+  const startResponse = await fetch(`${pbUrl}/api/app/import/ngx`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -571,14 +588,44 @@ export async function importFromNgx(url: string, apiKey: string, mode: NgxImport
     body: JSON.stringify({ url, api_key: apiKey, mode }),
   })
 
-  const data = (await response.json()) as NgxImportResult & { detail?: string }
-  if (!response.ok) {
-    throw new Error(data.detail ?? 'Import failed')
+  const startData = (await startResponse.json()) as NgxImportJobStart
+  if (!startResponse.ok) {
+    throw new Error(startData.detail ?? 'Import failed to start')
   }
-  return {
-    ...data,
-    errors: data.errors ?? [],
-  } as NgxImportResult
+  if (!startData.job_id) {
+    throw new Error('Import job id missing from server response')
+  }
+
+  for (let attempt = 0; attempt < importPollMaxAttempts; attempt++) {
+    const statusResponse = await fetch(
+      `${pbUrl}/api/app/import/ngx/status?job_id=${encodeURIComponent(startData.job_id)}`,
+      {
+        headers: {
+          Authorization: pb.authStore.token,
+        },
+      },
+    )
+    const statusData = (await statusResponse.json()) as NgxImportJobStatus
+    if (!statusResponse.ok) {
+      throw new Error(statusData.detail ?? 'Failed to poll import status')
+    }
+    if (statusData.status === 'completed') {
+      const result = statusData.result
+      if (!result) {
+        throw new Error('Import completed without a result')
+      }
+      return {
+        ...result,
+        errors: result.errors ?? [],
+      } as NgxImportResult
+    }
+    if (statusData.status === 'failed') {
+      throw new Error(statusData.error ?? 'Import failed')
+    }
+    await new Promise((resolve) => setTimeout(resolve, importPollIntervalMs))
+  }
+
+  throw new Error('Import timed out while waiting for completion')
 }
 
 export function parseDuplicateOfId(message: string): string | null {

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -547,6 +547,8 @@ export async function scanDuplicates() {
   return data as DuplicateScanResult
 }
 
+export type NgxImportMode = 'preserve' | 'reprocess'
+
 export type NgxImportResult = {
   imported: number
   skipped_duplicates: number
@@ -557,7 +559,7 @@ export type NgxImportResult = {
   errors: string[]
 }
 
-export async function importFromNgx(url: string, apiKey: string) {
+export async function importFromNgx(url: string, apiKey: string, mode: NgxImportMode = 'preserve') {
   await ensureAuth()
 
   const response = await fetch(`${pbUrl}/api/app/import/ngx`, {
@@ -566,7 +568,7 @@ export async function importFromNgx(url: string, apiKey: string) {
       'Content-Type': 'application/json',
       Authorization: pb.authStore.token,
     },
-    body: JSON.stringify({ url, api_key: apiKey }),
+    body: JSON.stringify({ url, api_key: apiKey, mode }),
   })
 
   const data = (await response.json()) as NgxImportResult & { detail?: string }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,6 +7,7 @@ import { DocumentAskPage } from './routes/document.$documentId.ask'
 import { OCRTestPage } from './routes/ocr-test'
 import { SearchPage } from './routes/search'
 import { SettingsPage } from './routes/settings'
+import { ImportPage } from './routes/import'
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -42,6 +43,12 @@ const settingsRoute = createRoute({
   component: SettingsPage,
 })
 
+const importRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/import',
+  component: ImportPage,
+})
+
 const documentRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/document/$documentId',
@@ -60,6 +67,7 @@ const routeTree = rootRoute.addChildren([
   searchRoute,
   ocrTestRoute,
   settingsRoute,
+  importRoute,
   documentRoute,
   documentAskRoute,
 ])

--- a/frontend/src/routes/import.tsx
+++ b/frontend/src/routes/import.tsx
@@ -4,6 +4,7 @@ import {
   ensureAuth,
   importFromNgx,
   isAdmin,
+  type NgxImportMode,
   type NgxImportResult,
 } from '../lib/pocketbase'
 
@@ -12,10 +13,26 @@ const inputClassName =
 const labelClassName = 'flex flex-col gap-1'
 const labelTextClassName = 'text-xs font-medium text-stone-500'
 
+const modeOptions: { value: NgxImportMode; label: string; description: string }[] = [
+  {
+    value: 'preserve',
+    label: 'Keep Paperless-ngx metadata',
+    description:
+      'Import title, tags, correspondent, document type, date, and OCR text. Preview and duplicate detection still run; AI does not overwrite metadata.',
+  },
+  {
+    value: 'reprocess',
+    label: 'Import files only and reprocess',
+    description:
+      'Import only the original files, then run the full OCR and AI pipeline as if they were newly uploaded.',
+  },
+]
+
 export function ImportPage() {
   const [allowed, setAllowed] = useState<boolean | null>(null)
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
+  const [mode, setMode] = useState<NgxImportMode>('preserve')
   const [loading, setLoading] = useState(true)
   const [running, setRunning] = useState(false)
   const [error, setError] = useState('')
@@ -56,7 +73,7 @@ export function ImportPage() {
       setRunning(true)
       setError('')
       setResult(null)
-      const summary = await importFromNgx(url.trim(), apiKey.trim())
+      const summary = await importFromNgx(url.trim(), apiKey.trim(), mode)
       setResult(summary)
       setApiKey('')
     } catch (err) {
@@ -78,9 +95,9 @@ export function ImportPage() {
       <div>
         <h1 className="text-2xl font-semibold text-stone-950">Import from Paperless-ngx</h1>
         <p className="mt-1 text-sm text-stone-500">
-          Pull documents, tags, correspondents, and document types from an existing Paperless-ngx
-          instance using its URL and API token. Remote OCR text is kept; AI metadata extraction
-          runs afterward. The API key is not stored.
+          Pull documents from an existing Paperless-ngx instance using its URL and API token. Choose
+          whether to keep remote metadata or reprocess files through OCR and AI. The API key is not
+          stored.
         </p>
       </div>
 
@@ -109,6 +126,34 @@ export function ImportPage() {
             autoComplete="off"
           />
         </label>
+        <fieldset className="space-y-2" disabled={running}>
+          <legend className={labelTextClassName}>Import mode</legend>
+          {modeOptions.map((option) => (
+            <label
+              key={option.value}
+              className={`flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-sm ${
+                mode === option.value
+                  ? 'border-stone-400 bg-white text-stone-800'
+                  : 'border-stone-200 bg-stone-50 text-stone-700'
+              }`}
+            >
+              <input
+                type="radio"
+                className="mt-0.5"
+                name="import-mode"
+                value={option.value}
+                checked={mode === option.value}
+                onChange={() => setMode(option.value)}
+              />
+              <span>
+                <span className="font-medium">{option.label}</span>
+                <span className="mt-0.5 block text-xs font-normal text-stone-500">
+                  {option.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
         <button
           type="submit"
           disabled={running}

--- a/frontend/src/routes/import.tsx
+++ b/frontend/src/routes/import.tsx
@@ -1,0 +1,148 @@
+import { type SubmitEvent, useEffect, useState } from 'react'
+import { Navigate } from '@tanstack/react-router'
+import {
+  ensureAuth,
+  importFromNgx,
+  isAdmin,
+  type NgxImportResult,
+} from '../lib/pocketbase'
+
+const inputClassName =
+  'w-full rounded-md border border-stone-300 bg-stone-50 px-3 py-2 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900'
+const labelClassName = 'flex flex-col gap-1'
+const labelTextClassName = 'text-xs font-medium text-stone-500'
+
+export function ImportPage() {
+  const [allowed, setAllowed] = useState<boolean | null>(null)
+  const [url, setUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState('')
+  const [result, setResult] = useState<NgxImportResult | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    async function load() {
+      try {
+        await ensureAuth()
+        const admin = await isAdmin()
+        if (active) setAllowed(admin)
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load')
+          setAllowed(false)
+        }
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  async function onSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!url.trim() || !apiKey.trim()) {
+      setError('URL and API key are required')
+      return
+    }
+
+    try {
+      setRunning(true)
+      setError('')
+      setResult(null)
+      const summary = await importFromNgx(url.trim(), apiKey.trim())
+      setResult(summary)
+      setApiKey('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (loading || allowed === null) {
+    return <p className="text-sm text-stone-500">Loading…</p>
+  }
+  if (!allowed) {
+    return <Navigate to="/" />
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-stone-950">Import from Paperless-ngx</h1>
+        <p className="mt-1 text-sm text-stone-500">
+          Pull documents, tags, correspondents, and document types from an existing Paperless-ngx
+          instance using its URL and API token. Remote OCR text is kept; AI metadata extraction
+          runs afterward. The API key is not stored.
+        </p>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-4 rounded-lg border border-stone-200 bg-stone-50 p-5">
+        <label className={labelClassName}>
+          <span className={labelTextClassName}>Paperless-ngx URL</span>
+          <input
+            className={inputClassName}
+            type="url"
+            required
+            placeholder="https://paperless.example.com"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            autoComplete="off"
+          />
+        </label>
+        <label className={labelClassName}>
+          <span className={labelTextClassName}>API key</span>
+          <input
+            className={inputClassName}
+            type="password"
+            required
+            placeholder="Token from Paperless-ngx profile"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            autoComplete="off"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={running}
+          className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {running ? 'Importing…' : 'Start import'}
+        </button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {result && (
+        <div className="space-y-2 rounded-lg border border-stone-200 bg-white p-5 text-sm text-stone-700">
+          <p className="font-medium text-stone-950">Import finished</p>
+          <ul className="list-inside list-disc space-y-1">
+            <li>Imported: {result.imported}</li>
+            <li>Skipped duplicates: {result.skipped_duplicates}</li>
+            <li>Failed: {result.failed}</li>
+            <li>Tags upserted: {result.tags_upserted}</li>
+            <li>Correspondents upserted: {result.correspondents_upserted}</li>
+            <li>Document types upserted: {result.document_types_upserted}</li>
+          </ul>
+          {result.errors.length > 0 && (
+            <div className="mt-3">
+              <p className="font-medium text-stone-950">Errors</p>
+              <ul className="mt-1 list-inside list-disc space-y-1 text-red-700">
+                {result.errors.map((msg) => (
+                  <li key={msg}>{msg}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds one-shot Paperless-ngx import (URL + API key) that upserts tags, correspondents, and document types, then downloads documents with remote OCR text.
- Imported documents go through the normal pipeline so OCR is skipped when text is present and AI metadata extraction still runs.
- Admin UI at `/import` (More menu) plus `POST /api/app/import/ngx`; API key is not persisted; exact checksum duplicates are skipped.

## Test plan
- [x] `./scripts/test-all.sh` (unit, API e2e, Playwright)
- [ ] Manually import from a real Paperless-ngx instance via `/import`
- [ ] Confirm re-import of the same files reports skipped duplicates
- [ ] Confirm non-admin users do not see Import in the menu

Fixes #12