### PR TITLE
Add Mistral as an AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,11 @@ EXTRACTION_PROMPT_VERSION=v1
 
 # google_vision free tier limits: 1000 pages per month
 GOOGLE_VISION_API_KEY=
+# Mistral can be used for OCR and as an LLM (extraction, chat, search).
 # Mistral OCR free tier limits: apparantely 625 pages per minute
 MISTRAL_API_KEY=
 # MISTRAL_OCR_MODEL=mistral-ocr-latest
+# MISTRAL_MODEL=mistral-small-latest
 # MISTRAL_API_BASE_URL=https://api.mistral.ai/v1
 OCR_TIMEOUT_SEC=40
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The API has been tested with the [swift-paperless](https://github.com/paulgessin
 
 - **Backend:** Go, [PocketBase as a framework](https://pocketbase.io/docs/use-as-framework/)
 - **Frontend:** React, TanStack Router, PocketBase JS SDK
-- **OCR:** Google Cloud Vision (`google_vision`) or Mistral AI OCR (`mistral`), configured in Settings
-- **AI:** OpenAI-compatible chat completions via the official OpenAI Go SDK
+- **OCR:** Google Cloud Vision (`google_vision`) or Mistral Document OCR (`mistral`), configured in Settings
+- **AI:** OpenAI-compatible chat completions (OpenAI, OpenRouter, or Mistral) via the official OpenAI Go SDK
 - **Deep Search:** natural-language archive search via a tool-calling agent (keyword expansion across configured languages)
 
 ## Project layout
@@ -32,7 +32,7 @@ cp .env.example .env
 docker compose up --build
 ```
 
-Open [http://127.0.0.1:8090](http://127.0.0.1:8090). On first launch, the in-app setup wizard creates your admin account and collects OCR + OpenAI API keys (hard gate until both are set). Data is stored in a Docker volume (`app_data`).
+Open [http://127.0.0.1:8090](http://127.0.0.1:8090). On first launch, the in-app setup wizard creates your admin account and collects OCR + LLM API keys (hard gate until both are set). A single Mistral key can cover OCR and extraction. Data is stored in a Docker volume (`app_data`).
 
 For local development without Docker, see [docs/development.md](docs/development.md).
 

--- a/backend/e2e/app_settings_test.go
+++ b/backend/e2e/app_settings_test.go
@@ -213,12 +213,18 @@ func TestAppMistralLLMProvider(t *testing.T) {
 	if strings.Contains(raw, "mistral-small-latest") {
 		t.Fatalf("OCR catalog should not include chat models: %s", raw)
 	}
+	if strings.Contains(raw, "mistral-embed") {
+		t.Fatalf("OCR catalog should not include embed models: %s", raw)
+	}
 
 	status, raw = h.doJSON(t, http.MethodGet, "/api/app/providers/"+mistralID+"/models?for=llm", superTok, nil)
 	requireStatus(t, status, http.StatusOK, raw)
 	requireContains(t, raw, "mistral-small-latest")
 	if strings.Contains(raw, "mistral-ocr-latest") {
 		t.Fatalf("LLM catalog should not include OCR models: %s", raw)
+	}
+	if strings.Contains(raw, "mistral-embed") {
+		t.Fatalf("LLM catalog should not include embed models: %s", raw)
 	}
 
 	status, raw = h.doJSON(t, http.MethodGet, "/api/app/settings", superTok, nil)

--- a/backend/e2e/app_settings_test.go
+++ b/backend/e2e/app_settings_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -161,10 +162,10 @@ func TestAppProvidersCRUD(t *testing.T) {
 		t.Fatal("expected extract_provider_id")
 	}
 	status, raw = h.doJSON(t, http.MethodPatch, "/api/app/providers/"+inUse, superTok, map[string]any{
-		"sdk": "mistral",
+		"sdk": "google_vision",
 	})
 	if status != http.StatusConflict {
-		t.Fatalf("expected 409 changing sdk of in-use LLM provider, got %d: %s", status, raw)
+		t.Fatalf("expected 409 changing sdk of in-use LLM provider to google_vision, got %d: %s", status, raw)
 	}
 	status, raw = h.doJSON(t, http.MethodDelete, "/api/app/providers/"+inUse, superTok, nil)
 	if status != http.StatusConflict {
@@ -178,4 +179,94 @@ func TestAppProvidersCRUD(t *testing.T) {
 
 	status, raw = h.doJSON(t, http.MethodDelete, "/api/app/providers/"+id, superTok, nil)
 	requireStatus(t, status, http.StatusOK, raw)
+}
+
+func TestAppMistralLLMProvider(t *testing.T) {
+	h := StartShared(t)
+	superTok := h.superToken(t)
+
+	status, raw := h.doJSON(t, http.MethodGet, "/api/app/providers", superTok, nil)
+	requireStatus(t, status, http.StatusOK, raw)
+	var body struct {
+		Providers []struct {
+			ID  string `json:"id"`
+			SDK string `json:"sdk"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode providers: %v", err)
+	}
+	mistralID := ""
+	for _, p := range body.Providers {
+		if p.SDK == "mistral" {
+			mistralID = p.ID
+			break
+		}
+	}
+	if mistralID == "" {
+		t.Fatalf("no mistral provider in %s", raw)
+	}
+
+	status, raw = h.doJSON(t, http.MethodGet, "/api/app/providers/"+mistralID+"/models?for=ocr", superTok, nil)
+	requireStatus(t, status, http.StatusOK, raw)
+	requireContains(t, raw, "mistral-ocr-latest")
+	if strings.Contains(raw, "mistral-small-latest") {
+		t.Fatalf("OCR catalog should not include chat models: %s", raw)
+	}
+
+	status, raw = h.doJSON(t, http.MethodGet, "/api/app/providers/"+mistralID+"/models?for=llm", superTok, nil)
+	requireStatus(t, status, http.StatusOK, raw)
+	requireContains(t, raw, "mistral-small-latest")
+	if strings.Contains(raw, "mistral-ocr-latest") {
+		t.Fatalf("LLM catalog should not include OCR models: %s", raw)
+	}
+
+	status, raw = h.doJSON(t, http.MethodGet, "/api/app/settings", superTok, nil)
+	requireStatus(t, status, http.StatusOK, raw)
+	var original map[string]any
+	if err := json.Unmarshal([]byte(raw), &original); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	t.Cleanup(func() {
+		status, restoreRaw := h.doJSON(t, http.MethodPatch, "/api/app/settings", superTok, map[string]any{
+			"extract_provider_id": original["extract_provider_id"],
+			"extract_model":       original["extract_model"],
+			"chat_provider_id":    original["chat_provider_id"],
+			"chat_model":          original["chat_model"],
+			"search_provider_id":  original["search_provider_id"],
+			"search_model":        original["search_model"],
+		})
+		if status != http.StatusOK {
+			t.Errorf("failed to restore LLM provider bindings (%d): %s", status, restoreRaw)
+		}
+	})
+
+	status, raw = h.doJSON(t, http.MethodPatch, "/api/app/settings", superTok, map[string]any{
+		"extract_provider_id": mistralID,
+		"extract_model":       "mistral-small-latest",
+		"chat_provider_id":    mistralID,
+		"chat_model":          "mistral-small-latest",
+		"search_provider_id":  mistralID,
+		"search_model":        "mistral-small-latest",
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+	requireContains(t, raw, mistralID)
+	requireContains(t, raw, "mistral-small-latest")
+
+	userTok := h.userToken(t)
+	rec := h.uploadDocument(t, userTok, h.UserID, fixturePath("sample.png"))
+	id := jsonGetString(rec, "id")
+	doc := h.waitDocumentStatus(t, userTok, id, "completed", "needs_review")
+	title := jsonGetString(doc, "title")
+	if title == "" {
+		t.Fatal("expected metadata extracted via Mistral chat completions")
+	}
+
+	status, raw = h.doJSON(t, http.MethodPost, "/api/app/documents/"+id+"/chat", userTok, map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "What is the invoice total?"},
+		},
+	})
+	requireStatus(t, status, http.StatusOK, raw)
+	requireContains(t, raw, "250")
 }

