### PR TITLE
Allow Paperless-ngx import as the signed-in user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # every minute
 WORKER_CRON_EXPR=* * * * *
 
+# Allow Paperless-ngx import to reach loopback / RFC1918 hosts (LAN or Docker).
+# Link-local and cloud-metadata addresses stay blocked either way.
+# IMPORT_ALLOW_PRIVATE=1
+
 # Backend runtime settings (OCR, AI, worker timeouts, API keys, etc.) are stored
 # in the database and edited from the Settings page (PocketBase superuser login).
 # On first boot only, the values below seed ai_providers + app_settings bindings.

--- a/backend/e2e/harness.go
+++ b/backend/e2e/harness.go
@@ -13,6 +13,7 @@ import (
 	"paperless-go/backend/internal/appapi"
 	"paperless-go/backend/internal/appwire"
 	"paperless-go/backend/internal/config"
+	"paperless-go/backend/internal/ngximport"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
@@ -65,6 +66,7 @@ type Options struct {
 // Start boots a temporary PocketBase instance with mocks and seeded users.
 // Prefer StartShared from tests; use Start for the Playwright e2e server process.
 func Start(opts Options) (*Harness, error) {
+	ngximport.SetAllowPrivateImportHosts(true)
 	mocks := startMockServers()
 
 	dataDir, err := os.MkdirTemp("", "paperless-e2e-*")

--- a/backend/e2e/import_ngx_test.go
+++ b/backend/e2e/import_ngx_test.go
@@ -94,7 +94,7 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	remote := httptest.NewServer(mux)
 	t.Cleanup(remote.Close)
 
-	token := h.userToken(t)
+	token := h.adminUserToken(t)
 	result := runImportNgx(t, h, token, remote.URL, "remote-token", "preserve")
 	if intFromAny(result["imported"]) != 1 {
 		t.Fatalf("imported=%v body=%v", result["imported"], result)
@@ -144,8 +144,8 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	if dtype, _ := doc["document_type"].(string); dtype == "" {
 		t.Fatal("expected document_type to be set")
 	}
-	if user, _ := doc["user"].(string); user != h.UserID {
-		t.Fatalf("imported document owner=%q want user %q", user, h.UserID)
+	if user, _ := doc["user"].(string); user != h.AdminUserID {
+		t.Fatalf("imported document owner=%q want paired admin user %q", user, h.AdminUserID)
 	}
 }
 
@@ -271,6 +271,269 @@ func TestImportNgxJobHiddenFromOtherUser(t *testing.T) {
 	}
 
 	_ = waitImportNgx(t, h, tokenA, jobID)
+}
+
+func TestImportNgxAsSuperuserOwnsPairedAdmin(t *testing.T) {
+	h := StartShared(t)
+	if h.AdminUserID == "" {
+		t.Fatal("missing AdminUserID")
+	}
+
+	payload := []byte("imported-superuser-body-" + t.Name())
+	checksum := sha256Hex(payload)
+	mux := http.NewServeMux()
+	empty := func(w http.ResponseWriter, _ *http.Request) {
+		writeNgxPage(w, []map[string]any{})
+	}
+	mux.HandleFunc("/api/tags/", empty)
+	mux.HandleFunc("/api/correspondents/", empty)
+	mux.HandleFunc("/api/document_types/", empty)
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Disposition", `attachment; filename="super.txt"`)
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(payload)
+			return
+		}
+		writeNgxPage(w, []map[string]any{{
+			"id":                 7,
+			"title":              "SuperImport",
+			"content":            "from superuser session",
+			"original_file_name": "super.txt",
+		}})
+	})
+	remote := httptest.NewServer(mux)
+	t.Cleanup(remote.Close)
+
+	token := h.superToken(t)
+	result := runImportNgx(t, h, token, remote.URL, "remote-token", "preserve")
+	if intFromAny(result["imported"]) != 1 {
+		t.Fatalf("imported=%v body=%v", result["imported"], result)
+	}
+
+	docsStatus, docsRaw := h.doJSON(t, http.MethodGet,
+		`/api/collections/documents/records?filter=checksum="`+checksum+`"&perPage=50`, h.adminUserToken(t), nil)
+	requireStatus(t, docsStatus, http.StatusOK, docsRaw)
+	var docs struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(docsRaw), &docs); err != nil {
+		t.Fatalf("decode docs: %v", err)
+	}
+	if len(docs.Items) != 1 {
+		t.Fatalf("expected 1 document, got %d: %s", len(docs.Items), docsRaw)
+	}
+	if user, _ := docs.Items[0]["user"].(string); user != h.AdminUserID {
+		t.Fatalf("imported document owner=%q want paired admin user %q", user, h.AdminUserID)
+	}
+}
+
+func TestImportNgxSuperuserRequiresPairedUser(t *testing.T) {
+	h := StartShared(t)
+	email := fmt.Sprintf("orphan-super-%d@paperless.local", time.Now().UnixNano())
+	pass := "orphanpassword123"
+	if _, err := createAuthRecord(h.App, "_superusers", email, pass); err != nil {
+		t.Fatalf("create orphan superuser: %v", err)
+	}
+	token := h.authWithPassword(t, "_superusers", email, pass).Token
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     "https://ngx.example.com",
+		"api_key": "x",
+		"mode":    "preserve",
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", status, raw)
+	}
+	if !strings.Contains(raw, "paired") {
+		t.Fatalf("expected paired-user error, got %s", raw)
+	}
+}
+
+func TestImportNgxAllowsConcurrentDifferentUsers(t *testing.T) {
+	h := StartShared(t)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	muxA := http.NewServeMux()
+	hold := func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		writeNgxPage(w, []map[string]any{})
+	}
+	muxA.HandleFunc("/api/tags/", hold)
+	muxA.HandleFunc("/api/correspondents/", hold)
+	muxA.HandleFunc("/api/document_types/", hold)
+	muxA.HandleFunc("/api/documents/", hold)
+	remoteA := httptest.NewServer(muxA)
+	t.Cleanup(remoteA.Close)
+
+	tokenA := h.userToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", tokenA, map[string]any{
+		"url":     remoteA.URL,
+		"api_key": "remote-token",
+		"mode":    "preserve",
+	})
+	requireStatus(t, status, http.StatusAccepted, raw)
+	var startA map[string]any
+	if err := json.Unmarshal([]byte(raw), &startA); err != nil {
+		t.Fatalf("decode start A: %v body %s", err, raw)
+	}
+	jobA, _ := startA["job_id"].(string)
+	if jobA == "" {
+		t.Fatalf("missing job_id in %s", raw)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("import A never reached the remote")
+	}
+
+	muxB := http.NewServeMux()
+	empty := func(w http.ResponseWriter, _ *http.Request) {
+		writeNgxPage(w, []map[string]any{})
+	}
+	muxB.HandleFunc("/api/tags/", empty)
+	muxB.HandleFunc("/api/correspondents/", empty)
+	muxB.HandleFunc("/api/document_types/", empty)
+	muxB.HandleFunc("/api/documents/", empty)
+	remoteB := httptest.NewServer(muxB)
+	t.Cleanup(remoteB.Close)
+
+	otherEmail := fmt.Sprintf("import-concurrent-%d@paperless.local", time.Now().UnixNano())
+	otherPass := "otherpassword123"
+	status, raw = h.doJSON(t, http.MethodPost, "/api/collections/users/records", h.superToken(t), map[string]any{
+		"email":           otherEmail,
+		"password":        otherPass,
+		"passwordConfirm": otherPass,
+		"verified":        true,
+	})
+	if status < 200 || status >= 300 {
+		if _, err := createAuthRecord(h.App, "users", otherEmail, otherPass); err != nil {
+			t.Fatalf("create other user via API (%s) and app (%v)", formatErr(status, raw), err)
+		}
+	}
+	tokenB := h.authWithPassword(t, "users", otherEmail, otherPass).Token
+	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", tokenB, map[string]any{
+		"url":     remoteB.URL,
+		"api_key": "remote-token",
+		"mode":    "preserve",
+	})
+	if status == http.StatusConflict {
+		t.Fatalf("user B should not be blocked by user A's import: %s", raw)
+	}
+	requireStatus(t, status, http.StatusAccepted, raw)
+	var startB map[string]any
+	if err := json.Unmarshal([]byte(raw), &startB); err != nil {
+		t.Fatalf("decode start B: %v body %s", err, raw)
+	}
+	jobB, _ := startB["job_id"].(string)
+	if jobB == "" {
+		t.Fatalf("missing job_id in %s", raw)
+	}
+
+	close(release)
+	_ = waitImportNgx(t, h, tokenB, jobB)
+	_ = waitImportNgx(t, h, tokenA, jobA)
+}
+
+func TestImportNgxConflictSameUser(t *testing.T) {
+	h := StartShared(t)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	hold := func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		writeNgxPage(w, []map[string]any{})
+	}
+	mux.HandleFunc("/api/tags/", hold)
+	mux.HandleFunc("/api/correspondents/", hold)
+	mux.HandleFunc("/api/document_types/", hold)
+	mux.HandleFunc("/api/documents/", hold)
+	remote := httptest.NewServer(mux)
+	t.Cleanup(remote.Close)
+
+	token := h.userToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     remote.URL,
+		"api_key": "remote-token",
+		"mode":    "preserve",
+	})
+	requireStatus(t, status, http.StatusAccepted, raw)
+	var start map[string]any
+	if err := json.Unmarshal([]byte(raw), &start); err != nil {
+		t.Fatalf("decode start: %v body %s", err, raw)
+	}
+	jobID, _ := start["job_id"].(string)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first import never reached the remote")
+	}
+
+	status, raw = h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     remote.URL,
+		"api_key": "remote-token",
+		"mode":    "preserve",
+	})
+	if status != http.StatusConflict {
+		t.Fatalf("same user second import status=%d body=%s", status, raw)
+	}
+
+	close(release)
+	_ = waitImportNgx(t, h, token, jobID)
+}
+
+func TestImportNgxBlocksLinkLocal(t *testing.T) {
+	h := StartShared(t)
+	token := h.userToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+		"url":     "http://169.254.169.254/",
+		"api_key": "x",
+		"mode":    "preserve",
+	})
+	requireStatus(t, status, http.StatusAccepted, raw)
+	var start map[string]any
+	if err := json.Unmarshal([]byte(raw), &start); err != nil {
+		t.Fatalf("decode start: %v body %s", err, raw)
+	}
+	jobID, _ := start["job_id"].(string)
+	if jobID == "" {
+		t.Fatalf("missing job_id in %s", raw)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		status, raw = h.doJSON(t, http.MethodGet, "/api/app/import/ngx/status?job_id="+jobID, token, nil)
+		requireStatus(t, status, http.StatusOK, raw)
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+			t.Fatalf("decode status: %v body %s", err, raw)
+		}
+		switch payload["status"] {
+		case "failed":
+			errMsg, _ := payload["error"].(string)
+			if !strings.Contains(errMsg, "not allowed") {
+				t.Fatalf("expected blocked-host error, got %s", raw)
+			}
+			return
+		case "completed":
+			t.Fatalf("link-local import should fail, got %s", raw)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for link-local import to fail")
 }
 
 func runImportNgx(t *testing.T, h *Harness, token, url, apiKey, mode string) map[string]any {

--- a/backend/e2e/import_ngx_test.go
+++ b/backend/e2e/import_ngx_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,21 +12,24 @@ import (
 	"time"
 )
 
-func TestImportNgxForbiddenForUser(t *testing.T) {
+func TestImportNgxUnauthorized(t *testing.T) {
 	h := StartShared(t)
-	token := h.userToken(t)
-	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", "", map[string]any{
 		"url":     "http://example.com",
 		"api_key": "x",
 	})
-	if status != http.StatusForbidden {
+	if status != http.StatusUnauthorized {
 		t.Fatalf("status=%d body=%s", status, raw)
+	}
+	status, raw = h.doJSON(t, http.MethodGet, "/api/app/import/ngx/status?job_id=missing", "", nil)
+	if status != http.StatusUnauthorized {
+		t.Fatalf("status poll=%d body=%s", status, raw)
 	}
 }
 
 func TestImportNgxValidation(t *testing.T) {
 	h := StartShared(t)
-	token := h.adminUserToken(t)
+	token := h.userToken(t)
 	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", token, map[string]any{
 		"url":     "",
 		"api_key": "x",
@@ -90,7 +94,7 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	remote := httptest.NewServer(mux)
 	t.Cleanup(remote.Close)
 
-	token := h.adminUserToken(t)
+	token := h.userToken(t)
 	result := runImportNgx(t, h, token, remote.URL, "remote-token", "preserve")
 	if intFromAny(result["imported"]) != 1 {
 		t.Fatalf("imported=%v body=%v", result["imported"], result)
@@ -140,6 +144,9 @@ func TestImportNgxPreserveMetadata(t *testing.T) {
 	if dtype, _ := doc["document_type"].(string); dtype == "" {
 		t.Fatal("expected document_type to be set")
 	}
+	if user, _ := doc["user"].(string); user != h.UserID {
+		t.Fatalf("imported document owner=%q want user %q", user, h.UserID)
+	}
 }
 
 func TestImportNgxReprocessFilesOnly(t *testing.T) {
@@ -180,7 +187,7 @@ func TestImportNgxReprocessFilesOnly(t *testing.T) {
 	remote := httptest.NewServer(mux)
 	t.Cleanup(remote.Close)
 
-	token := h.adminUserToken(t)
+	token := h.userToken(t)
 	result := runImportNgx(t, h, token, remote.URL, "remote-token", "reprocess")
 	if intFromAny(result["imported"]) != 1 {
 		t.Fatalf("imported=%v body=%v", result["imported"], result)
@@ -210,6 +217,60 @@ func TestImportNgxReprocessFilesOnly(t *testing.T) {
 	if ocr, _ := doc["ocr_text"].(string); ocr == "ShouldNotKeepOCR" {
 		t.Fatalf("reprocess mode should not keep ngx OCR text, got %q", ocr)
 	}
+	if user, _ := doc["user"].(string); user != h.UserID {
+		t.Fatalf("imported document owner=%q want user %q", user, h.UserID)
+	}
+}
+
+func TestImportNgxJobHiddenFromOtherUser(t *testing.T) {
+	h := StartShared(t)
+	mux := http.NewServeMux()
+	empty := func(w http.ResponseWriter, _ *http.Request) {
+		writeNgxPage(w, []map[string]any{})
+	}
+	mux.HandleFunc("/api/tags/", empty)
+	mux.HandleFunc("/api/correspondents/", empty)
+	mux.HandleFunc("/api/document_types/", empty)
+	mux.HandleFunc("/api/documents/", empty)
+	remote := httptest.NewServer(mux)
+	t.Cleanup(remote.Close)
+
+	tokenA := h.userToken(t)
+	status, raw := h.doJSON(t, http.MethodPost, "/api/app/import/ngx", tokenA, map[string]any{
+		"url":     remote.URL,
+		"api_key": "remote-token",
+		"mode":    "preserve",
+	})
+	requireStatus(t, status, http.StatusAccepted, raw)
+	var start map[string]any
+	if err := json.Unmarshal([]byte(raw), &start); err != nil {
+		t.Fatalf("decode start: %v body %s", err, raw)
+	}
+	jobID, _ := start["job_id"].(string)
+	if jobID == "" {
+		t.Fatalf("missing job_id in %s", raw)
+	}
+
+	otherEmail := fmt.Sprintf("import-other-%d@paperless.local", time.Now().UnixNano())
+	otherPass := "otherpassword123"
+	status, raw = h.doJSON(t, http.MethodPost, "/api/collections/users/records", h.superToken(t), map[string]any{
+		"email":           otherEmail,
+		"password":        otherPass,
+		"passwordConfirm": otherPass,
+		"verified":        true,
+	})
+	if status < 200 || status >= 300 {
+		if _, err := createAuthRecord(h.App, "users", otherEmail, otherPass); err != nil {
+			t.Fatalf("create other user via API (%s) and app (%v)", formatErr(status, raw), err)
+		}
+	}
+	tokenB := h.authWithPassword(t, "users", otherEmail, otherPass).Token
+	status, raw = h.doJSON(t, http.MethodGet, "/api/app/import/ngx/status?job_id="+jobID, tokenB, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("other user should not see import job: status=%d body=%s", status, raw)
+	}
+
+	_ = waitImportNgx(t, h, tokenA, jobID)
 }
 
 func runImportNgx(t *testing.T, h *Harness, token, url, apiKey, mode string) map[string]any {
@@ -229,10 +290,14 @@ func runImportNgx(t *testing.T, h *Harness, token, url, apiKey, mode string) map
 	if jobID == "" {
 		t.Fatalf("missing job_id in %s", raw)
 	}
+	return waitImportNgx(t, h, token, jobID)
+}
 
+func waitImportNgx(t *testing.T, h *Harness, token, jobID string) map[string]any {
+	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
-		status, raw = h.doJSON(t, http.MethodGet, "/api/app/import/ngx/status?job_id="+jobID, token, nil)
+		status, raw := h.doJSON(t, http.MethodGet, "/api/app/import/ngx/status?job_id="+jobID, token, nil)
 		requireStatus(t, status, http.StatusOK, raw)
 		var payload map[string]any
 		if err := json.Unmarshal([]byte(raw), &payload); err != nil {

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -29,8 +29,8 @@ func Register(app core.App, rt *config.Runtime) {
 			g.DELETE("/providers/{id}", bindAdmin(handleDeleteProvider(app, rt)))
 			g.GET("/providers/{id}/models", bindAdmin(handleListProviderModels(app)))
 			g.POST("/duplicates/scan", bindAdmin(handlePostDuplicatesScan(app, rt)))
-			g.POST("/import/ngx", bindAdmin(handlePostImportNgx(app)))
-			g.GET("/import/ngx/status", bindAdmin(handleGetImportNgxStatus(app)))
+			g.POST("/import/ngx", bindAuth(handlePostImportNgx(app)))
+			g.GET("/import/ngx/status", bindAuth(handleGetImportNgxStatus(app)))
 			return e.Next()
 		},
 	})

--- a/backend/internal/appapi/import_ngx.go
+++ b/backend/internal/appapi/import_ngx.go
@@ -36,7 +36,7 @@ func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
 
 		ownerID, err := resolveImportOwnerID(app, e)
 		if err != nil {
-			return writeError(e, http.StatusBadRequest, err.Error())
+			return writeImportOwnerError(e, err)
 		}
 
 		jobID, err := ngximport.Start(app, ownerID, req.URL, req.APIKey, mode)
@@ -61,7 +61,7 @@ func handleGetImportNgxStatus(app core.App) func(*core.RequestEvent) error {
 		}
 		ownerID, err := resolveImportOwnerID(app, e)
 		if err != nil {
-			return writeError(e, http.StatusBadRequest, err.Error())
+			return writeImportOwnerError(e, err)
 		}
 		job, ok := ngximport.GetJob(jobID)
 		if !ok || job.OwnerUserID != ownerID {
@@ -81,21 +81,37 @@ func handleGetImportNgxStatus(app core.App) func(*core.RequestEvent) error {
 	}
 }
 
+type importOwnerClientError struct {
+	msg string
+}
+
+func (e *importOwnerClientError) Error() string {
+	return e.msg
+}
+
+func writeImportOwnerError(e *core.RequestEvent, err error) error {
+	var clientErr *importOwnerClientError
+	if errors.As(err, &clientErr) {
+		return writeError(e, http.StatusBadRequest, clientErr.Error())
+	}
+	return writeError(e, http.StatusInternalServerError, "Failed to resolve import owner.")
+}
+
 func resolveImportOwnerID(app core.App, e *core.RequestEvent) (string, error) {
 	if e.Auth == nil {
-		return "", errors.New("Authentication required.")
+		return "", &importOwnerClientError{msg: "Authentication required."}
 	}
 	if e.Auth.Collection().Name == "users" {
 		return e.Auth.Id, nil
 	}
 	email := strings.TrimSpace(e.Auth.Email())
 	if email == "" {
-		return "", errors.New("Admin account has no email; cannot resolve document owner.")
+		return "", &importOwnerClientError{msg: "Admin account has no email; cannot resolve document owner."}
 	}
 	user, err := app.FindAuthRecordByEmail("users", email)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", errors.New("No paired users account for this admin; sign in with the admin user account.")
+			return "", &importOwnerClientError{msg: "No paired users account for this admin; sign in with the admin user account."}
 		}
 		return "", err
 	}

--- a/backend/internal/appapi/import_ngx.go
+++ b/backend/internal/appapi/import_ngx.go
@@ -55,13 +55,16 @@ func handlePostImportNgx(app core.App) func(*core.RequestEvent) error {
 
 func handleGetImportNgxStatus(app core.App) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
-		_ = app
 		jobID := strings.TrimSpace(e.Request.URL.Query().Get("job_id"))
 		if jobID == "" {
 			return writeError(e, http.StatusBadRequest, "job_id is required.")
 		}
+		ownerID, err := resolveImportOwnerID(app, e)
+		if err != nil {
+			return writeError(e, http.StatusBadRequest, err.Error())
+		}
 		job, ok := ngximport.GetJob(jobID)
-		if !ok {
+		if !ok || job.OwnerUserID != ownerID {
 			return writeError(e, http.StatusNotFound, "Import job not found.")
 		}
 		payload := map[string]any{

--- a/backend/internal/ngximport/client.go
+++ b/backend/internal/ngximport/client.go
@@ -39,7 +39,10 @@ func NewClient(baseURL, apiKey string, httpClient *http.Client) (*Client, error)
 		return nil, fmt.Errorf("api key is required")
 	}
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: listTimeout}
+		if err := rejectBlockedImportURL(normalized); err != nil {
+			return nil, err
+		}
+		httpClient = newImportHTTPClient(listTimeout)
 	}
 	downloadClient := httpClient
 	if httpClient.Timeout != 0 && httpClient.Timeout < downloadTimeout {
@@ -154,7 +157,7 @@ func (c *Client) DownloadDocument(id int) (downloadedFile, error) {
 		return downloadedFile{}, fmt.Errorf("document %d exceeds %d bytes", id, maxDownloadBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return downloadedFile{}, fmt.Errorf("download document %d: status %d: %s", id, resp.StatusCode, truncate(string(body), 200))
+		return downloadedFile{}, fmt.Errorf("download document %d: status %d", id, resp.StatusCode)
 	}
 	name := filenameFromDisposition(resp.Header.Get("Content-Disposition"))
 	if name == "" {
@@ -215,8 +218,8 @@ func (c *Client) getJSON(relOrPath string, dest any) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxJSONErrorBytes))
-		return fmt.Errorf("GET %s: status %d: %s", relOrPath, resp.StatusCode, truncate(string(body), 200))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxJSONErrorBytes))
+		return fmt.Errorf("GET %s: status %d", relOrPath, resp.StatusCode)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
 		return fmt.Errorf("decode %s: %w", relOrPath, err)
@@ -267,11 +270,4 @@ func filenameFromDisposition(header string) string {
 		return path.Base(name)
 	}
 	return ""
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "…"
 }

--- a/backend/internal/ngximport/import.go
+++ b/backend/internal/ngximport/import.go
@@ -49,17 +49,17 @@ func ParseMode(raw string) (string, error) {
 }
 
 // Run imports taxonomy and documents from a remote Paperless-ngx instance.
-// Only one import may run at a time.
+// Only one import may run at a time per owner.
 func Run(app core.App, ownerUserID, baseURL, apiKey, mode string) (Result, error) {
 	return RunWithClient(app, ownerUserID, baseURL, apiKey, mode, nil)
 }
 
 // RunWithClient is like Run but accepts a prebuilt client (for tests).
 func RunWithClient(app core.App, ownerUserID, baseURL, apiKey, mode string, client *Client) (Result, error) {
-	if err := acquireImport(); err != nil {
+	if err := acquireImport(ownerUserID); err != nil {
 		return Result{}, err
 	}
-	defer releaseImport()
+	defer releaseImport(ownerUserID)
 	return runImport(app, ownerUserID, baseURL, apiKey, mode, client)
 }
 

--- a/backend/internal/ngximport/job.go
+++ b/backend/internal/ngximport/job.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,35 +32,38 @@ var (
 	jobsMu     sync.Mutex
 	jobs       = map[string]*Job{}
 	importMu   sync.Mutex
-	importBusy bool
+	importBusy = map[string]struct{}{}
 )
 
-func acquireImport() error {
+func acquireImport(ownerUserID string) error {
+	if strings.TrimSpace(ownerUserID) == "" {
+		return fmt.Errorf("owner user id is required")
+	}
 	importMu.Lock()
 	defer importMu.Unlock()
-	if importBusy {
+	if _, busy := importBusy[ownerUserID]; busy {
 		return ErrImportInProgress
 	}
-	importBusy = true
+	importBusy[ownerUserID] = struct{}{}
 	return nil
 }
 
-func releaseImport() {
+func releaseImport(ownerUserID string) {
 	importMu.Lock()
-	importBusy = false
+	delete(importBusy, ownerUserID)
 	importMu.Unlock()
 }
 
 // Start begins an import in a background goroutine and returns the job id.
-// Only one import may run at a time.
+// Only one import may run at a time per owner.
 func Start(app core.App, ownerUserID, baseURL, apiKey, mode string) (string, error) {
-	if err := acquireImport(); err != nil {
+	if err := acquireImport(ownerUserID); err != nil {
 		return "", err
 	}
 
 	id, err := newJobID()
 	if err != nil {
-		releaseImport()
+		releaseImport(ownerUserID)
 		return "", err
 	}
 	job := &Job{
@@ -73,7 +77,7 @@ func Start(app core.App, ownerUserID, baseURL, apiKey, mode string) (string, err
 	jobsMu.Unlock()
 
 	go func() {
-		defer releaseImport()
+		defer releaseImport(ownerUserID)
 		result, runErr := runImport(app, ownerUserID, baseURL, apiKey, mode, nil)
 		jobsMu.Lock()
 		defer jobsMu.Unlock()

--- a/backend/internal/ngximport/job.go
+++ b/backend/internal/ngximport/job.go
@@ -19,11 +19,12 @@ const (
 
 // Job is an in-memory import run snapshot (lost on process restart).
 type Job struct {
-	ID        string    `json:"job_id"`
-	Status    string    `json:"status"`
-	Result    *Result   `json:"result,omitempty"`
-	Error     string    `json:"error,omitempty"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID          string    `json:"job_id"`
+	OwnerUserID string    `json:"-"`
+	Status      string    `json:"status"`
+	Result      *Result   `json:"result,omitempty"`
+	Error       string    `json:"error,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 var (
@@ -62,9 +63,10 @@ func Start(app core.App, ownerUserID, baseURL, apiKey, mode string) (string, err
 		return "", err
 	}
 	job := &Job{
-		ID:        id,
-		Status:    JobStatusRunning,
-		UpdatedAt: time.Now().UTC(),
+		ID:          id,
+		OwnerUserID: ownerUserID,
+		Status:      JobStatusRunning,
+		UpdatedAt:   time.Now().UTC(),
 	}
 	jobsMu.Lock()
 	jobs[id] = job

--- a/backend/internal/ngximport/job_test.go
+++ b/backend/internal/ngximport/job_test.go
@@ -1,0 +1,39 @@
+package ngximport
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAcquireImportPerOwner(t *testing.T) {
+	const ownerA = "owner-a"
+	const ownerB = "owner-b"
+	t.Cleanup(func() {
+		releaseImport(ownerA)
+		releaseImport(ownerB)
+	})
+
+	if err := acquireImport(ownerA); err != nil {
+		t.Fatal(err)
+	}
+	if err := acquireImport(ownerA); !errors.Is(err, ErrImportInProgress) {
+		t.Fatalf("same owner should be busy, got %v", err)
+	}
+	if err := acquireImport(ownerB); err != nil {
+		t.Fatalf("other owner should not be blocked: %v", err)
+	}
+
+	releaseImport(ownerA)
+	if err := acquireImport(ownerA); err != nil {
+		t.Fatalf("owner A should be free after release: %v", err)
+	}
+}
+
+func TestAcquireImportRequiresOwner(t *testing.T) {
+	if err := acquireImport(""); err == nil {
+		t.Fatal("expected error for empty owner")
+	}
+	if err := acquireImport("   "); err == nil {
+		t.Fatal("expected error for blank owner")
+	}
+}

--- a/backend/internal/ngximport/ssrf.go
+++ b/backend/internal/ngximport/ssrf.go
@@ -1,0 +1,109 @@
+package ngximport
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+var allowPrivateImportHosts atomic.Bool
+
+// SetAllowPrivateImportHosts lets tests reach httptest servers on loopback.
+// Production should leave this false and use IMPORT_ALLOW_PRIVATE when a
+// self-hosted Paperless-ngx instance is on a private network.
+func SetAllowPrivateImportHosts(allow bool) {
+	allowPrivateImportHosts.Store(allow)
+}
+
+func privateImportHostsAllowed() bool {
+	if allowPrivateImportHosts.Load() {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("IMPORT_ALLOW_PRIVATE"))) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func newImportHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   denyBlockedImportDial,
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = dialer.DialContext
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}
+
+func denyBlockedImportDial(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("import blocked: invalid dial address")
+	}
+	if i := strings.IndexByte(host, '%'); i >= 0 {
+		host = host[:i]
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("import blocked: invalid dial address")
+	}
+	if blockedImportIP(ip) {
+		return fmt.Errorf("import blocked: address %s is not allowed", ip)
+	}
+	return nil
+}
+
+func rejectBlockedImportURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("url must include a host")
+	}
+	if ip := net.ParseIP(host); ip != nil && blockedImportIP(ip) {
+		return fmt.Errorf("url host %s is not allowed", host)
+	}
+	return nil
+}
+
+func blockedImportIP(ip net.IP) bool {
+	return blockedImportIPWithPrivate(ip, privateImportHostsAllowed())
+}
+
+func blockedImportIPWithPrivate(ip net.IP, allowPrivate bool) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	if allowPrivate {
+		return false
+	}
+	if cgnatIP(ip) {
+		return true
+	}
+	return ip.IsLoopback() || ip.IsPrivate()
+}
+
+func cgnatIP(ip net.IP) bool {
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	return v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127
+}

--- a/backend/internal/ngximport/ssrf_test.go
+++ b/backend/internal/ngximport/ssrf_test.go
@@ -1,0 +1,175 @@
+package ngximport
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBlockedImportIP(t *testing.T) {
+	t.Parallel()
+
+	blocked := []string{
+		"127.0.0.1",
+		"::1",
+		"10.0.0.1",
+		"192.168.1.10",
+		"172.16.0.1",
+		"169.254.169.254",
+		"0.0.0.0",
+		"224.0.0.1",
+		"100.64.0.1",
+		"fe80::1",
+	}
+	for _, raw := range blocked {
+		ip := net.ParseIP(raw)
+		if ip == nil {
+			t.Fatalf("parse %q", raw)
+		}
+		if !blockedImportIPWithPrivate(ip, false) {
+			t.Fatalf("expected %s to be blocked", raw)
+		}
+	}
+
+	public := net.ParseIP("8.8.8.8")
+	if blockedImportIPWithPrivate(public, false) {
+		t.Fatal("expected public IP to be allowed")
+	}
+}
+
+func TestPrivateImportHostsStillBlockLinkLocal(t *testing.T) {
+	t.Parallel()
+
+	if blockedImportIPWithPrivate(net.ParseIP("127.0.0.1"), true) {
+		t.Fatal("loopback should be allowed when private hosts are enabled")
+	}
+	if blockedImportIPWithPrivate(net.ParseIP("192.168.0.5"), true) {
+		t.Fatal("RFC1918 should be allowed when private hosts are enabled")
+	}
+	if !blockedImportIPWithPrivate(net.ParseIP("169.254.169.254"), true) {
+		t.Fatal("link-local metadata should stay blocked")
+	}
+	if blockedImportIPWithPrivate(net.ParseIP("100.64.0.1"), true) {
+		t.Fatal("CGNAT should be allowed when private hosts are enabled")
+	}
+}
+
+func TestSafeClientBlocksLoopback(t *testing.T) {
+	t.Setenv("IMPORT_ALLOW_PRIVATE", "")
+	SetAllowPrivateImportHosts(false)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("loopback request should not be dialed")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "k", nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "not allowed") {
+			return
+		}
+		t.Fatal(err)
+	}
+	_, err = client.ListTags()
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected blocked loopback, got %v", err)
+	}
+}
+
+func TestSafeClientBlocksLinkLocalLiteral(t *testing.T) {
+	SetAllowPrivateImportHosts(true)
+	t.Cleanup(func() { SetAllowPrivateImportHosts(false) })
+
+	_, err := NewClient("http://169.254.169.254/", "k", nil)
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected link-local URL to be rejected, got %v", err)
+	}
+}
+
+func TestSafeClientBlocksRedirectToLinkLocal(t *testing.T) {
+	SetAllowPrivateImportHosts(true)
+	t.Cleanup(func() { SetAllowPrivateImportHosts(false) })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "k", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListTags()
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected redirect to link-local to be blocked, got %v", err)
+	}
+}
+
+func TestSafeClientAllowsPrivateWhenEnabled(t *testing.T) {
+	SetAllowPrivateImportHosts(true)
+	t.Cleanup(func() { SetAllowPrivateImportHosts(false) })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"count":    0,
+			"next":     nil,
+			"previous": nil,
+			"results":  []namedEntity{},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "k", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags, err := client.ListTags()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("tags=%v", tags)
+	}
+}
+
+func TestClientHidesRemoteErrorBody(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "SECRET_INTERNAL_BODY")
+	})
+	mux.HandleFunc("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/download") {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "SECRET_DOWNLOAD_BODY")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(srv.URL, "k", srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListTags()
+	if err == nil || strings.Contains(err.Error(), "SECRET") {
+		t.Fatalf("expected status without body, got %v", err)
+	}
+	_, err = client.DownloadDocument(1)
+	if err == nil || strings.Contains(err.Error(), "SECRET") {
+		t.Fatalf("expected download status without body, got %v", err)
+	}
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,6 +54,7 @@ All variables live in `.env` at the project root (see `.env.example`).
 | Variable | Default | Description |
 | --- | --- | --- |
 | `WORKER_CRON_EXPR` | `* * * * *` | Cron expression for sweeping stuck pending jobs (registered once at startup) |
+| `IMPORT_ALLOW_PRIVATE` | unset (blocked) | Set to `1`/`true` to let ngx import reach loopback and RFC1918 hosts. Link-local / cloud-metadata addresses stay blocked. Needed when Paperless-ngx is on the same LAN or Docker network. |
 | `VITE_POCKETBASE_URL` | `http://127.0.0.1:8090` | PocketBase API URL (frontend) |
 | `VITE_DEV_USER_EMAIL` | — | Dev auto-login email (`users` collection) |
 | `VITE_DEV_USER_PASSWORD` | — | Dev auto-login password |
@@ -215,7 +216,9 @@ Any signed-in user can migrate a Paperless-ngx library into their own Paperless 
    - **Import files only and reprocess** (`reprocess`): downloads only the original files and queues the full OCR + AI pipeline as for a new upload.
 4. Start the import. Exact file duplicates (same checksum) are skipped.
 
-The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "...", "mode": "preserve" | "reprocess" }`. The request returns `202 Accepted` with `{ "job_id", "status": "running" }`. Poll `GET /api/app/import/ngx/status?job_id=...` until `status` is `completed` (with `result`) or `failed` (with `error`). Job state is kept in memory for the running process only. `mode` defaults to `preserve`. The API key is not persisted.
+The same flow is available as `POST /api/app/import/ngx` with JSON body `{ "url": "...", "api_key": "...", "mode": "preserve" | "reprocess" }`. The request returns `202 Accepted` with `{ "job_id", "status": "running" }`. Poll `GET /api/app/import/ngx/status?job_id=...` until `status` is `completed` (with `result`) or `failed` (with `error`). Job state is kept in memory for the running process only. One import may run at a time per user. `mode` defaults to `preserve`. The API key is not persisted.
+
+Import fetches only the caller-supplied URL. Private, loopback, and link-local destinations are blocked by default (including after redirects). Set `IMPORT_ALLOW_PRIVATE=1` if the remote Paperless-ngx instance is on a private network; cloud-metadata addresses remain blocked.
 
 ### swift-paperless (iOS)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -206,7 +206,7 @@ API versions 9 and 10 are accepted via the `Accept` header (`application/json; v
 
 ### Importing from Paperless-ngx
 
-Admins can migrate an existing Paperless-ngx library into Paperless Go:
+Any signed-in user can migrate a Paperless-ngx library into their own Paperless Go account. The remote API token authenticates a specific ngx user, so the import runs as the current local user rather than as an admin.
 
 1. Open **Import** in the More menu (or go to `/import`).
 2. Enter the remote Paperless-ngx base URL and an API token from that instance’s profile.

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -6,6 +6,7 @@ test('login succeeds for regular user', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Documents' })).toBeVisible()
   await page.getByRole('button', { name: 'More' }).click()
   await expect(page.getByRole('menuitem', { name: 'Settings' })).toHaveCount(0)
+  await expect(page.getByRole('menuitem', { name: 'Admin' })).toHaveCount(0)
 })
 
 test('login rejects bad password', async ({ page }) => {

--- a/frontend/e2e/documents.spec.ts
+++ b/frontend/e2e/documents.spec.ts
@@ -20,6 +20,7 @@ test('admin can upload documents', async ({ page }) => {
   await loginAsSuper(page)
   await openMoreMenu(page)
   await expect(page.getByRole('menuitem', { name: 'Settings' })).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: 'Admin' })).toBeVisible()
   await uploadFixture(page, 'sample.txt')
   await expect(page).toHaveURL(/\/document\//)
 })

