### PR TITLE
Feature: download archive (#15)

### DIFF
--- a/backend/e2e/export_test.go
+++ b/backend/e2e/export_test.go
@@ -49,7 +49,10 @@ func TestDocumentsExportArchive(t *testing.T) {
 	if fileName == "" {
 		t.Fatal("missing file name")
 	}
-	stem := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+	ext := filepath.Ext(fileName)
+	origPath := "paperless-export/[" + id + "] " + wantTitle + ext
+	ocrPath := "paperless-export/[" + id + "] " + wantTitle + ".ocr.txt"
+	metaPath := "paperless-export/[" + id + "] " + wantTitle + ".metadata.json"
 
 	t.Run("unauthenticated", func(t *testing.T) {
 		status, body, _ := h.doRaw(t, http.MethodGet, "/api/app/documents/export?mode=originals", "", nil, "")
@@ -63,29 +66,28 @@ func TestDocumentsExportArchive(t *testing.T) {
 
 	t.Run("originals", func(t *testing.T) {
 		entries := fetchExportZip(t, h, token, "originals")
-		assertZipHas(t, entries, id+"/"+fileName)
-		assertZipMissing(t, entries, id+"/"+stem+".ocr.txt")
-		assertZipMissing(t, entries, id+"/"+stem+".metadata.json")
-		if !strings.Contains(entries[id+"/"+fileName], "Acme Plumbing") {
+		assertZipHas(t, entries, origPath)
+		assertZipMissing(t, entries, ocrPath)
+		assertZipMissing(t, entries, metaPath)
+		if !strings.Contains(entries[origPath], "Acme Plumbing") {
 			t.Fatalf("original content missing fixture text")
 		}
 	})
 
 	t.Run("ocr", func(t *testing.T) {
 		entries := fetchExportZip(t, h, token, "ocr")
-		assertZipHas(t, entries, id+"/"+fileName)
-		assertZipHas(t, entries, id+"/"+stem+".ocr.txt")
-		if entries[id+"/"+stem+".ocr.txt"] != wantOCR {
-			t.Fatalf("ocr sidecar=%q", entries[id+"/"+stem+".ocr.txt"])
+		assertZipHas(t, entries, origPath)
+		assertZipHas(t, entries, ocrPath)
+		if entries[ocrPath] != wantOCR {
+			t.Fatalf("ocr sidecar=%q", entries[ocrPath])
 		}
-		assertZipMissing(t, entries, id+"/"+stem+".metadata.json")
+		assertZipMissing(t, entries, metaPath)
 	})
 
 	t.Run("metadata", func(t *testing.T) {
 		entries := fetchExportZip(t, h, token, "metadata")
-		assertZipHas(t, entries, id+"/"+fileName)
-		assertZipHas(t, entries, id+"/"+stem+".ocr.txt")
-		metaPath := id + "/" + stem + ".metadata.json"
+		assertZipHas(t, entries, origPath)
+		assertZipHas(t, entries, ocrPath)
 		assertZipHas(t, entries, metaPath)
 		var meta map[string]any
 		if err := json.Unmarshal([]byte(entries[metaPath]), &meta); err != nil {
@@ -94,8 +96,8 @@ func TestDocumentsExportArchive(t *testing.T) {
 		if meta["title"] != wantTitle {
 			t.Fatalf("title=%v", meta["title"])
 		}
-		if meta["ocr_text"] != wantOCR {
-			t.Fatalf("ocr_text=%v", meta["ocr_text"])
+		if _, hasOCR := meta["ocr_text"]; hasOCR {
+			t.Fatal("metadata json must not include ocr_text")
 		}
 		if meta["original_filename"] != fileName {
 			t.Fatalf("original_filename=%v", meta["original_filename"])
@@ -125,7 +127,6 @@ func TestDocumentsExportOwnerIsolation(t *testing.T) {
 	rec := h.uploadDocument(t, tokenA, h.UserID, fixturePath("sample.txt"))
 	idA := jsonGetString(rec, "id")
 	h.settleDocuments(t, idA)
-	fileA := jsonGetString(h.getDocument(t, tokenA, idA), "file")
 
 	otherEmail := "export-other-e2e@paperless.local"
 	otherPass := "otherpassword123"
@@ -155,15 +156,14 @@ func TestDocumentsExportOwnerIsolation(t *testing.T) {
 	recB := h.uploadDocument(t, tokenB, otherID, fixturePath("sample.txt"))
 	idB := jsonGetString(recB, "id")
 	h.settleDocuments(t, idA, idB)
-	fileB := jsonGetString(h.getDocument(t, tokenB, idB), "file")
 
 	entriesA := fetchExportZip(t, h, tokenA, "originals")
-	assertZipHas(t, entriesA, idA+"/"+fileA)
-	assertZipMissing(t, entriesA, idB+"/"+fileB)
+	assertZipHasID(t, entriesA, idA)
+	assertZipMissingID(t, entriesA, idB)
 
 	entriesB := fetchExportZip(t, h, tokenB, "originals")
-	assertZipHas(t, entriesB, idB+"/"+fileB)
-	assertZipMissing(t, entriesB, idA+"/"+fileA)
+	assertZipHasID(t, entriesB, idB)
+	assertZipMissingID(t, entriesB, idA)
 
 	t.Cleanup(func() {
 		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+idA, tokenA, nil)
@@ -218,6 +218,31 @@ func assertZipMissing(t *testing.T, entries map[string]string, name string) {
 	t.Helper()
 	if _, ok := entries[name]; ok {
 		t.Fatalf("unexpected zip entry %q", name)
+	}
+}
+
+func assertZipHasID(t *testing.T, entries map[string]string, id string) {
+	t.Helper()
+	prefix := "paperless-export/[" + id + "]"
+	for name := range entries {
+		if strings.HasPrefix(name, prefix) {
+			return
+		}
+	}
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	t.Fatalf("missing zip entry for document %s; have %v", id, keys)
+}
+
+func assertZipMissingID(t *testing.T, entries map[string]string, id string) {
+	t.Helper()
+	prefix := "paperless-export/[" + id + "]"
+	for name := range entries {
+		if strings.HasPrefix(name, prefix) {
+			t.Fatalf("unexpected zip entry for document %s: %q", id, name)
+		}
 	}
 }
 

--- a/backend/e2e/export_test.go
+++ b/backend/e2e/export_test.go
@@ -1,0 +1,231 @@
+package e2e
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocumentsExportArchive(t *testing.T) {
+	h := StartShared(t)
+	token := h.userToken(t)
+
+	rec := h.uploadDocument(t, token, h.UserID, fixturePath("sample.txt"))
+	id := jsonGetString(rec, "id")
+	h.settleDocuments(t, id)
+
+	status, raw := h.doJSON(t, http.MethodPost, "/api/collections/tags/records", token, map[string]any{
+		"name": "export-e2e-tag-" + id,
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+	var tag map[string]any
+	if err := json.Unmarshal([]byte(raw), &tag); err != nil {
+		t.Fatalf("decode tag: %v", err)
+	}
+	tagID := jsonGetString(tag, "id")
+	tagName := jsonGetString(tag, "name")
+
+	const wantOCR = "OCR text for export e2e"
+	const wantTitle = "Export Invoice"
+	status, raw = h.doJSON(t, http.MethodPatch, "/api/collections/documents/records/"+id, token, map[string]any{
+		"title":                   wantTitle,
+		"ocr_text":                wantOCR,
+		"tags":                    []string{tagID},
+		"people_or_organizations": []string{"Acme Plumbing"},
+		"purpose":                 "Plumbing invoice",
+		"processing_status":       "completed",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+	doc := mustDecodeMap(t, raw)
+	if jsonGetString(doc, "title") != wantTitle || jsonGetString(doc, "ocr_text") != wantOCR {
+		t.Fatalf("patch did not stick: title=%q ocr=%q", jsonGetString(doc, "title"), jsonGetString(doc, "ocr_text"))
+	}
+	fileName := jsonGetString(doc, "file")
+	if fileName == "" {
+		t.Fatal("missing file name")
+	}
+	stem := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		status, body, _ := h.doRaw(t, http.MethodGet, "/api/app/documents/export?mode=originals", "", nil, "")
+		requireStatus(t, status, http.StatusUnauthorized, body)
+	})
+
+	t.Run("invalid_mode", func(t *testing.T) {
+		status, body, _ := h.doRaw(t, http.MethodGet, "/api/app/documents/export?mode=nope", token, nil, "")
+		requireStatus(t, status, http.StatusBadRequest, body)
+	})
+
+	t.Run("originals", func(t *testing.T) {
+		entries := fetchExportZip(t, h, token, "originals")
+		assertZipHas(t, entries, id+"/"+fileName)
+		assertZipMissing(t, entries, id+"/"+stem+".ocr.txt")
+		assertZipMissing(t, entries, id+"/"+stem+".metadata.json")
+		if !strings.Contains(entries[id+"/"+fileName], "Acme Plumbing") {
+			t.Fatalf("original content missing fixture text")
+		}
+	})
+
+	t.Run("ocr", func(t *testing.T) {
+		entries := fetchExportZip(t, h, token, "ocr")
+		assertZipHas(t, entries, id+"/"+fileName)
+		assertZipHas(t, entries, id+"/"+stem+".ocr.txt")
+		if entries[id+"/"+stem+".ocr.txt"] != wantOCR {
+			t.Fatalf("ocr sidecar=%q", entries[id+"/"+stem+".ocr.txt"])
+		}
+		assertZipMissing(t, entries, id+"/"+stem+".metadata.json")
+	})
+
+	t.Run("metadata", func(t *testing.T) {
+		entries := fetchExportZip(t, h, token, "metadata")
+		assertZipHas(t, entries, id+"/"+fileName)
+		assertZipHas(t, entries, id+"/"+stem+".ocr.txt")
+		metaPath := id + "/" + stem + ".metadata.json"
+		assertZipHas(t, entries, metaPath)
+		var meta map[string]any
+		if err := json.Unmarshal([]byte(entries[metaPath]), &meta); err != nil {
+			t.Fatalf("decode metadata: %v", err)
+		}
+		if meta["title"] != wantTitle {
+			t.Fatalf("title=%v", meta["title"])
+		}
+		if meta["ocr_text"] != wantOCR {
+			t.Fatalf("ocr_text=%v", meta["ocr_text"])
+		}
+		if meta["original_filename"] != fileName {
+			t.Fatalf("original_filename=%v", meta["original_filename"])
+		}
+		tags, _ := meta["tags"].([]any)
+		foundTag := false
+		for _, item := range tags {
+			if item == tagName {
+				foundTag = true
+				break
+			}
+		}
+		if !foundTag {
+			t.Fatalf("expected tag name %q in metadata, got %#v", tagName, meta["tags"])
+		}
+	})
+
+	t.Cleanup(func() {
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+id, token, nil)
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/tags/records/"+tagID, token, nil)
+	})
+}
+
+func TestDocumentsExportOwnerIsolation(t *testing.T) {
+	h := StartShared(t)
+	tokenA := h.userToken(t)
+	rec := h.uploadDocument(t, tokenA, h.UserID, fixturePath("sample.txt"))
+	idA := jsonGetString(rec, "id")
+	h.settleDocuments(t, idA)
+	fileA := jsonGetString(h.getDocument(t, tokenA, idA), "file")
+
+	otherEmail := "export-other-e2e@paperless.local"
+	otherPass := "otherpassword123"
+	status, raw := h.doJSON(t, http.MethodPost, "/api/collections/users/records", h.superToken(t), map[string]any{
+		"email":           otherEmail,
+		"password":        otherPass,
+		"passwordConfirm": otherPass,
+		"verified":        true,
+	})
+	otherID := ""
+	if status >= 200 && status < 300 {
+		otherID = jsonGetString(mustDecodeMap(t, raw), "id")
+	} else {
+		var err error
+		otherID, err = createAuthRecord(h.App, "users", otherEmail, otherPass)
+		if err != nil {
+			t.Fatalf("create other user via API (%s) and app (%v)", formatErr(status, raw), err)
+		}
+	}
+
+	authB := h.authWithPassword(t, "users", otherEmail, otherPass)
+	tokenB := authB.Token
+	if otherID == "" {
+		otherID = jsonGetString(authB.Record, "id")
+	}
+
+	recB := h.uploadDocument(t, tokenB, otherID, fixturePath("sample.txt"))
+	idB := jsonGetString(recB, "id")
+	h.settleDocuments(t, idA, idB)
+	fileB := jsonGetString(h.getDocument(t, tokenB, idB), "file")
+
+	entriesA := fetchExportZip(t, h, tokenA, "originals")
+	assertZipHas(t, entriesA, idA+"/"+fileA)
+	assertZipMissing(t, entriesA, idB+"/"+fileB)
+
+	entriesB := fetchExportZip(t, h, tokenB, "originals")
+	assertZipHas(t, entriesB, idB+"/"+fileB)
+	assertZipMissing(t, entriesB, idA+"/"+fileA)
+
+	t.Cleanup(func() {
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+idA, tokenA, nil)
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+idB, tokenB, nil)
+	})
+}
+
+func fetchExportZip(t *testing.T, h *Harness, token, mode string) map[string]string {
+	t.Helper()
+	status, body, headers := h.doRaw(t, http.MethodGet, "/api/app/documents/export?mode="+mode, token, nil, "")
+	requireStatus(t, status, http.StatusOK, body)
+	if ct := headers.Get("Content-Type"); !strings.Contains(ct, "application/zip") {
+		t.Fatalf("Content-Type=%q", ct)
+	}
+	if !strings.Contains(headers.Get("Content-Disposition"), "paperless-export.zip") {
+		t.Fatalf("Content-Disposition=%q", headers.Get("Content-Disposition"))
+	}
+
+	data := []byte(body)
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	out := make(map[string]string, len(zr.File))
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", f.Name, err)
+		}
+		raw, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("read %s: %v", f.Name, err)
+		}
+		out[f.Name] = string(raw)
+	}
+	return out
+}
+
+func assertZipHas(t *testing.T, entries map[string]string, name string) {
+	t.Helper()
+	if _, ok := entries[name]; !ok {
+		keys := make([]string, 0, len(entries))
+		for k := range entries {
+			keys = append(keys, k)
+		}
+		t.Fatalf("missing zip entry %q; have %v", name, keys)
+	}
+}
+
+func assertZipMissing(t *testing.T, entries map[string]string, name string) {
+	t.Helper()
+	if _, ok := entries[name]; ok {
+		t.Fatalf("unexpected zip entry %q", name)
+	}
+}
+
+func mustDecodeMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("decode map: %v body %s", err, raw)
+	}
+	return m
+}

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -17,6 +17,7 @@ func Register(app core.App, rt *config.Runtime) {
 			g.POST("/setup/admin", handlePostSetupAdmin(app))
 			g.POST("/ensure-user", handlePostEnsureUser(app))
 			g.POST("/documents/{documentId}/chat", bindAuth(handleDocumentChat(app, rt)))
+			g.GET("/documents/export", bindAuth(handleExportDocuments(app)))
 			g.POST("/search", bindAuth(handleDeepSearch(app, rt)))
 			g.GET("/ocr/providers", bindAuth(handleOCRProviders(rt)))
 			g.POST("/ocr/test", bindAuth(handleOCRTest(app, rt)))

--- a/backend/internal/appapi/export.go
+++ b/backend/internal/appapi/export.go
@@ -43,6 +43,7 @@ func handleExportDocuments(app core.App) func(*core.RequestEvent) error {
 			fileKey := rec.BaseFilesPath() + "/" + name
 			docs = append(docs, ExportDocument{
 				ID:               rec.Id,
+				Title:            firstNonEmpty(rec.GetString("title"), rec.GetString("title_original"), "Untitled"),
 				OriginalFilename: name,
 				OpenFile: func() (io.ReadCloser, error) {
 					reader, err := fsys.GetReader(fileKey)
@@ -141,7 +142,6 @@ func buildExportMetadata(app core.App, record *core.Record, originalFilename str
 		"checksum":                record.GetString("checksum"),
 		"created":                 record.GetString("created"),
 		"updated":                 record.GetString("updated"),
-		"ocr_text":                record.GetString("ocr_text"),
 		"original_filename":       originalFilename,
 	}
 }

--- a/backend/internal/appapi/export.go
+++ b/backend/internal/appapi/export.go
@@ -1,0 +1,184 @@
+package appapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const exportPageSize = 100
+
+func handleExportDocuments(app core.App) func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		mode, err := ParseExportMode(e.Request.URL.Query().Get("mode"))
+		if err != nil {
+			return writeError(e, http.StatusBadRequest, err.Error())
+		}
+
+		userID := e.Auth.Id
+		records, err := listOwnedDocuments(app, userID)
+		if err != nil {
+			return writeError(e, http.StatusInternalServerError, "Failed to list documents.")
+		}
+
+		fsys, err := app.NewFilesystem()
+		if err != nil {
+			return writeError(e, http.StatusInternalServerError, "Failed to open storage.")
+		}
+		defer fsys.Close()
+
+		docs := make([]ExportDocument, 0, len(records))
+		for _, record := range records {
+			fileName := record.GetString("file")
+			if fileName == "" {
+				continue
+			}
+			rec := record
+			name := fileName
+			fileKey := rec.BaseFilesPath() + "/" + name
+			docs = append(docs, ExportDocument{
+				ID:               rec.Id,
+				OriginalFilename: name,
+				OpenFile: func() (io.ReadCloser, error) {
+					reader, err := fsys.GetReader(fileKey)
+					if err != nil {
+						app.Logger().Warn("export skip missing file", "document", rec.Id, "error", err)
+						return nil, err
+					}
+					return reader, nil
+				},
+				OCRText:  rec.GetString("ocr_text"),
+				Metadata: buildExportMetadata(app, rec, name),
+			})
+		}
+
+		e.Response.Header().Set("Content-Type", "application/zip")
+		e.Response.Header().Set("Content-Disposition", `attachment; filename="paperless-export.zip"`)
+		e.Response.WriteHeader(http.StatusOK)
+
+		if err := WriteExportZip(e.Response, mode, docs); err != nil {
+			app.Logger().Error("export zip failed", "error", err)
+			return err
+		}
+		return nil
+	}
+}
+
+func listOwnedDocuments(app core.App, userID string) ([]*core.Record, error) {
+	var all []*core.Record
+	page := 1
+	for {
+		records, err := app.FindRecordsByFilter(
+			"documents",
+			"user = {:userId}",
+			"-created",
+			exportPageSize,
+			(page-1)*exportPageSize,
+			dbx.Params{"userId": userID},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("list documents: %w", err)
+		}
+		all = append(all, records...)
+		if len(records) < exportPageSize {
+			break
+		}
+		page++
+	}
+	return all, nil
+}
+
+func buildExportMetadata(app core.App, record *core.Record, originalFilename string) map[string]any {
+	tags := make([]string, 0)
+	for _, tagID := range record.GetStringSlice("tags") {
+		if tagID == "" {
+			continue
+		}
+		tagRec, err := app.FindRecordById("tags", tagID)
+		if err != nil {
+			continue
+		}
+		if name := strings.TrimSpace(tagRec.GetString("name")); name != "" {
+			tags = append(tags, name)
+		}
+	}
+
+	documentType := ""
+	if typeID := record.GetString("document_type"); typeID != "" {
+		if typeRec, err := app.FindRecordById("document_types", typeID); err == nil {
+			documentType = typeRec.GetString("name")
+		}
+	}
+
+	correspondent := ""
+	if corrID := record.GetString("correspondent"); corrID != "" {
+		if corrRec, err := app.FindRecordById("correspondents", corrID); err == nil {
+			correspondent = corrRec.GetString("name")
+		}
+	}
+
+	return map[string]any{
+		"id":                      record.Id,
+		"title":                   record.GetString("title"),
+		"title_original":          record.GetString("title_original"),
+		"purpose":                 record.GetString("purpose"),
+		"purpose_original":        record.GetString("purpose_original"),
+		"summary":                 record.GetString("summary"),
+		"summary_original":        record.GetString("summary_original"),
+		"document_date":           record.GetString("document_date"),
+		"tags":                    tags,
+		"document_type":           documentType,
+		"correspondent":           correspondent,
+		"people_or_organizations": peopleOrOrganizations(record),
+		"processing_status":       record.GetString("processing_status"),
+		"metadata_source":         record.GetString("metadata_source"),
+		"confidence":              record.GetFloat("confidence"),
+		"checksum":                record.GetString("checksum"),
+		"created":                 record.GetString("created"),
+		"updated":                 record.GetString("updated"),
+		"ocr_text":                record.GetString("ocr_text"),
+		"original_filename":       originalFilename,
+	}
+}
+
+func peopleOrOrganizations(record *core.Record) []string {
+	raw := record.Get("people_or_organizations")
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return []string{}
+		}
+		var out []string
+		if err := json.Unmarshal([]byte(v), &out); err == nil {
+			return out
+		}
+		return []string{}
+	case nil:
+		return []string{}
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return []string{}
+		}
+		var out []string
+		if err := json.Unmarshal(b, &out); err != nil {
+			return []string{}
+		}
+		return out
+	}
+}

--- a/backend/internal/appapi/export.go
+++ b/backend/internal/appapi/export.go
@@ -23,15 +23,18 @@ func handleExportDocuments(app core.App) func(*core.RequestEvent) error {
 		userID := e.Auth.Id
 		records, err := listOwnedDocuments(app, userID)
 		if err != nil {
+			app.Logger().Error("export list documents failed", "error", err)
 			return writeError(e, http.StatusInternalServerError, "Failed to list documents.")
 		}
 
 		fsys, err := app.NewFilesystem()
 		if err != nil {
+			app.Logger().Error("export open storage failed", "error", err)
 			return writeError(e, http.StatusInternalServerError, "Failed to open storage.")
 		}
 		defer fsys.Close()
 
+		includeMetadata := mode == ExportModeMetadata
 		docs := make([]ExportDocument, 0, len(records))
 		for _, record := range records {
 			fileName := record.GetString("file")
@@ -41,7 +44,7 @@ func handleExportDocuments(app core.App) func(*core.RequestEvent) error {
 			rec := record
 			name := fileName
 			fileKey := rec.BaseFilesPath() + "/" + name
-			docs = append(docs, ExportDocument{
+			doc := ExportDocument{
 				ID:               rec.Id,
 				Title:            firstNonEmpty(rec.GetString("title"), rec.GetString("title_original"), "Untitled"),
 				OriginalFilename: name,
@@ -53,9 +56,12 @@ func handleExportDocuments(app core.App) func(*core.RequestEvent) error {
 					}
 					return reader, nil
 				},
-				OCRText:  rec.GetString("ocr_text"),
-				Metadata: buildExportMetadata(app, rec, name),
-			})
+				OCRText: rec.GetString("ocr_text"),
+			}
+			if includeMetadata {
+				doc.Metadata = buildExportMetadata(app, rec, name)
+			}
+			docs = append(docs, doc)
 		}
 
 		e.Response.Header().Set("Content-Type", "application/zip")

--- a/backend/internal/appapi/export_zip.go
+++ b/backend/internal/appapi/export_zip.go
@@ -8,7 +8,10 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"unicode"
 )
+
+const exportZipRoot = "paperless-export"
 
 // ExportMode controls which sidecar files are included in the archive.
 type ExportMode string
@@ -37,6 +40,7 @@ func ParseExportMode(raw string) (ExportMode, error) {
 // OpenFile is called when packing; it may return an error to skip the document.
 type ExportDocument struct {
 	ID               string
+	Title            string
 	OriginalFilename string
 	OpenFile         func() (io.ReadCloser, error)
 	OCRText          string
@@ -44,6 +48,7 @@ type ExportDocument struct {
 }
 
 // WriteExportZip streams a zip of the given documents for mode into w.
+// Entries are flattened under paperless-export/ as "[id] title.ext".
 // Documents that fail OpenFile or lack an ID/filename are skipped.
 // Empty OCR text omits the OCR sidecar.
 func WriteExportZip(w io.Writer, mode ExportMode, docs []ExportDocument) (err error) {
@@ -64,9 +69,9 @@ func WriteExportZip(w io.Writer, mode ExportMode, docs []ExportDocument) (err er
 			continue
 		}
 
-		baseName := path.Base(doc.OriginalFilename)
-		dir := doc.ID
-		originalPath := path.Join(dir, baseName)
+		ext := filepath.Ext(path.Base(doc.OriginalFilename))
+		base := exportEntryBase(doc.ID, doc.Title)
+		originalPath := path.Join(exportZipRoot, base+ext)
 
 		copyErr := writeZipFile(zw, originalPath, reader)
 		_ = reader.Close()
@@ -74,11 +79,10 @@ func WriteExportZip(w io.Writer, mode ExportMode, docs []ExportDocument) (err er
 			return fmt.Errorf("write original %s: %w", originalPath, copyErr)
 		}
 
-		stem := fileStem(baseName)
 		includeOCR := mode == ExportModeOCR || mode == ExportModeMetadata
 		if includeOCR {
 			if text := strings.TrimSpace(doc.OCRText); text != "" {
-				ocrPath := path.Join(dir, stem+".ocr.txt")
+				ocrPath := path.Join(exportZipRoot, base+".ocr.txt")
 				if err = writeZipBytes(zw, ocrPath, []byte(doc.OCRText)); err != nil {
 					return fmt.Errorf("write ocr %s: %w", ocrPath, err)
 				}
@@ -95,7 +99,7 @@ func WriteExportZip(w io.Writer, mode ExportMode, docs []ExportDocument) (err er
 			if err != nil {
 				return fmt.Errorf("marshal metadata for %s: %w", doc.ID, err)
 			}
-			metaPath := path.Join(dir, stem+".metadata.json")
+			metaPath := path.Join(exportZipRoot, base+".metadata.json")
 			if err = writeZipBytes(zw, metaPath, payload); err != nil {
 				return fmt.Errorf("write metadata %s: %w", metaPath, err)
 			}
@@ -105,13 +109,46 @@ func WriteExportZip(w io.Writer, mode ExportMode, docs []ExportDocument) (err er
 	return nil
 }
 
-func fileStem(filename string) string {
-	base := path.Base(filename)
-	ext := filepath.Ext(base)
-	if ext == "" {
-		return base
+// exportEntryBase returns "[id] title" with a filesystem-safe title.
+func exportEntryBase(id, title string) string {
+	safeTitle := sanitizeExportTitle(title)
+	return "[" + id + "] " + safeTitle
+}
+
+func sanitizeExportTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return "Untitled"
 	}
-	return strings.TrimSuffix(base, ext)
+	var b strings.Builder
+	b.Grow(len(title))
+	prevSpace := false
+	for _, r := range title {
+		switch {
+		case r == '/' || r == '\\' || r == ':' || r == '*' || r == '?' || r == '"' || r == '<' || r == '>' || r == '|':
+			continue
+		case r == 0 || unicode.IsControl(r):
+			continue
+		case unicode.IsSpace(r):
+			if prevSpace || b.Len() == 0 {
+				continue
+			}
+			b.WriteByte(' ')
+			prevSpace = true
+		default:
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "Untitled"
+	}
+	// Avoid names that are only "." / ".." after sanitizing.
+	if out == "." || out == ".." {
+		return "Untitled"
+	}
+	return out
 }
 
 func writeZipFile(zw *zip.Writer, name string, r io.Reader) error {

--- a/backend/internal/appapi/export_zip.go
+++ b/backend/internal/appapi/export_zip.go
@@ -1,0 +1,133 @@
+package appapi
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// ExportMode controls which sidecar files are included in the archive.
+type ExportMode string
+
+const (
+	ExportModeOriginals ExportMode = "originals"
+	ExportModeOCR       ExportMode = "ocr"
+	ExportModeMetadata  ExportMode = "metadata"
+)
+
+// ParseExportMode validates the query value; empty defaults to originals.
+func ParseExportMode(raw string) (ExportMode, error) {
+	switch strings.TrimSpace(raw) {
+	case "", string(ExportModeOriginals):
+		return ExportModeOriginals, nil
+	case string(ExportModeOCR):
+		return ExportModeOCR, nil
+	case string(ExportModeMetadata):
+		return ExportModeMetadata, nil
+	default:
+		return "", fmt.Errorf("invalid mode %q; use originals, ocr, or metadata", raw)
+	}
+}
+
+// ExportDocument is one document entry ready to pack into a zip.
+// OpenFile is called when packing; it may return an error to skip the document.
+type ExportDocument struct {
+	ID               string
+	OriginalFilename string
+	OpenFile         func() (io.ReadCloser, error)
+	OCRText          string
+	Metadata         map[string]any
+}
+
+// WriteExportZip streams a zip of the given documents for mode into w.
+// Documents that fail OpenFile or lack an ID/filename are skipped.
+// Empty OCR text omits the OCR sidecar.
+func WriteExportZip(w io.Writer, mode ExportMode, docs []ExportDocument) (err error) {
+	zw := zip.NewWriter(w)
+	defer func() {
+		if closeErr := zw.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	for _, doc := range docs {
+		if doc.OpenFile == nil || strings.TrimSpace(doc.OriginalFilename) == "" || strings.TrimSpace(doc.ID) == "" {
+			continue
+		}
+
+		reader, openErr := doc.OpenFile()
+		if openErr != nil {
+			continue
+		}
+
+		baseName := path.Base(doc.OriginalFilename)
+		dir := doc.ID
+		originalPath := path.Join(dir, baseName)
+
+		copyErr := writeZipFile(zw, originalPath, reader)
+		_ = reader.Close()
+		if copyErr != nil {
+			return fmt.Errorf("write original %s: %w", originalPath, copyErr)
+		}
+
+		stem := fileStem(baseName)
+		includeOCR := mode == ExportModeOCR || mode == ExportModeMetadata
+		if includeOCR {
+			if text := strings.TrimSpace(doc.OCRText); text != "" {
+				ocrPath := path.Join(dir, stem+".ocr.txt")
+				if err = writeZipBytes(zw, ocrPath, []byte(doc.OCRText)); err != nil {
+					return fmt.Errorf("write ocr %s: %w", ocrPath, err)
+				}
+			}
+		}
+
+		if mode == ExportModeMetadata {
+			meta := doc.Metadata
+			if meta == nil {
+				meta = map[string]any{}
+			}
+			var payload []byte
+			payload, err = json.MarshalIndent(meta, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal metadata for %s: %w", doc.ID, err)
+			}
+			metaPath := path.Join(dir, stem+".metadata.json")
+			if err = writeZipBytes(zw, metaPath, payload); err != nil {
+				return fmt.Errorf("write metadata %s: %w", metaPath, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func fileStem(filename string) string {
+	base := path.Base(filename)
+	ext := filepath.Ext(base)
+	if ext == "" {
+		return base
+	}
+	return strings.TrimSuffix(base, ext)
+}
+
+func writeZipFile(zw *zip.Writer, name string, r io.Reader) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, r)
+	return err
+}
+
+func writeZipBytes(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}

--- a/backend/internal/appapi/export_zip.go
+++ b/backend/internal/appapi/export_zip.go
@@ -9,9 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 const exportZipRoot = "paperless-export"
+
+// Max length of the sanitized title portion of an export entry name.
+// Keeps "[id] title.metadata.json" under common 255-byte filesystem limits.
+const maxExportTitleBytes = 120
 
 // ExportMode controls which sidecar files are included in the archive.
 type ExportMode string
@@ -148,7 +153,19 @@ func sanitizeExportTitle(title string) string {
 	if out == "." || out == ".." {
 		return "Untitled"
 	}
-	return out
+	return truncateUTF8Bytes(out, maxExportTitleBytes)
+}
+
+// truncateUTF8Bytes shortens s to at most maxBytes without splitting a rune.
+func truncateUTF8Bytes(s string, maxBytes int) string {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s
+	}
+	truncated := s[:maxBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return strings.TrimSpace(truncated)
 }
 
 func writeZipFile(zw *zip.Writer, name string, r io.Reader) error {

--- a/backend/internal/appapi/export_zip_test.go
+++ b/backend/internal/appapi/export_zip_test.go
@@ -1,0 +1,198 @@
+package appapi
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestParseExportMode(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    ExportMode
+		wantErr bool
+	}{
+		{"", ExportModeOriginals, false},
+		{"originals", ExportModeOriginals, false},
+		{"ocr", ExportModeOCR, false},
+		{"metadata", ExportModeMetadata, false},
+		{"bogus", "", true},
+	}
+	for _, tt := range tests {
+		got, err := ParseExportMode(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("ParseExportMode(%q) expected error", tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("ParseExportMode(%q): %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Fatalf("ParseExportMode(%q)=%q want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestWriteExportZipModes(t *testing.T) {
+	ocrText := "Invoice OCR body"
+	meta := map[string]any{
+		"id":                "doc1",
+		"title":             "Invoice",
+		"tags":              []string{"finance"},
+		"document_type":     "Invoice",
+		"correspondent":     "Acme",
+		"ocr_text":          ocrText,
+		"original_filename": "invoice.pdf",
+	}
+
+	docs := []ExportDocument{
+		{
+			ID:               "doc1",
+			OriginalFilename: "invoice.pdf",
+			OpenFile: func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("PDFBYTES")), nil
+			},
+			OCRText:  ocrText,
+			Metadata: meta,
+		},
+		{
+			ID:               "doc2",
+			OriginalFilename: "note.txt",
+			OpenFile: func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("note body")), nil
+			},
+			OCRText:  "",
+			Metadata: map[string]any{"id": "doc2", "title": "Note"},
+		},
+	}
+
+	t.Run("originals", func(t *testing.T) {
+		entries := mustZipEntries(t, ExportModeOriginals, docs)
+		assertHas(t, entries, "doc1/invoice.pdf", "PDFBYTES")
+		assertHas(t, entries, "doc2/note.txt", "note body")
+		assertMissing(t, entries, "doc1/invoice.ocr.txt")
+		assertMissing(t, entries, "doc1/invoice.metadata.json")
+	})
+
+	t.Run("ocr", func(t *testing.T) {
+		entries := mustZipEntries(t, ExportModeOCR, docs)
+		assertHas(t, entries, "doc1/invoice.pdf", "PDFBYTES")
+		assertHas(t, entries, "doc1/invoice.ocr.txt", ocrText)
+		assertMissing(t, entries, "doc2/note.ocr.txt") // empty OCR
+		assertMissing(t, entries, "doc1/invoice.metadata.json")
+	})
+
+	t.Run("metadata", func(t *testing.T) {
+		entries := mustZipEntries(t, ExportModeMetadata, docs)
+		assertHas(t, entries, "doc1/invoice.pdf", "PDFBYTES")
+		assertHas(t, entries, "doc1/invoice.ocr.txt", ocrText)
+		raw, ok := entries["doc1/invoice.metadata.json"]
+		if !ok {
+			t.Fatal("missing metadata json")
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+			t.Fatalf("decode metadata: %v", err)
+		}
+		if decoded["title"] != "Invoice" {
+			t.Fatalf("title=%v", decoded["title"])
+		}
+		if decoded["original_filename"] != "invoice.pdf" {
+			t.Fatalf("original_filename=%v", decoded["original_filename"])
+		}
+		if decoded["ocr_text"] != ocrText {
+			t.Fatalf("ocr_text=%v", decoded["ocr_text"])
+		}
+		assertHas(t, entries, "doc2/note.metadata.json", "")
+	})
+}
+
+func TestWriteExportZipSkipsFailedOpen(t *testing.T) {
+	docs := []ExportDocument{
+		{
+			ID:               "missing",
+			OriginalFilename: "gone.pdf",
+			OpenFile: func() (io.ReadCloser, error) {
+				return nil, io.ErrUnexpectedEOF
+			},
+		},
+		{
+			ID:               "ok",
+			OriginalFilename: "ok.txt",
+			OpenFile: func() (io.ReadCloser, error) {
+				return io.NopCloser(strings.NewReader("ok")), nil
+			},
+		},
+	}
+	entries := mustZipEntries(t, ExportModeOriginals, docs)
+	if _, ok := entries["missing/gone.pdf"]; ok {
+		t.Fatal("expected missing file to be skipped")
+	}
+	assertHas(t, entries, "ok/ok.txt", "ok")
+}
+
+func TestFileStem(t *testing.T) {
+	if got := fileStem("invoice.pdf"); got != "invoice" {
+		t.Fatalf("got %q", got)
+	}
+	if got := fileStem("archive"); got != "archive" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func mustZipEntries(t *testing.T, mode ExportMode, docs []ExportDocument) map[string]string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteExportZip(&buf, mode, docs); err != nil {
+		t.Fatalf("WriteExportZip: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	out := make(map[string]string, len(zr.File))
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", f.Name, err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("read %s: %v", f.Name, err)
+		}
+		out[f.Name] = string(data)
+	}
+	return out
+}
+
+func assertHas(t *testing.T, entries map[string]string, name, contains string) {
+	t.Helper()
+	raw, ok := entries[name]
+	if !ok {
+		t.Fatalf("missing entry %q; have %#v", name, keys(entries))
+	}
+	if contains != "" && !strings.Contains(raw, contains) {
+		t.Fatalf("entry %q missing %q; got %q", name, contains, raw)
+	}
+}
+
+func assertMissing(t *testing.T, entries map[string]string, name string) {
+	t.Helper()
+	if _, ok := entries[name]; ok {
+		t.Fatalf("unexpected entry %q", name)
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/backend/internal/appapi/export_zip_test.go
+++ b/backend/internal/appapi/export_zip_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestParseExportMode(t *testing.T) {
@@ -154,6 +155,35 @@ func TestExportEntryBase(t *testing.T) {
 	}
 	if got := sanitizeExportTitle(`bad:name*?<>|`); got != "badname" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSanitizeExportTitleTruncates(t *testing.T) {
+	long := strings.Repeat("a", maxExportTitleBytes+50)
+	got := sanitizeExportTitle(long)
+	if len(got) != maxExportTitleBytes {
+		t.Fatalf("len=%d want %d", len(got), maxExportTitleBytes)
+	}
+
+	// Multi-byte runes must not be split.
+	multi := strings.Repeat("é", maxExportTitleBytes)
+	got = sanitizeExportTitle(multi)
+	if len(got) > maxExportTitleBytes {
+		t.Fatalf("len=%d exceeds %d", len(got), maxExportTitleBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("truncated title is not valid UTF-8")
+	}
+	if got == "" {
+		t.Fatal("expected non-empty truncated title")
+	}
+
+	// Entry with longest sidecar suffix stays under 255 bytes.
+	id := strings.Repeat("x", 15)
+	base := exportEntryBase(id, strings.Repeat("t", 300))
+	metaName := base + ".metadata.json"
+	if len(metaName) > 255 {
+		t.Fatalf("metadata entry name len=%d exceeds 255: %q", len(metaName), metaName)
 	}
 }
 

--- a/backend/internal/appapi/export_zip_test.go
+++ b/backend/internal/appapi/export_zip_test.go
@@ -46,13 +46,13 @@ func TestWriteExportZipModes(t *testing.T) {
 		"tags":              []string{"finance"},
 		"document_type":     "Invoice",
 		"correspondent":     "Acme",
-		"ocr_text":          ocrText,
 		"original_filename": "invoice.pdf",
 	}
 
 	docs := []ExportDocument{
 		{
 			ID:               "doc1",
+			Title:            "Invoice",
 			OriginalFilename: "invoice.pdf",
 			OpenFile: func() (io.ReadCloser, error) {
 				return io.NopCloser(strings.NewReader("PDFBYTES")), nil
@@ -62,6 +62,7 @@ func TestWriteExportZipModes(t *testing.T) {
 		},
 		{
 			ID:               "doc2",
+			Title:            "Note",
 			OriginalFilename: "note.txt",
 			OpenFile: func() (io.ReadCloser, error) {
 				return io.NopCloser(strings.NewReader("note body")), nil
@@ -71,27 +72,33 @@ func TestWriteExportZipModes(t *testing.T) {
 		},
 	}
 
+	orig1 := "paperless-export/[doc1] Invoice.pdf"
+	ocr1 := "paperless-export/[doc1] Invoice.ocr.txt"
+	meta1 := "paperless-export/[doc1] Invoice.metadata.json"
+	orig2 := "paperless-export/[doc2] Note.txt"
+	meta2 := "paperless-export/[doc2] Note.metadata.json"
+
 	t.Run("originals", func(t *testing.T) {
 		entries := mustZipEntries(t, ExportModeOriginals, docs)
-		assertHas(t, entries, "doc1/invoice.pdf", "PDFBYTES")
-		assertHas(t, entries, "doc2/note.txt", "note body")
-		assertMissing(t, entries, "doc1/invoice.ocr.txt")
-		assertMissing(t, entries, "doc1/invoice.metadata.json")
+		assertHas(t, entries, orig1, "PDFBYTES")
+		assertHas(t, entries, orig2, "note body")
+		assertMissing(t, entries, ocr1)
+		assertMissing(t, entries, meta1)
 	})
 
 	t.Run("ocr", func(t *testing.T) {
 		entries := mustZipEntries(t, ExportModeOCR, docs)
-		assertHas(t, entries, "doc1/invoice.pdf", "PDFBYTES")
-		assertHas(t, entries, "doc1/invoice.ocr.txt", ocrText)
-		assertMissing(t, entries, "doc2/note.ocr.txt") // empty OCR
-		assertMissing(t, entries, "doc1/invoice.metadata.json")
+		assertHas(t, entries, orig1, "PDFBYTES")
+		assertHas(t, entries, ocr1, ocrText)
+		assertMissing(t, entries, "paperless-export/[doc2] Note.ocr.txt")
+		assertMissing(t, entries, meta1)
 	})
 
 	t.Run("metadata", func(t *testing.T) {
 		entries := mustZipEntries(t, ExportModeMetadata, docs)
-		assertHas(t, entries, "doc1/invoice.pdf", "PDFBYTES")
-		assertHas(t, entries, "doc1/invoice.ocr.txt", ocrText)
-		raw, ok := entries["doc1/invoice.metadata.json"]
+		assertHas(t, entries, orig1, "PDFBYTES")
+		assertHas(t, entries, ocr1, ocrText)
+		raw, ok := entries[meta1]
 		if !ok {
 			t.Fatal("missing metadata json")
 		}
@@ -105,10 +112,10 @@ func TestWriteExportZipModes(t *testing.T) {
 		if decoded["original_filename"] != "invoice.pdf" {
 			t.Fatalf("original_filename=%v", decoded["original_filename"])
 		}
-		if decoded["ocr_text"] != ocrText {
-			t.Fatalf("ocr_text=%v", decoded["ocr_text"])
+		if _, hasOCR := decoded["ocr_text"]; hasOCR {
+			t.Fatal("metadata json must not include ocr_text")
 		}
-		assertHas(t, entries, "doc2/note.metadata.json", "")
+		assertHas(t, entries, meta2, "")
 	})
 }
 
@@ -116,6 +123,7 @@ func TestWriteExportZipSkipsFailedOpen(t *testing.T) {
 	docs := []ExportDocument{
 		{
 			ID:               "missing",
+			Title:            "Gone",
 			OriginalFilename: "gone.pdf",
 			OpenFile: func() (io.ReadCloser, error) {
 				return nil, io.ErrUnexpectedEOF
@@ -123,6 +131,7 @@ func TestWriteExportZipSkipsFailedOpen(t *testing.T) {
 		},
 		{
 			ID:               "ok",
+			Title:            "Ok",
 			OriginalFilename: "ok.txt",
 			OpenFile: func() (io.ReadCloser, error) {
 				return io.NopCloser(strings.NewReader("ok")), nil
@@ -130,17 +139,20 @@ func TestWriteExportZipSkipsFailedOpen(t *testing.T) {
 		},
 	}
 	entries := mustZipEntries(t, ExportModeOriginals, docs)
-	if _, ok := entries["missing/gone.pdf"]; ok {
+	if _, ok := entries["paperless-export/[missing] Gone.pdf"]; ok {
 		t.Fatal("expected missing file to be skipped")
 	}
-	assertHas(t, entries, "ok/ok.txt", "ok")
+	assertHas(t, entries, "paperless-export/[ok] Ok.txt", "ok")
 }
 
-func TestFileStem(t *testing.T) {
-	if got := fileStem("invoice.pdf"); got != "invoice" {
+func TestExportEntryBase(t *testing.T) {
+	if got := exportEntryBase("abc", "Invoice / Q1"); got != "[abc] Invoice Q1" {
 		t.Fatalf("got %q", got)
 	}
-	if got := fileStem("archive"); got != "archive" {
+	if got := exportEntryBase("abc", "  "); got != "[abc] Untitled" {
+		t.Fatalf("got %q", got)
+	}
+	if got := sanitizeExportTitle(`bad:name*?<>|`); got != "badname" {
 		t.Fatalf("got %q", got)
 	}
 }

--- a/frontend/e2e/export.spec.ts
+++ b/frontend/e2e/export.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+import { loginAsUser, openMoreMenu } from './helpers/auth'
+
+test('regular user can open export page and see modes', async ({ page }) => {
+  await loginAsUser(page)
+  await openMoreMenu(page)
+  await page.getByRole('menuitem', { name: 'Export' }).click()
+  await expect(page.getByRole('heading', { name: 'Export archive' })).toBeVisible()
+  await expect(page.getByRole('radio', { name: /Original files only/i })).toBeChecked()
+  await expect(page.getByRole('radio', { name: /Originals with OCR text/i })).toBeVisible()
+  await expect(page.getByRole('radio', { name: /Originals with OCR and metadata/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Download archive' })).toBeVisible()
+})
+
+test('download archive starts without error', async ({ page }) => {
+  await loginAsUser(page)
+  await page.goto('/export')
+  await expect(page.getByRole('heading', { name: 'Export archive' })).toBeVisible()
+
+  const downloadPromise = page.waitForEvent('download', { timeout: 30_000 })
+  await page.getByRole('button', { name: 'Download archive' }).click()
+  const download = await downloadPromise
+  expect(download.suggestedFilename()).toBe('paperless-export.zip')
+  await expect(page.getByText('Archive download started.')).toBeVisible()
+})

--- a/frontend/src/components/RootLayout.tsx
+++ b/frontend/src/components/RootLayout.tsx
@@ -69,8 +69,9 @@ function MoreNavMenu({ admin }: { admin: boolean }) {
   const matchRoute = useMatchRoute()
   const settingsActive = Boolean(matchRoute({ to: '/settings' }))
   const importActive = Boolean(matchRoute({ to: '/import' }))
+  const exportActive = Boolean(matchRoute({ to: '/export' }))
   const ocrTestActive = Boolean(matchRoute({ to: '/ocr-test' }))
-  const menuActive = settingsActive || importActive || ocrTestActive
+  const menuActive = settingsActive || importActive || exportActive || ocrTestActive
 
   useEffect(() => {
     if (!open) return
@@ -120,6 +121,14 @@ function MoreNavMenu({ admin }: { admin: boolean }) {
             onClick={() => setOpen(false)}
           >
             OCR test
+          </Link>
+          <Link
+            to="/export"
+            role="menuitem"
+            className={`${menuItemClass} ${exportActive ? navLinkActiveClass : ''}`}
+            onClick={() => setOpen(false)}
+          >
+            Export
           </Link>
           {admin && (
             <Link

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -628,6 +628,46 @@ export async function importFromNgx(url: string, apiKey: string, mode: NgxImport
   throw new Error('Import timed out while waiting for completion')
 }
 
+export type ExportArchiveMode = 'originals' | 'ocr' | 'metadata'
+
+export async function downloadDocumentsArchive(mode: ExportArchiveMode = 'originals') {
+  await ensureAuth()
+
+  const response = await fetch(
+    `${pbUrl}/api/app/documents/export?mode=${encodeURIComponent(mode)}`,
+    {
+      headers: {
+        Authorization: pb.authStore.token,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    let detail = 'Failed to download archive'
+    try {
+      const data = (await response.json()) as { detail?: string }
+      if (data.detail) detail = data.detail
+    } catch {
+      // response may be non-JSON on some errors
+    }
+    throw new Error(detail)
+  }
+
+  const blob = await response.blob()
+  const objectUrl = URL.createObjectURL(blob)
+  try {
+    const anchor = document.createElement('a')
+    anchor.href = objectUrl
+    anchor.download = 'paperless-export.zip'
+    anchor.rel = 'noopener'
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+  } finally {
+    URL.revokeObjectURL(objectUrl)
+  }
+}
+
 export function parseDuplicateOfId(message: string): string | null {
   const match = message.match(/duplicate of ([a-z0-9]{15})/i)
   return match?.[1] ?? null

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,7 @@ import { OCRTestPage } from './routes/ocr-test'
 import { SearchPage } from './routes/search'
 import { SettingsPage } from './routes/settings'
 import { ImportPage } from './routes/import'
+import { ExportPage } from './routes/export'
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -49,6 +50,12 @@ const importRoute = createRoute({
   component: ImportPage,
 })
 
+const exportRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/export',
+  component: ExportPage,
+})
+
 const documentRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/document/$documentId',
@@ -68,6 +75,7 @@ const routeTree = rootRoute.addChildren([
   ocrTestRoute,
   settingsRoute,
   importRoute,
+  exportRoute,
   documentRoute,
   documentAskRoute,
 ])

--- a/frontend/src/routes/export.tsx
+++ b/frontend/src/routes/export.tsx
@@ -1,0 +1,129 @@
+import { type SubmitEvent, useEffect, useState } from 'react'
+import {
+  downloadDocumentsArchive,
+  ensureAuth,
+  type ExportArchiveMode,
+} from '../lib/pocketbase'
+
+const labelTextClassName = 'text-xs font-medium text-stone-500'
+
+const modeOptions: { value: ExportArchiveMode; label: string; description: string }[] = [
+  {
+    value: 'originals',
+    label: 'Original files only',
+    description: 'Download a zip containing only the original uploaded files.',
+  },
+  {
+    value: 'ocr',
+    label: 'Originals with OCR text',
+    description:
+      'Include .ocr.txt sidecars next to each original when OCR text is available.',
+  },
+  {
+    value: 'metadata',
+    label: 'Originals with OCR and metadata',
+    description:
+      'Include OCR sidecars plus .metadata.json with titles, tags, dates, and other extracted fields.',
+  },
+]
+
+export function ExportPage() {
+  const [mode, setMode] = useState<ExportArchiveMode>('originals')
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  useEffect(() => {
+    let active = true
+
+    async function load() {
+      try {
+        await ensureAuth()
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load')
+        }
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  async function onSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault()
+    try {
+      setRunning(true)
+      setError('')
+      setSuccess('')
+      await downloadDocumentsArchive(mode)
+      setSuccess('Archive download started.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Download failed')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-stone-500">Loading…</p>
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-stone-950">Export archive</h1>
+        <p className="mt-1 text-sm text-stone-500">
+          Download a zip of all your documents. Choose whether to include OCR text and
+          metadata sidecars alongside the original files.
+        </p>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-4 rounded-lg border border-stone-200 bg-stone-50 p-5">
+        <fieldset className="space-y-2" disabled={running}>
+          <legend className={labelTextClassName}>Export mode</legend>
+          {modeOptions.map((option) => (
+            <label
+              key={option.value}
+              className={`flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-sm ${
+                mode === option.value
+                  ? 'border-stone-400 bg-white text-stone-800'
+                  : 'border-stone-200 bg-stone-50 text-stone-700'
+              }`}
+            >
+              <input
+                type="radio"
+                className="mt-0.5"
+                name="export-mode"
+                value={option.value}
+                checked={mode === option.value}
+                onChange={() => setMode(option.value)}
+              />
+              <span>
+                <span className="font-medium">{option.label}</span>
+                <span className="mt-0.5 block text-xs font-normal text-stone-500">
+                  {option.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+        <button
+          type="submit"
+          disabled={running}
+          className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {running ? 'Preparing archive…' : 'Download archive'}
+        </button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {success && <p className="text-sm text-green-700">{success}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/app/documents/export?mode=originals|ocr|metadata` that streams a zip of the authenticated user's documents
- Adds an Export page (More menu) with mode radios for originals, OCR sidecars, and metadata JSON
- Zip layout: `{documentId}/{original}` plus optional `{stem}.ocr.txt` / `{stem}.metadata.json`

Fixes #15

## Test plan
- [x] `./scripts/test-all.sh` (unit, API e2e, Playwright)
- [ ] Manually open Export, download each mode, and confirm zip contents
- [ ] Confirm another user's documents do not appear in the archive