--- a/backend/e2e/mocks.go
+++ b/backend/e2e/mocks.go
@@ -47,8 +47,15 @@ func startMockServers() *mockServers {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": []map[string]any{
 					{"id": "mistral-ocr-latest", "name": "mistral-ocr-latest"},
+					{"id": "mistral-small-latest", "name": "mistral-small-latest"},
 				},
 			})
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			body, _ := io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(m.openAIResponseFromBody(string(body)))
 			return
 		}
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/ocr") {

--- a/backend/e2e/mocks.go
+++ b/backend/e2e/mocks.go
@@ -46,8 +46,31 @@ func startMockServers() *mockServers {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": []map[string]any{
-					{"id": "mistral-ocr-latest", "name": "mistral-ocr-latest"},
-					{"id": "mistral-small-latest", "name": "mistral-small-latest"},
+					{
+						"id":   "mistral-ocr-latest",
+						"name": "mistral-ocr-latest",
+						"capabilities": map[string]any{
+							"completion_chat": false,
+							"ocr":             true,
+						},
+					},
+					{
+						"id":   "mistral-small-latest",
+						"name": "mistral-small-latest",
+						"capabilities": map[string]any{
+							"completion_chat":  true,
+							"function_calling": true,
+							"ocr":              false,
+						},
+					},
+					{
+						"id":   "mistral-embed",
+						"name": "mistral-embed",
+						"capabilities": map[string]any{
+							"completion_chat": false,
+							"ocr":             false,
+						},
+					},
 				},
 			})
 			return

