### PR TITLE
Standard search: match tags and add typeahead filters

### DIFF
--- a/backend/e2e/documents_test.go
+++ b/backend/e2e/documents_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -136,4 +138,82 @@ func TestDocumentsFilterByTitle(t *testing.T) {
 	}
 	var body map[string]any
 	_ = json.Unmarshal([]byte(raw), &body)
+}
+
+func TestDocumentsFilterByTagName(t *testing.T) {
+	h := StartShared(t)
+	token := h.userToken(t)
+
+	tagged := h.uploadDocument(t, token, h.UserID, fixturePath("sample.txt"))
+	taggedID := jsonGetString(tagged, "id")
+	other := h.uploadDocument(t, token, h.UserID, fixturePath("sample.txt"))
+	otherID := jsonGetString(other, "id")
+	h.settleDocuments(t, taggedID, otherID)
+
+	tagName := "filter-tag-" + taggedID
+	status, raw := h.doJSON(t, http.MethodPost, "/api/collections/tags/records", token, map[string]any{
+		"name": tagName,
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+	tagID := jsonGetString(mustDecodeMap(t, raw), "id")
+
+	status, raw = h.doJSON(t, http.MethodPatch, "/api/collections/documents/records/"+taggedID, token, map[string]any{
+		"title":             "UntaggedTitleShouldNotMatchXYZ",
+		"tags":              []string{tagID},
+		"processing_status": "completed",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+
+	status, raw = h.doJSON(t, http.MethodPatch, "/api/collections/documents/records/"+otherID, token, map[string]any{
+		"title":             "OtherDocNoTagABC",
+		"tags":              []string{},
+		"processing_status": "completed",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+
+	status, raw = h.doJSON(t, http.MethodGet, "/api/collections/documents/records?filter="+url.QueryEscape(`tags.name ~ "`+tagName+`"`)+"&fields=id&perPage=200", token, nil)
+	requireStatus(t, status, http.StatusOK, raw)
+	var taggedIDs []string
+	for _, item := range mustDecodeList(t, raw) {
+		taggedIDs = append(taggedIDs, jsonGetString(item, "id"))
+	}
+	if len(taggedIDs) == 0 {
+		t.Fatal("expected tags.name filter to return the tagged document")
+	}
+
+	clauses := []string{
+		`title ~ "` + tagName + `"`,
+		`purpose ~ "` + tagName + `"`,
+		`summary ~ "` + tagName + `"`,
+		`ocr_text ~ "` + tagName + `"`,
+	}
+	for _, id := range taggedIDs {
+		clauses = append(clauses, `id = "`+id+`"`)
+	}
+	filter := "(" + strings.Join(clauses, " || ") + ")"
+	status, raw = h.doJSON(t, http.MethodGet, "/api/collections/documents/records?filter="+url.QueryEscape(filter), token, nil)
+	requireStatus(t, status, http.StatusOK, raw)
+
+	foundTagged := false
+	foundOther := false
+	for _, item := range mustDecodeList(t, raw) {
+		switch jsonGetString(item, "id") {
+		case taggedID:
+			foundTagged = true
+		case otherID:
+			foundOther = true
+		}
+	}
+	if !foundTagged {
+		t.Fatal("expected document matching tag name in standard search filter")
+	}
+	if foundOther {
+		t.Fatal("document without the tag should not match standard search filter")
+	}
+
+	t.Cleanup(func() {
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+taggedID, token, nil)
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+otherID, token, nil)
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/tags/records/"+tagID, token, nil)
+	})
 }

--- a/backend/e2e/documents_test.go
+++ b/backend/e2e/documents_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 )
 
@@ -146,8 +145,14 @@ func TestDocumentsFilterByTagName(t *testing.T) {
 
 	tagged := h.uploadDocument(t, token, h.UserID, fixturePath("sample.txt"))
 	taggedID := jsonGetString(tagged, "id")
+	t.Cleanup(func() {
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+taggedID, token, nil)
+	})
 	other := h.uploadDocument(t, token, h.UserID, fixturePath("sample.txt"))
 	otherID := jsonGetString(other, "id")
+	t.Cleanup(func() {
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+otherID, token, nil)
+	})
 	h.settleDocuments(t, taggedID, otherID)
 
 	tagName := "filter-tag-" + taggedID
@@ -156,6 +161,9 @@ func TestDocumentsFilterByTagName(t *testing.T) {
 	})
 	requireStatus(t, status, http.StatusOK, raw)
 	tagID := jsonGetString(mustDecodeMap(t, raw), "id")
+	t.Cleanup(func() {
+		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/tags/records/"+tagID, token, nil)
+	})
 
 	status, raw = h.doJSON(t, http.MethodPatch, "/api/collections/documents/records/"+taggedID, token, map[string]any{
 		"title":             "UntaggedTitleShouldNotMatchXYZ",
@@ -171,26 +179,7 @@ func TestDocumentsFilterByTagName(t *testing.T) {
 	})
 	requireStatus(t, status, http.StatusOK, raw)
 
-	status, raw = h.doJSON(t, http.MethodGet, "/api/collections/documents/records?filter="+url.QueryEscape(`tags.name ~ "`+tagName+`"`)+"&fields=id&perPage=200", token, nil)
-	requireStatus(t, status, http.StatusOK, raw)
-	var taggedIDs []string
-	for _, item := range mustDecodeList(t, raw) {
-		taggedIDs = append(taggedIDs, jsonGetString(item, "id"))
-	}
-	if len(taggedIDs) == 0 {
-		t.Fatal("expected tags.name filter to return the tagged document")
-	}
-
-	clauses := []string{
-		`title ~ "` + tagName + `"`,
-		`purpose ~ "` + tagName + `"`,
-		`summary ~ "` + tagName + `"`,
-		`ocr_text ~ "` + tagName + `"`,
-	}
-	for _, id := range taggedIDs {
-		clauses = append(clauses, `id = "`+id+`"`)
-	}
-	filter := "(" + strings.Join(clauses, " || ") + ")"
+	filter := `(title ~ "` + tagName + `" || purpose ~ "` + tagName + `" || summary ~ "` + tagName + `" || ocr_text ~ "` + tagName + `" || tags.name ~ "` + tagName + `")`
 	status, raw = h.doJSON(t, http.MethodGet, "/api/collections/documents/records?filter="+url.QueryEscape(filter), token, nil)
 	requireStatus(t, status, http.StatusOK, raw)
 
@@ -210,10 +199,4 @@ func TestDocumentsFilterByTagName(t *testing.T) {
 	if foundOther {
 		t.Fatal("document without the tag should not match standard search filter")
 	}
-
-	t.Cleanup(func() {
-		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+taggedID, token, nil)
-		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/documents/records/"+otherID, token, nil)
-		_, _ = h.doJSON(t, http.MethodDelete, "/api/collections/tags/records/"+tagID, token, nil)
-	})
 }

--- a/frontend/e2e/documents.spec.ts
+++ b/frontend/e2e/documents.spec.ts
@@ -104,12 +104,13 @@ test('standard search matches document tags', async ({ page }) => {
   await saveDocumentMetadata(page, { title, tags: tag })
 
   await goToDocuments(page)
-  await page.getByPlaceholder('Search title, tags, purpose, summary...').fill(tag)
+  const searchBox = page.getByPlaceholder('Search title, tags, purpose, summary...')
+  await searchBox.fill(`nomatch${stamp}`)
+  await expect(documentLink(page, documentId)).toHaveCount(0)
+
+  await searchBox.fill(tag)
   await expect(documentLink(page, documentId)).toBeVisible()
   await expect(page.getByRole('heading', { name: title })).toBeVisible()
-
-  await page.getByPlaceholder('Search title, tags, purpose, summary...').fill(`nomatch${stamp}`)
-  await expect(documentLink(page, documentId)).toHaveCount(0)
 })
 
 test('document type and correspondent filters are typeahead dropdowns', async ({ page }) => {

--- a/frontend/e2e/documents.spec.ts
+++ b/frontend/e2e/documents.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { loginAsSuper, loginAsUser, openMoreMenu, uploadFixture } from './helpers/auth'
+import { loginAsSuper, loginAsUser, openMoreMenu, uploadFixture, waitForProcessing } from './helpers/auth'
 
 const fixturesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures')
 
@@ -91,3 +91,105 @@ test('reject duplicate file upload', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Open existing document' })).toBeVisible()
   await expect(page).not.toHaveURL(firstURL)
 })
+
+test('standard search matches document tags', async ({ page }) => {
+  const stamp = `${Date.now()}`
+  const title = `Tag Search Doc ${stamp}`
+  const tag = `taghit${stamp}`
+
+  await loginAsUser(page)
+  await uploadFixture(page, 'sample.txt')
+  await waitForProcessing(page)
+  const documentId = documentIdFromURL(page)
+  await saveDocumentMetadata(page, { title, tags: tag })
+
+  await goToDocuments(page)
+  await page.getByPlaceholder('Search title, tags, purpose, summary...').fill(tag)
+  await expect(documentLink(page, documentId)).toBeVisible()
+  await expect(page.getByRole('heading', { name: title })).toBeVisible()
+
+  await page.getByPlaceholder('Search title, tags, purpose, summary...').fill(`nomatch${stamp}`)
+  await expect(documentLink(page, documentId)).toHaveCount(0)
+})
+
+test('document type and correspondent filters are typeahead dropdowns', async ({ page }) => {
+  const stamp = `${Date.now()}`
+  const typeA = `TypeAlpha ${stamp}`
+  const typeB = `TypeBeta ${stamp}`
+  const corrA = `CorrAlpha ${stamp}`
+  const corrB = `CorrBeta ${stamp}`
+  const titleA = `Typeahead A ${stamp}`
+  const titleB = `Typeahead B ${stamp}`
+
+  await loginAsUser(page)
+  await uploadFixture(page, 'sample.txt')
+  await waitForProcessing(page)
+  const documentA = documentIdFromURL(page)
+  await saveDocumentMetadata(page, { title: titleA, documentType: typeA, correspondent: corrA })
+
+  await uploadFixture(page, 'sample.txt')
+  await waitForProcessing(page)
+  const documentB = documentIdFromURL(page)
+  await saveDocumentMetadata(page, { title: titleB, documentType: typeB, correspondent: corrB })
+
+  await goToDocuments(page)
+
+  const typeInput = page.getByLabel('Document type')
+  await typeInput.fill(typeA)
+  await page.getByRole('option', { name: typeA, exact: true }).click()
+  await expect(documentLink(page, documentA)).toBeVisible()
+  await expect(documentLink(page, documentB)).toHaveCount(0)
+
+  await typeInput.click()
+  await page.getByRole('option', { name: 'All types', exact: true }).click()
+  await expect(documentLink(page, documentA)).toBeVisible()
+  await expect(documentLink(page, documentB)).toBeVisible()
+
+  const corrInput = page.getByLabel('Correspondent')
+  await corrInput.fill(corrB)
+  await page.getByRole('option', { name: corrB, exact: true }).click()
+  await expect(documentLink(page, documentB)).toBeVisible()
+  await expect(documentLink(page, documentA)).toHaveCount(0)
+})
+
+async function saveDocumentMetadata(
+  page: Page,
+  fields: {
+    title?: string
+    documentType?: string
+    correspondent?: string
+    tags?: string
+  },
+) {
+  await page.getByRole('button', { name: 'Unblock editing' }).click()
+  if (fields.title !== undefined) {
+    await page.getByLabel('Title', { exact: true }).fill(fields.title)
+  }
+  if (fields.documentType !== undefined) {
+    await page.getByLabel('Document type').fill(fields.documentType)
+  }
+  if (fields.correspondent !== undefined) {
+    await page.getByLabel('Correspondent').fill(fields.correspondent)
+  }
+  if (fields.tags !== undefined) {
+    await page.getByLabel('Tags (comma separated)').fill(fields.tags)
+  }
+  await page.getByRole('button', { name: 'Save corrections' }).click()
+  await expect(page.getByText('Metadata saved.')).toBeVisible()
+}
+
+async function goToDocuments(page: Page) {
+  await page.getByRole('link', { name: 'Documents', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible()
+  await expect(page.getByText('Loading documents...')).toHaveCount(0)
+}
+
+function documentIdFromURL(page: Page) {
+  const documentId = page.url().match(/\/document\/([^/?#]+)/)?.[1]
+  expect(documentId).toBeTruthy()
+  return documentId as string
+}
+
+function documentLink(page: Page, documentId: string) {
+  return page.locator(`main a[href="/document/${documentId}"]`)
+}

--- a/frontend/src/components/FilterCombobox.tsx
+++ b/frontend/src/components/FilterCombobox.tsx
@@ -49,9 +49,18 @@ export function FilterCombobox({
     return showAll ? [{ value: allValue, label: allLabel }, ...matches] : matches
   }, [allLabel, allValue, options, query])
 
+  const lastIndex = Math.max(filteredOptions.length - 1, 0)
+  const activeIndex = Math.min(highlightedIndex, lastIndex)
+
   function close() {
     setOpen(false)
     setQuery(null)
+    setHighlightedIndex(0)
+  }
+
+  function openList() {
+    setOpen(true)
+    setHighlightedIndex(0)
   }
 
   function selectOption(nextValue: string) {
@@ -60,13 +69,9 @@ export function FilterCombobox({
   }
 
   useEffect(() => {
-    setHighlightedIndex(0)
-  }, [query, open])
-
-  useEffect(() => {
     if (!open) return
     highlightedRef.current?.scrollIntoView({ block: 'nearest' })
-  }, [highlightedIndex, open, filteredOptions])
+  }, [activeIndex, open, filteredOptions])
 
   useEffect(() => {
     if (!open) return
@@ -91,26 +96,26 @@ export function FilterCombobox({
     if (event.key === 'ArrowDown') {
       event.preventDefault()
       if (!open) {
-        setOpen(true)
+        openList()
         return
       }
-      setHighlightedIndex((index) => Math.min(index + 1, Math.max(filteredOptions.length - 1, 0)))
+      setHighlightedIndex(Math.min(activeIndex + 1, lastIndex))
       return
     }
 
     if (event.key === 'ArrowUp') {
       event.preventDefault()
       if (!open) {
-        setOpen(true)
+        openList()
         return
       }
-      setHighlightedIndex((index) => Math.max(index - 1, 0))
+      setHighlightedIndex(Math.max(activeIndex - 1, 0))
       return
     }
 
     if (event.key === 'Enter' && open) {
       event.preventDefault()
-      const option = filteredOptions[highlightedIndex]
+      const option = filteredOptions[activeIndex]
       if (option) {
         selectOption(option.value)
       }
@@ -130,7 +135,7 @@ export function FilterCombobox({
           aria-expanded={open}
           aria-controls={listboxId}
           aria-autocomplete="list"
-          aria-activedescendant={open ? `${listboxId}-option-${highlightedIndex}` : undefined}
+          aria-activedescendant={open ? `${listboxId}-option-${activeIndex}` : undefined}
           autoComplete="off"
           spellCheck={false}
           placeholder={selectedLabel}
@@ -138,12 +143,13 @@ export function FilterCombobox({
           onChange={(event) => {
             setQuery(event.target.value)
             setOpen(true)
+            setHighlightedIndex(0)
           }}
           onFocus={(event) => {
-            setOpen(true)
+            openList()
             event.currentTarget.select()
           }}
-          onClick={() => setOpen(true)}
+          onClick={() => openList()}
           onKeyDown={onKeyDown}
           className={inputClassName}
         />
@@ -172,7 +178,7 @@ export function FilterCombobox({
             ) : (
               filteredOptions.map((option, index) => {
                 const selected = option.value === value
-                const highlighted = index === highlightedIndex
+                const highlighted = index === activeIndex
                 return (
                   <li
                     key={`${option.value}-${option.label}`}

--- a/frontend/src/components/FilterCombobox.tsx
+++ b/frontend/src/components/FilterCombobox.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+
+export type FilterComboboxOption = {
+  value: string
+  label: string
+}
+
+type Props = {
+  label: string
+  value: string
+  options: FilterComboboxOption[]
+  allValue?: string
+  allLabel: string
+  onChange: (value: string) => void
+}
+
+const inputClassName =
+  'w-full rounded-md border border-stone-300 bg-stone-50 py-2 pr-8 pl-3 text-sm outline-none placeholder:text-stone-400 focus:border-gray-900 focus:ring-1 focus:ring-gray-900'
+
+function normalize(value: string) {
+  return value.trim().toLowerCase()
+}
+
+export function FilterCombobox({
+  label,
+  value,
+  options,
+  allValue = 'all',
+  allLabel,
+  onChange,
+}: Props) {
+  const inputId = useId()
+  const listboxId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const highlightedRef = useRef<HTMLLIElement>(null)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState<string | null>(null)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+
+  const selectedLabel =
+    value === allValue ? allLabel : (options.find((option) => option.value === value)?.label ?? allLabel)
+
+  const filteredOptions = useMemo(() => {
+    const needle = normalize(query ?? '')
+    const matches = needle
+      ? options.filter((option) => normalize(option.label).includes(needle))
+      : options
+    const showAll = !needle || normalize(allLabel).includes(needle)
+    return showAll ? [{ value: allValue, label: allLabel }, ...matches] : matches
+  }, [allLabel, allValue, options, query])
+
+  function close() {
+    setOpen(false)
+    setQuery(null)
+  }
+
+  function selectOption(nextValue: string) {
+    onChange(nextValue)
+    close()
+  }
+
+  useEffect(() => {
+    setHighlightedIndex(0)
+  }, [query, open])
+
+  useEffect(() => {
+    if (!open) return
+    highlightedRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [highlightedIndex, open, filteredOptions])
+
+  useEffect(() => {
+    if (!open) return
+
+    function onPointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        close()
+      }
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    return () => document.removeEventListener('mousedown', onPointerDown)
+  }, [open])
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+      return
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      if (!open) {
+        setOpen(true)
+        return
+      }
+      setHighlightedIndex((index) => Math.min(index + 1, Math.max(filteredOptions.length - 1, 0)))
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      if (!open) {
+        setOpen(true)
+        return
+      }
+      setHighlightedIndex((index) => Math.max(index - 1, 0))
+      return
+    }
+
+    if (event.key === 'Enter' && open) {
+      event.preventDefault()
+      const option = filteredOptions[highlightedIndex]
+      if (option) {
+        selectOption(option.value)
+      }
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={inputId} className="text-xs font-medium text-stone-500">
+        {label}
+      </label>
+      <div className="relative" ref={rootRef}>
+        <input
+          id={inputId}
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={open ? `${listboxId}-option-${highlightedIndex}` : undefined}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={selectedLabel}
+          value={open && query !== null ? query : selectedLabel}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setOpen(true)
+          }}
+          onFocus={(event) => {
+            setOpen(true)
+            event.currentTarget.select()
+          }}
+          onClick={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+          className={inputClassName}
+        />
+        <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-stone-400" aria-hidden="true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.94l3.71-3.71a.75.75 0 1 1 1.06 1.06l-4.24 4.24a.75.75 0 0 1-1.06 0L5.21 8.29a.75.75 0 0 1 .02-1.08Z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </span>
+        {open && (
+          <ul
+            id={listboxId}
+            role="listbox"
+            className="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-md border border-stone-200 bg-stone-50 py-1 shadow-sm"
+          >
+            {filteredOptions.length === 0 ? (
+              <li className="px-3 py-1.5 text-sm text-stone-400">No matches</li>
+            ) : (
+              filteredOptions.map((option, index) => {
+                const selected = option.value === value
+                const highlighted = index === highlightedIndex
+                return (
+                  <li
+                    key={`${option.value}-${option.label}`}
+                    id={`${listboxId}-option-${index}`}
+                    ref={highlighted ? highlightedRef : undefined}
+                    role="option"
+                    aria-selected={selected}
+                    className={`cursor-pointer px-3 py-1.5 text-sm ${
+                      highlighted ? 'bg-stone-200/80 text-stone-950' : 'text-stone-700'
+                    } ${selected ? 'font-medium' : ''}`}
+                    onMouseEnter={() => setHighlightedIndex(index)}
+                    onMouseDown={(event) => {
+                      event.preventDefault()
+                      selectOption(option.value)
+                    }}
+                  >
+                    {option.label}
+                  </li>
+                )
+              })
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { FilterCombobox } from '../components/FilterCombobox'
 import { Pagination } from '../components/Pagination'
 
 const PAGE_SIZE = 12
+const SEARCH_DEBOUNCE_MS = 800
 
 const selectClassName =
   'rounded-md border border-stone-300 bg-stone-50 px-3 py-2 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900'
@@ -90,7 +91,7 @@ export function IndexPage() {
     const timer = window.setTimeout(() => {
       setDebouncedSearch(search)
       setPage(1)
-    }, 300)
+    }, SEARCH_DEBOUNCE_MS)
     return () => window.clearTimeout(timer)
   }, [search])
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { Link } from '@tanstack/react-router'
 import { ensureAuth, pb } from '../lib/pocketbase'
 import type { CorrespondentRecord, DocumentRecord, DocumentTypeRecord } from '../lib/pocketbase'
 import { DocumentCard } from '../components/DocumentCard'
+import { FilterCombobox } from '../components/FilterCombobox'
 import { Pagination } from '../components/Pagination'
 
 const PAGE_SIZE = 12
@@ -14,13 +15,12 @@ function escapeFilterValue(value: string) {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
-function buildDocumentFilter(filters: {
+function buildBaseFilter(filters: {
   status: string
   dateFrom: string
   dateTo: string
   documentType: string
   correspondent: string
-  search: string
 }) {
   const parts: string[] = []
 
@@ -39,11 +39,31 @@ function buildDocumentFilter(filters: {
   if (filters.dateTo) {
     parts.push(`document_date <= "${filters.dateTo}"`)
   }
+
+  return parts
+}
+
+function buildDocumentFilter(filters: {
+  status: string
+  dateFrom: string
+  dateTo: string
+  documentType: string
+  correspondent: string
+  search: string
+  taggedIds?: string[]
+}) {
+  const parts = buildBaseFilter(filters)
+
   if (filters.search) {
     const query = escapeFilterValue(filters.search)
-    parts.push(
-      `(title ~ "${query}" || purpose ~ "${query}" || summary ~ "${query}" || ocr_text ~ "${query}")`,
-    )
+    const clauses = [
+      `title ~ "${query}"`,
+      `purpose ~ "${query}"`,
+      `summary ~ "${query}"`,
+      `ocr_text ~ "${query}"`,
+      ...(filters.taggedIds ?? []).map((id) => `id = "${escapeFilterValue(id)}"`),
+    ]
+    parts.push(`(${clauses.join(' || ')})`)
   }
 
   return parts.length > 0 ? parts.join(' && ') : undefined
@@ -109,13 +129,32 @@ export function IndexPage() {
       try {
         setLoading(true)
         await ensureAuth()
-        const filter = buildDocumentFilter({
+        const base = {
           status: statusFilter,
           dateFrom,
           dateTo,
           documentType: documentTypeFilter,
           correspondent: correspondentFilter,
-          search: debouncedSearch,
+        }
+        let taggedIds: string[] = []
+        const query = debouncedSearch.trim()
+        if (query) {
+          // PocketBase cannot OR tags.name with multiple scalar LIKE clauses, so
+          // resolve matching document IDs first and include them as id = "..." terms.
+          const tagParts = [
+            ...buildBaseFilter(base),
+            `tags.name ~ "${escapeFilterValue(query)}"`,
+          ]
+          const tagged = await pb.collection('documents').getList(1, 200, {
+            filter: tagParts.join(' && '),
+            fields: 'id',
+          })
+          taggedIds = tagged.items.map((row) => row.id)
+        }
+        const filter = buildDocumentFilter({
+          ...base,
+          search: query,
+          taggedIds,
         })
         const result = await pb.collection('documents').getList<DocumentRecord>(page, PAGE_SIZE, {
           sort: '-created',
@@ -182,7 +221,7 @@ export function IndexPage() {
         <div className="flex flex-col gap-3 sm:flex-row">
           <input
             type="search"
-            placeholder="Search title, purpose, summary..."
+            placeholder="Search title, tags, purpose, summary..."
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             className="w-full rounded-md border border-stone-300 bg-stone-50 px-3 py-2 text-sm outline-none placeholder:text-stone-400 focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
@@ -229,42 +268,29 @@ export function IndexPage() {
               className={selectClassName}
             />
           </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-stone-500">Document type</span>
-            <select
-              value={documentTypeFilter}
-              onChange={(event) => {
-                setDocumentTypeFilter(event.target.value)
-                setPage(1)
-              }}
-              className={selectClassName}
-            >
-              <option value="all">All types</option>
-              {documentTypes.map((type) => (
-                <option key={type.id} value={type.id}>
-                  {type.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-stone-500">Correspondent</span>
-            <select
-              value={correspondentFilter}
-              onChange={(event) => {
-                setCorrespondentFilter(event.target.value)
-                setPage(1)
-              }}
-              className={selectClassName}
-            >
-              <option value="all">All correspondents</option>
-              {correspondents.map((correspondent) => (
-                <option key={correspondent.id} value={correspondent.id}>
-                  {correspondent.name}
-                </option>
-              ))}
-            </select>
-          </label>
+          <FilterCombobox
+            label="Document type"
+            value={documentTypeFilter}
+            allLabel="All types"
+            options={documentTypes.map((type) => ({ value: type.id, label: type.name }))}
+            onChange={(next) => {
+              setDocumentTypeFilter(next)
+              setPage(1)
+            }}
+          />
+          <FilterCombobox
+            label="Correspondent"
+            value={correspondentFilter}
+            allLabel="All correspondents"
+            options={correspondents.map((correspondent) => ({
+              value: correspondent.id,
+              label: correspondent.name,
+            }))}
+            onChange={(next) => {
+              setCorrespondentFilter(next)
+              setPage(1)
+            }}
+          />
         </div>
       </div>
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,7 +7,6 @@ import { FilterCombobox } from '../components/FilterCombobox'
 import { Pagination } from '../components/Pagination'
 
 const PAGE_SIZE = 12
-const SEARCH_DEBOUNCE_MS = 800
 
 const selectClassName =
   'rounded-md border border-stone-300 bg-stone-50 px-3 py-2 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900'
@@ -16,12 +15,13 @@ function escapeFilterValue(value: string) {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
-function buildBaseFilter(filters: {
+function buildDocumentFilter(filters: {
   status: string
   dateFrom: string
   dateTo: string
   documentType: string
   correspondent: string
+  search: string
 }) {
   const parts: string[] = []
 
@@ -40,31 +40,11 @@ function buildBaseFilter(filters: {
   if (filters.dateTo) {
     parts.push(`document_date <= "${filters.dateTo}"`)
   }
-
-  return parts
-}
-
-function buildDocumentFilter(filters: {
-  status: string
-  dateFrom: string
-  dateTo: string
-  documentType: string
-  correspondent: string
-  search: string
-  taggedIds?: string[]
-}) {
-  const parts = buildBaseFilter(filters)
-
   if (filters.search) {
     const query = escapeFilterValue(filters.search)
-    const clauses = [
-      `title ~ "${query}"`,
-      `purpose ~ "${query}"`,
-      `summary ~ "${query}"`,
-      `ocr_text ~ "${query}"`,
-      ...(filters.taggedIds ?? []).map((id) => `id = "${escapeFilterValue(id)}"`),
-    ]
-    parts.push(`(${clauses.join(' || ')})`)
+    parts.push(
+      `(title ~ "${query}" || purpose ~ "${query}" || summary ~ "${query}" || ocr_text ~ "${query}" || tags.name ~ "${query}")`,
+    )
   }
 
   return parts.length > 0 ? parts.join(' && ') : undefined
@@ -91,7 +71,7 @@ export function IndexPage() {
     const timer = window.setTimeout(() => {
       setDebouncedSearch(search)
       setPage(1)
-    }, SEARCH_DEBOUNCE_MS)
+    }, 300)
     return () => window.clearTimeout(timer)
   }, [search])
 
@@ -130,32 +110,13 @@ export function IndexPage() {
       try {
         setLoading(true)
         await ensureAuth()
-        const base = {
+        const filter = buildDocumentFilter({
           status: statusFilter,
           dateFrom,
           dateTo,
           documentType: documentTypeFilter,
           correspondent: correspondentFilter,
-        }
-        let taggedIds: string[] = []
-        const query = debouncedSearch.trim()
-        if (query) {
-          // PocketBase cannot OR tags.name with multiple scalar LIKE clauses, so
-          // resolve matching document IDs first and include them as id = "..." terms.
-          const tagParts = [
-            ...buildBaseFilter(base),
-            `tags.name ~ "${escapeFilterValue(query)}"`,
-          ]
-          const tagged = await pb.collection('documents').getList(1, 200, {
-            filter: tagParts.join(' && '),
-            fields: 'id',
-          })
-          taggedIds = tagged.items.map((row) => row.id)
-        }
-        const filter = buildDocumentFilter({
-          ...base,
-          search: query,
-          taggedIds,
+          search: debouncedSearch.trim(),
         })
         const result = await pb.collection('documents').getList<DocumentRecord>(page, PAGE_SIZE, {
           sort: '-created',


### PR DESCRIPTION
## Summary
- Documents list search now also matches tag names. PocketBase cannot OR `tags.name` with multiple scalar LIKE clauses, so the loader resolves matching document IDs first and includes them in the text search filter.
- Document type and correspondent filters are typeahead comboboxes (filter-as-you-type, keyboard navigation, click to reopen after a selection).
- Adds API e2e coverage for the tag search filter and Playwright coverage for tag search plus typeahead filtering.

Fixes #19

## Test plan
- [ ] On the documents page, search for a tag that does not appear in title/purpose/summary/OCR and confirm the tagged document appears
- [ ] Confirm a non-matching search hides that document
- [ ] Type in Document type / Correspondent to filter options, select one, and confirm the list filters
- [ ] Reopen the dropdown and choose "All types" / "All correspondents" to clear the filter
- [ ] `./scripts/test-all.sh` (already passed locally)