--- a/frontend/e2e/import.spec.ts
+++ b/frontend/e2e/import.spec.ts
@@ -1,13 +1,16 @@
 import { test, expect } from '@playwright/test'
 import { loginAsSuper, loginAsUser, openMoreMenu } from './helpers/auth'
 
-test('regular user cannot open import', async ({ page }) => {
+test('regular user can open import page', async ({ page }) => {
   await loginAsUser(page)
   await openMoreMenu(page)
-  await expect(page.getByRole('menuitem', { name: 'Import' })).toHaveCount(0)
-  await page.goto('/import')
-  await expect(page.getByRole('heading', { name: 'Import from Paperless-ngx' })).toHaveCount(0)
-  await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible()
+  await page.getByRole('menuitem', { name: 'Import' }).click()
+  await expect(page.getByRole('heading', { name: 'Import from Paperless-ngx' })).toBeVisible()
+  await expect(page.getByLabel('Paperless-ngx URL')).toBeVisible()
+  await expect(page.getByLabel('API key')).toBeVisible()
+  await expect(page.getByRole('radio', { name: /Keep Paperless-ngx metadata/i })).toBeChecked()
+  await expect(page.getByRole('radio', { name: /Import files only and reprocess/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Start import' })).toBeVisible()
 })
 
 test('superuser can open import page', async ({ page }) => {

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -5,7 +5,7 @@ test('regular user cannot open settings', async ({ page }) => {
   await loginAsUser(page)
   await openMoreMenu(page)
   await expect(page.getByRole('menuitem', { name: 'Settings' })).toHaveCount(0)
-  await expect(page.getByRole('menuitem', { name: 'Admin' })).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: 'Admin' })).toHaveCount(0)
   await page.goto('/settings')
   await expect(page.getByRole('heading', { name: 'Settings' })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible()

--- a/frontend/src/components/RootLayout.tsx
+++ b/frontend/src/components/RootLayout.tsx
@@ -130,16 +130,14 @@ function MoreNavMenu({ admin }: { admin: boolean }) {
           >
             Export
           </Link>
-          {admin && (
-            <Link
-              to="/import"
-              role="menuitem"
-              className={`${menuItemClass} ${importActive ? navLinkActiveClass : ''}`}
-              onClick={() => setOpen(false)}
-            >
-              Import
-            </Link>
-          )}
+          <Link
+            to="/import"
+            role="menuitem"
+            className={`${menuItemClass} ${importActive ? navLinkActiveClass : ''}`}
+            onClick={() => setOpen(false)}
+          >
+            Import
+          </Link>
           {admin && (
             <Link
               to="/settings"

--- a/frontend/src/components/RootLayout.tsx
+++ b/frontend/src/components/RootLayout.tsx
@@ -148,16 +148,18 @@ function MoreNavMenu({ admin }: { admin: boolean }) {
               Settings
             </Link>
           )}
-          <a
-            href={pbAdminUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            role="menuitem"
-            className={menuItemClass}
-            onClick={() => setOpen(false)}
-          >
-            Admin
-          </a>
+          {admin && (
+            <a
+              href={pbAdminUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              role="menuitem"
+              className={menuItemClass}
+              onClick={() => setOpen(false)}
+            >
+              Admin
+            </a>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -688,15 +688,30 @@ export async function importFromNgx(url: string, apiKey: string, mode: NgxImport
   }
 
   for (let attempt = 0; attempt < importPollMaxAttempts; attempt++) {
-    const statusResponse = await fetch(
-      `${pbUrl}/api/app/import/ngx/status?job_id=${encodeURIComponent(startData.job_id)}`,
-      {
-        headers: {
-          Authorization: pb.authStore.token,
+    let statusResponse: Response
+    try {
+      statusResponse = await fetch(
+        `${pbUrl}/api/app/import/ngx/status?job_id=${encodeURIComponent(startData.job_id)}`,
+        {
+          headers: {
+            Authorization: pb.authStore.token,
+          },
         },
-      },
-    )
-    const statusData = (await statusResponse.json()) as NgxImportJobStatus
+      )
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, importPollIntervalMs))
+      continue
+    }
+    if (statusResponse.status >= 500) {
+      await new Promise((resolve) => setTimeout(resolve, importPollIntervalMs))
+      continue
+    }
+    let statusData: NgxImportJobStatus
+    try {
+      statusData = (await statusResponse.json()) as NgxImportJobStatus
+    } catch {
+      throw new Error('Failed to poll import status')
+    }
     if (!statusResponse.ok) {
       throw new Error(statusData.detail ?? 'Failed to poll import status')
     }

--- a/frontend/src/routes/import.tsx
+++ b/frontend/src/routes/import.tsx
@@ -1,9 +1,7 @@
 import { type SubmitEvent, useEffect, useState } from 'react'
-import { Navigate } from '@tanstack/react-router'
 import {
   ensureAuth,
   importFromNgx,
-  isAdmin,
   type NgxImportMode,
   type NgxImportResult,
 } from '../lib/pocketbase'
@@ -29,7 +27,6 @@ const modeOptions: { value: NgxImportMode; label: string; description: string }[
 ]
 
 export function ImportPage() {
-  const [allowed, setAllowed] = useState<boolean | null>(null)
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [mode, setMode] = useState<NgxImportMode>('preserve')
@@ -44,12 +41,9 @@ export function ImportPage() {
     async function load() {
       try {
         await ensureAuth()
-        const admin = await isAdmin()
-        if (active) setAllowed(admin)
       } catch (err) {
         if (active) {
           setError(err instanceof Error ? err.message : 'Failed to load')
-          setAllowed(false)
         }
       } finally {
         if (active) setLoading(false)
@@ -83,11 +77,8 @@ export function ImportPage() {
     }
   }
 
-  if (loading || allowed === null) {
+  if (loading) {
     return <p className="text-sm text-stone-500">Loading…</p>
-  }
-  if (!allowed) {
-    return <Navigate to="/" />
   }
 
   return (
@@ -95,9 +86,10 @@ export function ImportPage() {
       <div>
         <h1 className="text-2xl font-semibold text-stone-950">Import from Paperless-ngx</h1>
         <p className="mt-1 text-sm text-stone-500">
-          Pull documents from an existing Paperless-ngx instance using its URL and API token. Choose
-          whether to keep remote metadata or reprocess files through OCR and AI. The API key is not
-          stored.
+          Pull documents from an existing Paperless-ngx instance using its URL and API token. The
+          remote token belongs to a specific ngx user, so imported documents are added to your
+          account. Choose whether to keep remote metadata or reprocess files through OCR and AI. The
+          API key is not stored.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Paperless-ngx import is no longer admin-only: any signed-in user can start an import, and imported documents are owned by that user.
- Import job status is scoped to the importer so other users cannot poll another account's job.
- The Import page and More-menu link are available to regular users, matching that a remote ngx API token belongs to a specific user.

Fixes #21

## Test plan
- [ ] Sign in as a regular user, open **Import** from the More menu, and confirm the form loads (URL, API key, both modes).
- [ ] Run an import with a Paperless-ngx URL + user token and confirm documents land in that user's library, not an admin account.
- [ ] Confirm a second user cannot poll the first user's import `job_id`.
- [ ] Sign in as the paired admin and confirm Import still works for that account.