--- a/backend/internal/aiprovider/models.go
+++ b/backend/internal/aiprovider/models.go
@@ -15,6 +15,14 @@ import (
 type Model struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+
+	// caps is set when the provider returned a capabilities object (Mistral).
+	caps *modelCapabilities
+}
+
+type modelCapabilities struct {
+	completionChat bool
+	ocr            bool
 }
 
 const modelsListTimeout = 20 * time.Second
@@ -86,41 +94,32 @@ func ListModels(ctx context.Context, p Provider, forOCR bool, client *http.Clien
 		return nil, err
 	}
 	if p.SDK == SDKMistral {
-		if forOCR {
-			models = filterModelsBySubstring(models, "ocr")
-		} else {
-			models = rejectModelsBySubstring(models, "ocr")
-		}
+		models = filterMistralModels(models, forOCR)
 	}
 	return models, nil
 }
 
-func filterModelsBySubstring(models []Model, substr string) []Model {
-	needle := strings.ToLower(strings.TrimSpace(substr))
-	if needle == "" {
-		return models
-	}
+func filterMistralModels(models []Model, forOCR bool) []Model {
 	out := make([]Model, 0, len(models))
 	for _, m := range models {
-		if modelContains(m, needle) {
+		if includeMistralModel(m, forOCR) {
 			out = append(out, m)
 		}
 	}
 	return out
 }
 
-func rejectModelsBySubstring(models []Model, substr string) []Model {
-	needle := strings.ToLower(strings.TrimSpace(substr))
-	if needle == "" {
-		return models
-	}
-	out := make([]Model, 0, len(models))
-	for _, m := range models {
-		if !modelContains(m, needle) {
-			out = append(out, m)
+func includeMistralModel(m Model, forOCR bool) bool {
+	if m.caps != nil {
+		if forOCR {
+			return m.caps.ocr
 		}
+		return m.caps.completionChat
 	}
-	return out
+	if forOCR {
+		return modelContains(m, "ocr")
+	}
+	return !modelContains(m, "ocr")
 }
 
 func modelContains(m Model, needle string) bool {
@@ -152,9 +151,13 @@ func modelsFromRaw(raw []json.RawMessage) []Model {
 	seen := map[string]struct{}{}
 	for _, item := range raw {
 		var row struct {
-			ID    string `json:"id"`
-			Name  string `json:"name"`
-			Model string `json:"model"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			Model        string `json:"model"`
+			Capabilities *struct {
+				CompletionChat bool `json:"completion_chat"`
+				OCR            bool `json:"ocr"`
+			} `json:"capabilities"`
 		}
 		if json.Unmarshal(item, &row) != nil {
 			continue
@@ -174,7 +177,14 @@ func modelsFromRaw(raw []json.RawMessage) []Model {
 		if name == "" {
 			name = id
 		}
-		out = append(out, Model{ID: id, Name: name})
+		m := Model{ID: id, Name: name}
+		if row.Capabilities != nil {
+			m.caps = &modelCapabilities{
+				completionChat: row.Capabilities.CompletionChat,
+				ocr:            row.Capabilities.OCR,
+			}
+		}
+		out = append(out, m)
 	}
 	return out
 }

--- a/backend/internal/aiprovider/models.go
+++ b/backend/internal/aiprovider/models.go
@@ -85,8 +85,12 @@ func ListModels(ctx context.Context, p Provider, forOCR bool, client *http.Clien
 	if err != nil {
 		return nil, err
 	}
-	if forOCR && p.SDK == SDKMistral {
-		models = filterModelsBySubstring(models, "ocr")
+	if p.SDK == SDKMistral {
+		if forOCR {
+			models = filterModelsBySubstring(models, "ocr")
+		} else {
+			models = rejectModelsBySubstring(models, "ocr")
+		}
 	}
 	return models, nil
 }
@@ -98,11 +102,29 @@ func filterModelsBySubstring(models []Model, substr string) []Model {
 	}
 	out := make([]Model, 0, len(models))
 	for _, m := range models {
-		if strings.Contains(strings.ToLower(m.ID), needle) || strings.Contains(strings.ToLower(m.Name), needle) {
+		if modelContains(m, needle) {
 			out = append(out, m)
 		}
 	}
 	return out
+}
+
+func rejectModelsBySubstring(models []Model, substr string) []Model {
+	needle := strings.ToLower(strings.TrimSpace(substr))
+	if needle == "" {
+		return models
+	}
+	out := make([]Model, 0, len(models))
+	for _, m := range models {
+		if !modelContains(m, needle) {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func modelContains(m Model, needle string) bool {
+	return strings.Contains(strings.ToLower(m.ID), needle) || strings.Contains(strings.ToLower(m.Name), needle)
 }
 
 func parseModelsResponse(body []byte) ([]Model, error) {

--- a/backend/internal/aiprovider/models_test.go
+++ b/backend/internal/aiprovider/models_test.go
@@ -133,8 +133,11 @@ func TestListModelsMistralOCRFiltersByOCRSubstring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(all) != 4 {
-		t.Fatalf("unfiltered len=%d want 4: %+v", len(all), all)
+	if len(all) != 2 {
+		t.Fatalf("llm catalog len=%d want 2: %+v", len(all), all)
+	}
+	if all[0].ID != "mistral-small-latest" || all[1].ID != "codestral-latest" {
+		t.Fatalf("llm catalog=%+v", all)
 	}
 }
 
@@ -148,6 +151,10 @@ func TestFilterModelsBySubstring(t *testing.T) {
 	got := filterModelsBySubstring(in, "ocr")
 	if len(got) != 2 || got[0].ID != "mistral-ocr-latest" || got[1].ID != "other" {
 		t.Fatalf("got %+v", got)
+	}
+	rejected := rejectModelsBySubstring(in, "ocr")
+	if len(rejected) != 1 || rejected[0].ID != "codestral-latest" {
+		t.Fatalf("rejected %+v", rejected)
 	}
 }
 

--- a/backend/internal/aiprovider/models_test.go
+++ b/backend/internal/aiprovider/models_test.go
@@ -100,7 +100,47 @@ func TestListModels(t *testing.T) {
 	}
 }
 
-func TestListModelsMistralOCRFiltersByOCRSubstring(t *testing.T) {
+func TestListModelsMistralFiltersByCapabilities(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[
+			{"id":"mistral-small-latest","capabilities":{"completion_chat":true,"function_calling":true,"ocr":false}},
+			{"id":"mistral-ocr-latest","capabilities":{"completion_chat":false,"ocr":true}},
+			{"id":"mistral-embed","capabilities":{"completion_chat":false,"ocr":false}},
+			{"id":"mistral-moderation-latest","capabilities":{"completion_chat":false,"moderation":true,"ocr":false}},
+			{"id":"codestral-embed","capabilities":{"completion_chat":false,"ocr":false}},
+			{"id":"invoice-ocr-extract","capabilities":{"completion_chat":true,"ocr":false}}
+		]}`))
+	}))
+	defer srv.Close()
+
+	p := Provider{SDK: SDKMistral, BaseURL: srv.URL + "/v1", APIKey: "test-key"}
+	ocr, err := ListModels(t.Context(), p, true, srv.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ocr) != 1 || ocr[0].ID != "mistral-ocr-latest" {
+		t.Fatalf("ocr catalog=%+v", ocr)
+	}
+
+	llm, err := ListModels(t.Context(), p, false, srv.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(llm) != 2 {
+		t.Fatalf("llm catalog len=%d want 2: %+v", len(llm), llm)
+	}
+	if llm[0].ID != "mistral-small-latest" || llm[1].ID != "invoice-ocr-extract" {
+		t.Fatalf("llm catalog=%+v", llm)
+	}
+}
+
+func TestListModelsMistralFallsBackToOCRSubstring(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/models" {
@@ -141,20 +181,25 @@ func TestListModelsMistralOCRFiltersByOCRSubstring(t *testing.T) {
 	}
 }
 
-func TestFilterModelsBySubstring(t *testing.T) {
+func TestFilterMistralModelsMixesCapabilitiesAndSubstringFallback(t *testing.T) {
 	t.Parallel()
 	in := []Model{
-		{ID: "mistral-ocr-latest", Name: "mistral-ocr-latest"},
+		{ID: "mistral-ocr-latest", Name: "mistral-ocr-latest", caps: &modelCapabilities{ocr: true}},
+		{ID: "mistral-embed", Name: "mistral-embed", caps: &modelCapabilities{}},
+		{ID: "invoice-ocr-extract", Name: "invoice-ocr-extract", caps: &modelCapabilities{completionChat: true}},
+		{ID: "legacy-ocr", Name: "legacy-ocr"},
 		{ID: "codestral-latest", Name: "codestral-latest"},
-		{ID: "other", Name: "Has OCR in name"},
+		{ID: "named", Name: "Has OCR in name"},
 	}
-	got := filterModelsBySubstring(in, "ocr")
-	if len(got) != 2 || got[0].ID != "mistral-ocr-latest" || got[1].ID != "other" {
-		t.Fatalf("got %+v", got)
+
+	ocr := filterMistralModels(in, true)
+	if len(ocr) != 3 || ocr[0].ID != "mistral-ocr-latest" || ocr[1].ID != "legacy-ocr" || ocr[2].ID != "named" {
+		t.Fatalf("ocr=%+v", ocr)
 	}
-	rejected := rejectModelsBySubstring(in, "ocr")
-	if len(rejected) != 1 || rejected[0].ID != "codestral-latest" {
-		t.Fatalf("rejected %+v", rejected)
+
+	llm := filterMistralModels(in, false)
+	if len(llm) != 2 || llm[0].ID != "invoice-ocr-extract" || llm[1].ID != "codestral-latest" {
+		t.Fatalf("llm=%+v", llm)
 	}
 }
 

--- a/backend/internal/aiprovider/sdk.go
+++ b/backend/internal/aiprovider/sdk.go
@@ -24,7 +24,7 @@ func ValidSDK(sdk string) bool {
 
 func IsLLM(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKOpenAI, SDKOpenRouter:
+	case SDKOpenAI, SDKOpenRouter, SDKMistral:
 		return true
 	default:
 		return false
@@ -57,7 +57,7 @@ func DefaultAlias(sdk string) string {
 	case SDKGoogleVision:
 		return "Google Cloud Vision"
 	case SDKMistral:
-		return "Mistral OCR"
+		return "Mistral"
 	default:
 		return sdk
 	}

--- a/backend/internal/aiprovider/sdk_test.go
+++ b/backend/internal/aiprovider/sdk_test.go
@@ -12,3 +12,20 @@ func TestChatCompletionsURL(t *testing.T) {
 		t.Fatalf("default ChatCompletionsURL() = %q", got)
 	}
 }
+
+func TestIsLLM(t *testing.T) {
+	t.Parallel()
+	if !IsLLM(SDKOpenAI) || !IsLLM(SDKOpenRouter) || !IsLLM(SDKMistral) {
+		t.Fatal("openai, openrouter, and mistral should be LLM SDKs")
+	}
+	if IsLLM(SDKGoogleVision) || IsLLM("unknown") {
+		t.Fatal("google_vision and unknown should not be LLM SDKs")
+	}
+}
+
+func TestDefaultAlias(t *testing.T) {
+	t.Parallel()
+	if got := DefaultAlias(SDKMistral); got != "Mistral" {
+		t.Fatalf("DefaultAlias(mistral) = %q", got)
+	}
+}

--- a/backend/internal/aiprovider/seed.go
+++ b/backend/internal/aiprovider/seed.go
@@ -69,33 +69,36 @@ func MigrateLegacySettings(app core.App, settings *core.Record) error {
 	}
 
 	models := taskModels{
-		extract: firstNonEmpty(settings.GetString("openai_model"), "gpt-4o-mini"),
-		chat:    strings.TrimSpace(settings.GetString("openai_chat_model")),
-		search:  strings.TrimSpace(settings.GetString("openai_search_model")),
-		ocr:     firstNonEmpty(settings.GetString("mistral_ocr_model"), "mistral-ocr-latest"),
-		ocrSDK:  firstNonEmpty(settings.GetString("ocr_provider"), "google_vision"),
+		extract:    firstNonEmpty(settings.GetString("openai_model"), "gpt-4o-mini"),
+		chat:       strings.TrimSpace(settings.GetString("openai_chat_model")),
+		search:     strings.TrimSpace(settings.GetString("openai_search_model")),
+		ocr:        firstNonEmpty(settings.GetString("mistral_ocr_model"), "mistral-ocr-latest"),
+		ocrSDK:     firstNonEmpty(settings.GetString("ocr_provider"), "google_vision"),
+		mistralLLM: "mistral-small-latest",
 	}
 	bindFromIDs(settings, openaiID, mistralID, googleID, models)
 	return nil
 }
 
 type taskModels struct {
-	extract string
-	chat    string
-	search  string
-	ocr     string
-	ocrSDK  string
+	extract    string
+	chat       string
+	search     string
+	ocr        string
+	ocrSDK     string
+	mistralLLM string
 }
 
 func envTaskModels() taskModels {
 	extract := getenv("OPENAI_MODEL", "gpt-4o-mini")
 	chat := getenv("OPENAI_CHAT_MODEL", extract)
 	return taskModels{
-		extract: extract,
-		chat:    chat,
-		search:  getenv("OPENAI_SEARCH_MODEL", chat),
-		ocr:     getenv("MISTRAL_OCR_MODEL", "mistral-ocr-latest"),
-		ocrSDK:  getenv("OCR_PROVIDER", "google_vision"),
+		extract:    extract,
+		chat:       chat,
+		search:     getenv("OPENAI_SEARCH_MODEL", chat),
+		ocr:        getenv("MISTRAL_OCR_MODEL", "mistral-ocr-latest"),
+		ocrSDK:     getenv("OCR_PROVIDER", "google_vision"),
+		mistralLLM: getenv("MISTRAL_MODEL", "mistral-small-latest"),
 	}
 }
 
@@ -125,21 +128,28 @@ func bindFromIDs(settings *core.Record, openaiID, mistralID, googleID string, mo
 	}
 
 	if openaiID != "" {
-		settings.Set("extract_provider_id", openaiID)
-		settings.Set("extract_model", models.extract)
-		chatModel := models.chat
-		if chatModel == "" {
-			chatModel = models.extract
-		}
-		settings.Set("chat_provider_id", openaiID)
-		settings.Set("chat_model", chatModel)
-		searchModel := models.search
-		if searchModel == "" {
-			searchModel = chatModel
-		}
-		settings.Set("search_provider_id", openaiID)
-		settings.Set("search_model", searchModel)
+		bindLLM(settings, openaiID, models.extract, models.chat, models.search)
+	} else if mistralID != "" {
+		model := firstNonEmpty(models.mistralLLM, "mistral-small-latest")
+		bindLLM(settings, mistralID, model, model, model)
 	}
+}
+
+func bindLLM(settings *core.Record, providerID, extract, chat, search string) {
+	settings.Set("extract_provider_id", providerID)
+	settings.Set("extract_model", extract)
+	chatModel := chat
+	if chatModel == "" {
+		chatModel = extract
+	}
+	settings.Set("chat_provider_id", providerID)
+	settings.Set("chat_model", chatModel)
+	searchModel := search
+	if searchModel == "" {
+		searchModel = chatModel
+	}
+	settings.Set("search_provider_id", providerID)
+	settings.Set("search_model", searchModel)
 }
 
 func alreadyBound(settings *core.Record) bool {

--- a/backend/internal/appapi/providers.go
+++ b/backend/internal/appapi/providers.go
@@ -127,7 +127,7 @@ func handlePatchProvider(app core.App, rt *config.Runtime) func(*core.RequestEve
 				if settings, err := config.FindSettingsRecord(app); err == nil {
 					for _, field := range []string{"extract_provider_id", "chat_provider_id", "search_provider_id"} {
 						if strings.TrimSpace(settings.GetString(field)) == record.Id {
-							return writeError(e, http.StatusConflict, "Provider is bound to extraction, chat, or search and must stay openai or openrouter.")
+							return writeError(e, http.StatusConflict, "Provider is bound to extraction, chat, or search and must stay an LLM SDK (openai, openrouter, or mistral).")
 						}
 					}
 				}

--- a/backend/internal/appapi/settings.go
+++ b/backend/internal/appapi/settings.go
@@ -226,7 +226,7 @@ func validateProviderID(app core.App, id string, llmOnly bool) error {
 		return errInvalid("unknown provider")
 	}
 	if llmOnly && !aiprovider.IsLLM(p.SDK) {
-		return errInvalid("extraction, chat, and search require an openai or openrouter provider")
+		return errInvalid("extraction, chat, and search require an openai, openrouter, or mistral provider")
 	}
 	return nil
 }

--- a/backend/internal/appapi/setup_test.go
+++ b/backend/internal/appapi/setup_test.go
@@ -67,6 +67,23 @@ func TestNeedsConfigSetup(t *testing.T) {
 				OCRProvider:     google,
 				ExtractProvider: mistral,
 			},
+			want: false,
+		},
+		{
+			name: "ready mistral only",
+			cfg: config.Config{
+				OCRProvider:     mistral,
+				OCRModel:        "mistral-ocr-latest",
+				ExtractProvider: mistral,
+			},
+			want: false,
+		},
+		{
+			name: "google used as llm",
+			cfg: config.Config{
+				OCRProvider:     google,
+				ExtractProvider: google,
+			},
 			want: true,
 		},
 	}

--- a/docs/development.md
+++ b/docs/development.md
@@ -67,12 +67,13 @@ These seed `app_settings` and `ai_providers` when the singleton record does not 
 | --- | --- | --- |
 | `OCR_PROVIDER` | `google_vision` | Which env-seeded provider to bind for OCR (`google_vision`, `mistral`, `openai`, `openrouter`) |
 | `GOOGLE_VISION_API_KEY` | empty | Seeds a Google Cloud Vision provider |
-| `MISTRAL_API_KEY` | empty | Seeds a Mistral OCR provider |
+| `MISTRAL_API_KEY` | empty | Seeds a Mistral provider (OCR + chat completions) |
 | `MISTRAL_OCR_MODEL` | `mistral-ocr-latest` | OCR model when seeding Mistral |
+| `MISTRAL_MODEL` | `mistral-small-latest` | Chat model when Mistral is the only LLM (no `OPENAI_API_KEY`) |
 | `MISTRAL_API_BASE_URL` | `https://api.mistral.ai/v1` | Mistral API base URL |
 | `OCR_TIMEOUT_SEC` | `40` | OCR request timeout |
 | `PROCESSING_RESULT_LANGUAGE` | empty | ISO 639-1 code (e.g. `en`, `de`). When set, `title`, `summary`, `purpose`, and `document_type` are stored in this language; originals go in `*_original` fields. |
-| `OPENAI_API_KEY` | empty | Seeds an OpenAI-compatible provider (used for extraction, chat, search, and optional LLM OCR) |
+| `OPENAI_API_KEY` | empty | Seeds an OpenAI-compatible provider (used for extraction, chat, search, and optional LLM OCR). If unset, a seeded Mistral provider is bound for those tasks instead. |
 | `OPENAI_MODEL` | `gpt-4o-mini` | Model ID for metadata extraction |
 | `OPENAI_CHAT_MODEL` | `OPENAI_MODEL` | Optional model ID for document chat |
 | `OPENAI_SEARCH_MODEL` | `OPENAI_CHAT_MODEL` | Optional model ID for Deep Search |
@@ -123,14 +124,16 @@ Browse them in PocketBase Admin as a superuser. Enable SMTP when you want real d
 
 Text extraction:
 
-- **PDF and images** — configured OCR provider (Google Vision, Mistral OCR, or an OpenAI/OpenRouter model that accepts files/images)
+- **PDF and images** — configured OCR provider (Google Vision, Mistral Document OCR, or an OpenAI/OpenRouter model that accepts files/images)
 - **TXT, CSV, DOCX, XLSX** — native parsers (no OCR API call); preview is skipped for these formats
 
 Cron jobs are visible and manually triggerable in PocketBase Admin → Settings → Crons.
 
-## OpenAI / OpenRouter setup
+## LLM setup (OpenAI / OpenRouter / Mistral)
 
-Prefer **Settings** in the UI (admin): add a provider with SDK `openai` or `openrouter`, then select it for extraction, chat, and search. For a fresh install you can also put `OPENAI_API_KEY` (and optional model/base URL) in `.env` so they seed an `ai_providers` row on first boot.
+Prefer **Settings** in the UI (admin): add a provider with SDK `openai`, `openrouter`, or `mistral`, then select it for extraction, chat, and search. Mistral uses the same [OpenAI-compatible chat completions](https://docs.mistral.ai/api) endpoint as the other LLMs (`/v1/chat/completions`); OCR still uses Mistral’s dedicated Document OCR API.
+
+For a fresh install you can put `OPENAI_API_KEY` and/or `MISTRAL_API_KEY` in `.env` so they seed `ai_providers` rows on first boot. If both are set, OpenAI is bound for LLM tasks and Mistral can still be chosen in Settings. If only Mistral is set, it is bound for extraction, chat, and search using `MISTRAL_MODEL` (default `mistral-small-latest`).
 
 Without an LLM provider, AI extraction, document chat, and Deep Search return a configuration error.
 
@@ -138,7 +141,7 @@ Deep Search (`/search`) uses a tool-calling agent over keyword search. Configure
 
 ## OCR setup
 
-Add an OCR-capable provider in **Settings** (or seed via `.env` on first boot), then bind it under **Models**. OpenRouter OCR lists only models that advertise `file` input. Other SDKs show the full catalog with a warning to choose a file-capable model.
+Add an OCR-capable provider in **Settings** (or seed via `.env` on first boot), then bind it under **Models**. OpenRouter OCR lists only models that advertise `file` input. Mistral OCR lists models whose ids contain `ocr`. Other SDKs show the full catalog with a warning to choose a file-capable model.
 
 ### Google Cloud Vision
 
@@ -151,7 +154,7 @@ See [docs/google_vision.md](google_vision.md) for obtaining a Google API key.
 
 ### Mistral OCR
 
-Uses the [Mistral Document OCR API](https://docs.mistral.ai/en/studio-api/document-processing/basic_ocr). Local files are sent as base64 data URLs (up to 10 MB).
+Uses the [Mistral Document OCR API](https://docs.mistral.ai/en/studio-api/document-processing/basic_ocr) when the provider is bound for OCR. Local files are sent as base64 data URLs (up to 10 MB). The same provider can be bound for extraction, chat, and search (chat completions, not this OCR endpoint).
 
 - **PDFs and office documents** — `document_url` with a base64 data URL
 - **Images** — `image_url` with a base64 data URL
@@ -226,9 +229,9 @@ Import fetches only the caller-supplied URL. Private, loopback, and link-local d
 
 ## Troubleshooting
 
-- **Stuck on setup wizard:** create the admin account and add an OCR provider plus an OpenAI-compatible provider (or seed keys in `.env` before first boot / use `superuser upsert`). Clearing required keys later brings the config steps back for admins.
+- **Stuck on setup wizard:** create the admin account and add an OCR provider plus an LLM provider (OpenAI, OpenRouter, or Mistral — or seed keys in `.env` before first boot / use `superuser upsert`). Clearing required keys later brings the config steps back for admins.
 - **Upload succeeds but stays pending:** ensure the backend server is running; the worker starts with `serve`.
 - **OCR fails:** configure the OCR provider and API key in Settings (or seed `.env` before first boot). For Google Vision, ensure the Vision API is enabled for your project.
-- **AI extraction fails:** configure OpenAI settings in Settings. Check the processing job error on the document detail page.
+- **AI extraction fails:** configure an LLM provider (OpenAI, OpenRouter, or Mistral) in Settings. Check the processing job error on the document detail page.
 - **Settings page missing:** log in with the admin email (the account created at setup / `superuser upsert`). Regular non-admin users do not see Settings.
 - **Auth errors in frontend:** delete PocketBase data dir (`backend/pb_data`) and restart to recreate collections, then reload the app.

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -19,6 +19,7 @@ test('superuser can load and save settings', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Models' })).toBeVisible()
   const extractionModel = page.getByLabel('Extraction model')
   await expect(extractionModel.locator('option[value="e2e-mock"]')).toHaveCount(1, { timeout: 15_000 })
+  await expect(page.getByLabel('Extraction provider').locator('option', { hasText: 'Mistral' })).toHaveCount(1)
   await extractionModel.selectOption('e2e-mock-updated')
   await page.getByRole('button', { name: 'Save settings' }).click()
   await expect(page.getByText('Settings saved. Runtime reloaded.')).toBeVisible({ timeout: 15_000 })

--- a/frontend/src/components/ProviderModelFields.tsx
+++ b/frontend/src/components/ProviderModelFields.tsx
@@ -21,7 +21,7 @@ export function showsOCRModelWarning(sdk?: string) {
 }
 
 export function isLLMProvider(sdk: string) {
-  return sdk === 'openai' || sdk === 'openrouter'
+  return sdk === 'openai' || sdk === 'openrouter' || sdk === 'mistral'
 }
 
 export function sdkLabel(sdk: ProviderSDK | string) {
@@ -33,7 +33,7 @@ export function sdkLabel(sdk: ProviderSDK | string) {
     case 'google_vision':
       return 'Google Cloud Vision'
     case 'mistral':
-      return 'Mistral OCR'
+      return 'Mistral'
     default:
       return sdk
   }

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -162,7 +162,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
         throw new Error('Choose an OCR provider.')
       }
       if (!extractProviderId) {
-        throw new Error('Choose an extraction provider (OpenAI or OpenRouter).')
+        throw new Error('Choose an extraction provider (OpenAI, OpenRouter, or Mistral).')
       }
       await updateAppSettings({
         ocr_provider_id: ocrProviderId,
@@ -175,7 +175,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
         if (!next.has_ocr || !next.has_llm) {
           setStep(next.provider_count ? 'models' : 'providers')
         }
-        setError('Setup is still incomplete. Add an OCR provider and an OpenAI-compatible provider.')
+        setError('Setup is still incomplete. Add an OCR provider and an LLM provider (OpenAI, OpenRouter, or Mistral).')
         return
       }
       setStep('done')
@@ -272,8 +272,8 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
           {step === 'providers' && (
             <form className="flex flex-col gap-4" onSubmit={onSaveProvider}>
               <p className="text-sm text-stone-600">
-                Add an API provider. OpenAI or OpenRouter is required for extraction and chat; Google
-                Vision or Mistral can be used for OCR.
+                Add an API provider. OpenAI, OpenRouter, or Mistral can run extraction and chat;
+                Google Vision or Mistral OCR can run OCR. One Mistral provider covers both.
               </p>
               {providers.length > 0 && (
                 <p className="text-xs text-stone-500">
@@ -293,7 +293,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
                 >
                   <option value="openai">OpenAI</option>
                   <option value="openrouter">OpenRouter</option>
-                  <option value="mistral">Mistral OCR</option>
+                  <option value="mistral">Mistral</option>
                   <option value="google_vision">Google Cloud Vision</option>
                 </select>
               </label>
@@ -347,7 +347,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
               </p>
               {llmProviders.length === 0 && (
                 <p className="text-sm text-amber-800">
-                  Add an OpenAI or OpenRouter provider to enable extraction and chat.
+                  Add an OpenAI, OpenRouter, or Mistral provider to enable extraction and chat.
                 </p>
               )}
               <ProviderModelFields

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -360,7 +360,7 @@ export function SettingsPage() {
               >
                 <option value="openai">OpenAI</option>
                 <option value="openrouter">OpenRouter</option>
-                <option value="mistral">Mistral OCR</option>
+                <option value="mistral">Mistral</option>
                 <option value="google_vision">Google Cloud Vision</option>
               </select>
             </label>


### PR DESCRIPTION
## Summary
- Treat the existing `mistral` SDK as a full LLM provider for extraction, chat, and search (OpenAI-compatible `/v1/chat/completions`), while OCR still uses Mistral’s Document OCR API.
- Settings, setup wizard, and first-boot seed now allow a single Mistral key to cover both OCR and metadata extraction (`MISTRAL_MODEL`, default `mistral-small-latest` when no OpenAI key is seeded).
- OCR model pickers keep `*ocr*` models; LLM pickers hide them.

Fixes #23

## Test plan
- [x] Backend unit tests
- [x] API e2e (`TestAppMistralLLMProvider` binds Mistral for extract/chat and runs pipeline + chat)
- [x] Playwright e2e (Settings extraction provider lists Mistral)
- [ ] In Settings, add/select a Mistral provider for extraction, chat, and search; confirm OCR still uses an OCR model
- [ ] Fresh install with only `MISTRAL_API_KEY` completes setup without OpenAI/OpenRouter