### PR TITLE
Omit custom temperature for GPT-5 models

### DIFF
--- a/backend/internal/ai/chat.go
+++ b/backend/internal/ai/chat.go
@@ -61,7 +61,7 @@ func (c *OpenAIClient) Chat(ctx context.Context, ocrText string, messages []Chat
 	chatResp, err := c.complete(ctx, openai.ChatCompletionNewParams{
 		Model:       shared.ChatModel(c.model),
 		Messages:    apiMessages,
-		Temperature: completionTemperature(c.model, 0.3),
+		Temperature: CompletionTemperature(c.model, 0.3),
 	}, "purpose", "chat", "messages", len(apiMessages))
 	if err != nil {
 		c.logger.Error("chat request failed",

--- a/backend/internal/ai/chat.go
+++ b/backend/internal/ai/chat.go
@@ -61,7 +61,7 @@ func (c *OpenAIClient) Chat(ctx context.Context, ocrText string, messages []Chat
 	chatResp, err := c.complete(ctx, openai.ChatCompletionNewParams{
 		Model:       shared.ChatModel(c.model),
 		Messages:    apiMessages,
-		Temperature: openai.Float(0.3),
+		Temperature: completionTemperature(c.model, 0.3),
 	}, "purpose", "chat", "messages", len(apiMessages))
 	if err != nil {
 		c.logger.Error("chat request failed",

--- a/backend/internal/ai/extract.go
+++ b/backend/internal/ai/extract.go
@@ -76,7 +76,7 @@ func (c *OpenAIClient) ExtractMetadata(ctx context.Context, ocrText string) (*mo
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
 		},
-		Temperature: openai.Float(0.1),
+		Temperature: completionTemperature(c.model, 0.1),
 	}, "purpose", "extract", "messages", 2)
 	if err != nil {
 		c.logger.Error("request failed",

--- a/backend/internal/ai/extract.go
+++ b/backend/internal/ai/extract.go
@@ -76,7 +76,7 @@ func (c *OpenAIClient) ExtractMetadata(ctx context.Context, ocrText string) (*mo
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
 		},
-		Temperature: completionTemperature(c.model, 0.1),
+		Temperature: CompletionTemperature(c.model, 0.1),
 	}, "purpose", "extract", "messages", 2)
 	if err != nil {
 		c.logger.Error("request failed",

--- a/backend/internal/ai/extract_test.go
+++ b/backend/internal/ai/extract_test.go
@@ -30,12 +30,12 @@ const extractTestJSON = `{
 
 func TestCompletionTemperature(t *testing.T) {
 	t.Parallel()
-	if CompletionTemperature("gpt-5-mini", 0.1).Valid() {
-		t.Fatal("gpt-5-mini should omit temperature")
+	if CompletionTemperature("gpt-5.6-luna", 0.1).Valid() {
+		t.Fatal("gpt-5.6-luna should omit temperature")
 	}
-	got := CompletionTemperature("gpt-4o-mini", 0.1)
+	got := CompletionTemperature("mistral-small-latest", 0.1)
 	if !got.Valid() || got.Value != 0.1 {
-		t.Fatalf("gpt-4o-mini temperature = %+v, want 0.1", got)
+		t.Fatalf("mistral-small-latest temperature = %+v, want 0.1", got)
 	}
 }
 
@@ -60,17 +60,17 @@ func TestIsUnsupportedTemperatureError(t *testing.T) {
 
 func TestExtractMetadataOmitsTemperatureForGPT5(t *testing.T) {
 	t.Parallel()
-	body := captureChatBody(t, "gpt-5-mini")
+	body := captureChatBody(t, "gpt-5.6-luna")
 	if strings.Contains(body, `"temperature"`) {
-		t.Fatalf("gpt-5-mini request should omit temperature, got %s", body)
+		t.Fatalf("gpt-5.6-luna request should omit temperature, got %s", body)
 	}
 }
 
-func TestExtractMetadataSendsTemperatureForGPT4o(t *testing.T) {
+func TestExtractMetadataSendsTemperatureForMistral(t *testing.T) {
 	t.Parallel()
-	body := captureChatBody(t, "gpt-4o-mini")
+	body := captureChatBody(t, "mistral-small-latest")
 	if !strings.Contains(body, `"temperature"`) {
-		t.Fatalf("gpt-4o-mini request should include temperature, got %s", body)
+		t.Fatalf("mistral-small-latest request should include temperature, got %s", body)
 	}
 }
 
@@ -93,7 +93,7 @@ func TestExtractMetadataRetriesWithoutTemperature(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	client := NewOpenAIClient("openai", "test-key", "gpt-4o-mini", srv.URL, "v1", "", 5*time.Second, slog.Default())
+	client := NewOpenAIClient("openai", "test-key", "mistral-small-latest", srv.URL, "v1", "", 5*time.Second, slog.Default())
 	meta, err := client.ExtractMetadata(context.Background(), "Invoice from Acme")
 	if err != nil {
 		t.Fatalf("ExtractMetadata: %v", err)

--- a/backend/internal/ai/extract_test.go
+++ b/backend/internal/ai/extract_test.go
@@ -30,10 +30,10 @@ const extractTestJSON = `{
 
 func TestCompletionTemperature(t *testing.T) {
 	t.Parallel()
-	if completionTemperature("gpt-5-mini", 0.1).Valid() {
+	if CompletionTemperature("gpt-5-mini", 0.1).Valid() {
 		t.Fatal("gpt-5-mini should omit temperature")
 	}
-	got := completionTemperature("gpt-4o-mini", 0.1)
+	got := CompletionTemperature("gpt-4o-mini", 0.1)
 	if !got.Valid() || got.Value != 0.1 {
 		t.Fatalf("gpt-4o-mini temperature = %+v, want 0.1", got)
 	}

--- a/backend/internal/ai/extract_test.go
+++ b/backend/internal/ai/extract_test.go
@@ -1,0 +1,148 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+)
+
+const extractTestJSON = `{
+  "title": "Invoice",
+  "purpose": "Pay",
+  "document_date": "2024-07-15",
+  "document_type": "Invoice",
+  "correspondent": "Acme",
+  "tags": ["invoice"],
+  "people_or_organizations": ["Acme"],
+  "summary": "Invoice from Acme.",
+  "confidence": 0.9
+}`
+
+func TestCompletionTemperature(t *testing.T) {
+	t.Parallel()
+	if completionTemperature("gpt-5-mini", 0.1).Valid() {
+		t.Fatal("gpt-5-mini should omit temperature")
+	}
+	got := completionTemperature("gpt-4o-mini", 0.1)
+	if !got.Valid() || got.Value != 0.1 {
+		t.Fatalf("gpt-4o-mini temperature = %+v, want 0.1", got)
+	}
+}
+
+func TestIsUnsupportedTemperatureError(t *testing.T) {
+	t.Parallel()
+	if isUnsupportedTemperatureError(nil) {
+		t.Fatal("nil should not match")
+	}
+	if isUnsupportedTemperatureError(errors.New("rate limited")) {
+		t.Fatal("unrelated error should not match")
+	}
+	apiErr := &openai.Error{
+		Param:   "temperature",
+		Message: "Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.",
+		Type:    "invalid_request_error",
+		Code:    "unsupported_value",
+	}
+	if !isUnsupportedTemperatureError(apiErr) {
+		t.Fatal("openai temperature error should match")
+	}
+}
+
+func TestExtractMetadataOmitsTemperatureForGPT5(t *testing.T) {
+	t.Parallel()
+	body := captureChatBody(t, "gpt-5-mini")
+	if strings.Contains(body, `"temperature"`) {
+		t.Fatalf("gpt-5-mini request should omit temperature, got %s", body)
+	}
+}
+
+func TestExtractMetadataSendsTemperatureForGPT4o(t *testing.T) {
+	t.Parallel()
+	body := captureChatBody(t, "gpt-4o-mini")
+	if !strings.Contains(body, `"temperature"`) {
+		t.Fatalf("gpt-4o-mini request should include temperature, got %s", body)
+	}
+}
+
+func TestExtractMetadataRetriesWithoutTemperature(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	var firstBody, secondBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		n := calls.Add(1)
+		if n == 1 {
+			firstBody = string(raw)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.","type":"invalid_request_error","param":"temperature","code":"unsupported_value"}}`))
+			return
+		}
+		secondBody = string(raw)
+		writeChatJSON(w, extractTestJSON)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewOpenAIClient("openai", "test-key", "gpt-4o-mini", srv.URL, "v1", "", 5*time.Second, slog.Default())
+	meta, err := client.ExtractMetadata(context.Background(), "Invoice from Acme")
+	if err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	if meta.Title != "Invoice" {
+		t.Fatalf("title = %q", meta.Title)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2", calls.Load())
+	}
+	if !strings.Contains(firstBody, `"temperature"`) {
+		t.Fatalf("first request should include temperature, got %s", firstBody)
+	}
+	if strings.Contains(secondBody, `"temperature"`) {
+		t.Fatalf("retry should omit temperature, got %s", secondBody)
+	}
+}
+
+func captureChatBody(t *testing.T, model string) string {
+	t.Helper()
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		body = string(raw)
+		writeChatJSON(w, extractTestJSON)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewOpenAIClient("openai", "test-key", model, srv.URL, "v1", "", 5*time.Second, slog.Default())
+	if _, err := client.ExtractMetadata(context.Background(), "Invoice from Acme"); err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	return body
+}
+
+func writeChatJSON(w http.ResponseWriter, content string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":      "chatcmpl-test",
+		"object":  "chat.completion",
+		"created": 1,
+		"model":   "test",
+		"choices": []map[string]any{{
+			"index": 0,
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": content,
+			},
+			"finish_reason": "stop",
+		}},
+	})
+}

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/param"
 	"paperless-go/backend/internal/aiprovider"
 )
 
@@ -69,7 +70,24 @@ func (c *OpenAIClient) complete(ctx context.Context, params openai.ChatCompletio
 		string(params.Model),
 		extra...,
 	)
-	return c.client.Chat.Completions.New(ctx, params)
+	resp, err := c.client.Chat.Completions.New(ctx, params)
+	if err != nil && params.Temperature.Valid() && isUnsupportedTemperatureError(err) {
+		c.logger.Warn("model rejected temperature; retrying with API default",
+			"model", params.Model,
+			slog.Any("error", err),
+		)
+		params.Temperature = param.Opt[float64]{}
+		aiprovider.LogRequest(
+			c.logger,
+			c.sdk,
+			http.MethodPost,
+			aiprovider.ChatCompletionsURL(c.baseURL),
+			string(params.Model),
+			append(extra, "retry", "omit_temperature")...,
+		)
+		return c.client.Chat.Completions.New(ctx, params)
+	}
+	return resp, err
 }
 
 func (c *OpenAIClient) PromptVersion() string {

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -62,30 +62,39 @@ func (c *OpenAIClient) Model() string {
 }
 
 func (c *OpenAIClient) complete(ctx context.Context, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
+	return CompleteChat(ctx, c.client, c.logger, c.sdk, c.baseURL, params, extra...)
+}
+
+// CompleteChat sends a chat completion and retries once without temperature
+// if the model rejects a custom value.
+func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger, sdk, baseURL string, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	aiprovider.LogRequest(
-		c.logger,
-		c.sdk,
+		logger,
+		sdk,
 		http.MethodPost,
-		aiprovider.ChatCompletionsURL(c.baseURL),
+		aiprovider.ChatCompletionsURL(baseURL),
 		string(params.Model),
 		extra...,
 	)
-	resp, err := c.client.Chat.Completions.New(ctx, params)
+	resp, err := client.Chat.Completions.New(ctx, params)
 	if err != nil && params.Temperature.Valid() && isUnsupportedTemperatureError(err) {
-		c.logger.Warn("model rejected temperature; retrying with API default",
+		logger.Warn("model rejected temperature; retrying with API default",
 			"model", params.Model,
 			slog.Any("error", err),
 		)
 		params.Temperature = param.Opt[float64]{}
 		aiprovider.LogRequest(
-			c.logger,
-			c.sdk,
+			logger,
+			sdk,
 			http.MethodPost,
-			aiprovider.ChatCompletionsURL(c.baseURL),
+			aiprovider.ChatCompletionsURL(baseURL),
 			string(params.Model),
 			append(extra, "retry", "omit_temperature")...,
 		)
-		return c.client.Chat.Completions.New(ctx, params)
+		return client.Chat.Completions.New(ctx, params)
 	}
 	return resp, err
 }

--- a/backend/internal/ai/search.go
+++ b/backend/internal/ai/search.go
@@ -110,7 +110,7 @@ func (a *openAISearchAgent) Search(ctx context.Context, messages []ChatMessage, 
 		params := openai.ChatCompletionNewParams{
 			Model:       shared.ChatModel(a.client.model),
 			Messages:    apiMessages,
-			Temperature: openai.Float(0.2),
+			Temperature: completionTemperature(a.client.model, 0.2),
 		}
 		if allowTools {
 			params.Tools = tools
@@ -214,7 +214,7 @@ If nothing relevant was found, say so clearly.`,
 	chatResp, err := a.client.complete(ctx, openai.ChatCompletionNewParams{
 		Model:       shared.ChatModel(a.client.model),
 		Messages:    msgs,
-		Temperature: openai.Float(0.2),
+		Temperature: completionTemperature(a.client.model, 0.2),
 	}, "purpose", "search_final", "messages", len(msgs))
 	if err != nil {
 		a.client.logger.Error("search agent force-final failed",

--- a/backend/internal/ai/search.go
+++ b/backend/internal/ai/search.go
@@ -110,7 +110,7 @@ func (a *openAISearchAgent) Search(ctx context.Context, messages []ChatMessage, 
 		params := openai.ChatCompletionNewParams{
 			Model:       shared.ChatModel(a.client.model),
 			Messages:    apiMessages,
-			Temperature: completionTemperature(a.client.model, 0.2),
+			Temperature: CompletionTemperature(a.client.model, 0.2),
 		}
 		if allowTools {
 			params.Tools = tools
@@ -214,7 +214,7 @@ If nothing relevant was found, say so clearly.`,
 	chatResp, err := a.client.complete(ctx, openai.ChatCompletionNewParams{
 		Model:       shared.ChatModel(a.client.model),
 		Messages:    msgs,
-		Temperature: completionTemperature(a.client.model, 0.2),
+		Temperature: CompletionTemperature(a.client.model, 0.2),
 	}, "purpose", "search_final", "messages", len(msgs))
 	if err != nil {
 		a.client.logger.Error("search agent force-final failed",

--- a/backend/internal/ai/temperature.go
+++ b/backend/internal/ai/temperature.go
@@ -9,7 +9,7 @@ import (
 	"paperless-go/backend/internal/aiprovider"
 )
 
-func completionTemperature(model string, value float64) param.Opt[float64] {
+func CompletionTemperature(model string, value float64) param.Opt[float64] {
 	if !aiprovider.AllowsCustomTemperature(model) {
 		return param.Opt[float64]{}
 	}

--- a/backend/internal/ai/temperature.go
+++ b/backend/internal/ai/temperature.go
@@ -1,0 +1,36 @@
+package ai
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+	"paperless-go/backend/internal/aiprovider"
+)
+
+func completionTemperature(model string, value float64) param.Opt[float64] {
+	if !aiprovider.AllowsCustomTemperature(model) {
+		return param.Opt[float64]{}
+	}
+	return openai.Float(value)
+}
+
+func isUnsupportedTemperatureError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *openai.Error
+	if errors.As(err, &apiErr) {
+		if strings.EqualFold(strings.TrimSpace(apiErr.Param), "temperature") {
+			return true
+		}
+		msg := strings.ToLower(apiErr.Message)
+		if strings.Contains(msg, "temperature") && strings.Contains(msg, "unsupported") {
+			return true
+		}
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "temperature") &&
+		(strings.Contains(msg, "does not support") || strings.Contains(msg, "unsupported"))
+}

--- a/backend/internal/aiprovider/models_test.go
+++ b/backend/internal/aiprovider/models_test.go
@@ -26,14 +26,14 @@ func TestModelsURLOpenAIOCRUnfiltered(t *testing.T) {
 
 func TestParseModelsResponse(t *testing.T) {
 	t.Parallel()
-	models, err := parseModelsResponse([]byte(`{"data":[{"id":"gpt-4o","name":"GPT-4o"},{"id":"other"},{"model":"skip-me"}]}`))
+	models, err := parseModelsResponse([]byte(`{"data":[{"id":"gpt-5.6-luna","name":"GPT-5.6 Luna"},{"id":"other"},{"model":"skip-me"}]}`))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(models) != 3 {
 		t.Fatalf("len=%d want 3: %+v", len(models), models)
 	}
-	if models[0].ID != "gpt-4o" || models[0].Name != "GPT-4o" {
+	if models[0].ID != "gpt-5.6-luna" || models[0].Name != "GPT-5.6 Luna" {
 		t.Fatalf("first=%+v", models[0])
 	}
 	if models[2].ID != "skip-me" {

--- a/backend/internal/aiprovider/seed.go
+++ b/backend/internal/aiprovider/seed.go
@@ -69,7 +69,7 @@ func MigrateLegacySettings(app core.App, settings *core.Record) error {
 	}
 
 	models := taskModels{
-		extract:    firstNonEmpty(settings.GetString("openai_model"), "gpt-4o-mini"),
+		extract:    firstNonEmpty(settings.GetString("openai_model"), "gpt-5.6-luna"),
 		chat:       strings.TrimSpace(settings.GetString("openai_chat_model")),
 		search:     strings.TrimSpace(settings.GetString("openai_search_model")),
 		ocr:        firstNonEmpty(settings.GetString("mistral_ocr_model"), "mistral-ocr-latest"),
@@ -90,7 +90,7 @@ type taskModels struct {
 }
 
 func envTaskModels() taskModels {
-	extract := getenv("OPENAI_MODEL", "gpt-4o-mini")
+	extract := getenv("OPENAI_MODEL", "gpt-5.6-luna")
 	chat := getenv("OPENAI_CHAT_MODEL", extract)
 	return taskModels{
 		extract:    extract,

--- a/backend/internal/aiprovider/temperature.go
+++ b/backend/internal/aiprovider/temperature.go
@@ -1,0 +1,38 @@
+package aiprovider
+
+import "strings"
+
+// AllowsCustomTemperature reports whether an OpenAI-compatible chat model
+// accepts a non-default temperature. GPT-5 and o-series reasoning models
+// only allow the API default (1); sending 0.1 causes a 400.
+func AllowsCustomTemperature(model string) bool {
+	name := canonicalChatModel(model)
+	if name == "" {
+		return true
+	}
+	if strings.HasPrefix(name, "gpt-5") {
+		return false
+	}
+	return !isOSeriesReasoningModel(name)
+}
+
+func canonicalChatModel(model string) string {
+	name := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	if strings.HasPrefix(name, "ft:") {
+		parts := strings.Split(name, ":")
+		if len(parts) >= 2 {
+			name = parts[1]
+		}
+	}
+	return name
+}
+
+func isOSeriesReasoningModel(name string) bool {
+	if len(name) < 2 || name[0] != 'o' || name[1] < '1' || name[1] > '9' {
+		return false
+	}
+	return len(name) == 2 || name[2] == '-' || name[2] == '.'
+}

--- a/backend/internal/aiprovider/temperature_test.go
+++ b/backend/internal/aiprovider/temperature_test.go
@@ -8,9 +8,9 @@ func TestAllowsCustomTemperature(t *testing.T) {
 		model string
 		want  bool
 	}{
-		{"gpt-4o-mini", true},
+		{"gpt-5.6-luna", false},
 		{"gpt-4.1", true},
-		{"openai/gpt-4o", true},
+		{"openai/gpt-5.6-luna", false},
 		{"mistral-small-latest", true},
 		{"gpt-5", false},
 		{"gpt-5-mini", false},

--- a/backend/internal/aiprovider/temperature_test.go
+++ b/backend/internal/aiprovider/temperature_test.go
@@ -1,0 +1,36 @@
+package aiprovider
+
+import "testing"
+
+func TestAllowsCustomTemperature(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-4o-mini", true},
+		{"gpt-4.1", true},
+		{"openai/gpt-4o", true},
+		{"mistral-small-latest", true},
+		{"gpt-5", false},
+		{"gpt-5-mini", false},
+		{"gpt-5-nano", false},
+		{"GPT-5-mini", false},
+		{"openai/gpt-5-mini", false},
+		{"gpt-5.2-chat-latest", false},
+		{"ft:gpt-5-mini:org:custom:abc", false},
+		{"o1", false},
+		{"o1-mini", false},
+		{"o3-mini", false},
+		{"openai/o4-mini", false},
+		{"o10-experimental", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			t.Parallel()
+			if got := AllowsCustomTemperature(tc.model); got != tc.want {
+				t.Fatalf("AllowsCustomTemperature(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -54,7 +54,7 @@ func DefaultsFromEnv() Config {
 	workerTimeoutSec, _ := strconv.Atoi(getEnv("WORKER_TIMEOUT_SEC", "300"))
 	maxRetries, _ := strconv.Atoi(getEnv("WORKER_MAX_RETRIES", "0"))
 
-	openAIModel := getEnv("OPENAI_MODEL", "gpt-4o-mini")
+	openAIModel := getEnv("OPENAI_MODEL", "gpt-5.6-luna")
 	chatModel := getEnv("OPENAI_CHAT_MODEL", openAIModel)
 
 	return Config{

--- a/backend/internal/ocr/llm.go
+++ b/backend/internal/ocr/llm.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
+	"paperless-go/backend/internal/ai"
 	"paperless-go/backend/internal/aiprovider"
 )
 
@@ -82,18 +83,15 @@ func (p *LLMProvider) ExtractText(ctx context.Context, filePath string, mimeType
 		"bytes", len(data),
 	)
 
-	aiprovider.LogRequest(p.logger, p.sdk, http.MethodPost, aiprovider.ChatCompletionsURL(p.baseURL), p.model, "purpose", "ocr", "messages", 2)
 	ocrParams := openai.ChatCompletionNewParams{
 		Model: shared.ChatModel(p.model),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage("You transcribe documents for an archive. Return only the extracted text."),
 			openai.UserMessage(parts),
 		},
+		Temperature: ai.CompletionTemperature(p.model, 0),
 	}
-	if aiprovider.AllowsCustomTemperature(p.model) {
-		ocrParams.Temperature = openai.Float(0)
-	}
-	chatResp, err := p.client.Chat.Completions.New(ctx, ocrParams)
+	chatResp, err := ai.CompleteChat(ctx, p.client, p.logger, p.sdk, p.baseURL, ocrParams, "purpose", "ocr", "messages", 2)
 	if err != nil {
 		p.logger.Error("llm ocr failed",
 			"file", filepath.Base(filePath),

--- a/backend/internal/ocr/llm.go
+++ b/backend/internal/ocr/llm.go
@@ -83,14 +83,17 @@ func (p *LLMProvider) ExtractText(ctx context.Context, filePath string, mimeType
 	)
 
 	aiprovider.LogRequest(p.logger, p.sdk, http.MethodPost, aiprovider.ChatCompletionsURL(p.baseURL), p.model, "purpose", "ocr", "messages", 2)
-	chatResp, err := p.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+	ocrParams := openai.ChatCompletionNewParams{
 		Model: shared.ChatModel(p.model),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage("You transcribe documents for an archive. Return only the extracted text."),
 			openai.UserMessage(parts),
 		},
-		Temperature: openai.Float(0),
-	})
+	}
+	if aiprovider.AllowsCustomTemperature(p.model) {
+		ocrParams.Temperature = openai.Float(0)
+	}
+	chatResp, err := p.client.Chat.Completions.New(ctx, ocrParams)
 	if err != nil {
 		p.logger.Error("llm ocr failed",
 			"file", filepath.Base(filePath),

--- a/backend/internal/ocr/llm_test.go
+++ b/backend/internal/ocr/llm_test.go
@@ -1,11 +1,21 @@
 package ocr
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go"
+	"paperless-go/backend/internal/aiprovider"
 )
 
 func TestLLMUserContentPartsImage(t *testing.T) {
@@ -59,5 +69,72 @@ func TestLLMUserContentPartsEmpty(t *testing.T) {
 	t.Parallel()
 	if _, err := LLMUserContentParts("x", "image/png", nil); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestExtractTextRetriesWithoutTemperatureForUnknownModel(t *testing.T) {
+	t.Parallel()
+	const model = "azure-custom-deployment"
+	if !aiprovider.AllowsCustomTemperature(model) {
+		t.Fatalf("%q should send a custom temperature so the retry path is exercised", model)
+	}
+
+	var calls atomic.Int64
+	var firstBody, secondBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		n := calls.Add(1)
+		if n == 1 {
+			firstBody = string(raw)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.","type":"invalid_request_error","param":"temperature","code":"unsupported_value"}}`))
+			return
+		}
+		secondBody = string(raw)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-ocr",
+			"object":  "chat.completion",
+			"created": 1,
+			"model":   model,
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "Invoice INV-1001",
+				},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scan.png")
+	if err := os.WriteFile(path, []byte("png-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewLLMProvider(aiprovider.Provider{
+		SDK:     aiprovider.SDKOpenAI,
+		APIKey:  "test-key",
+		BaseURL: srv.URL,
+	}, model, 5*time.Second, slog.Default())
+	text, err := p.ExtractText(context.Background(), path, "image/png")
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if text != "Invoice INV-1001" {
+		t.Fatalf("text = %q", text)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2", calls.Load())
+	}
+	if !strings.Contains(firstBody, `"temperature"`) {
+		t.Fatalf("first OCR request should include temperature, got %s", firstBody)
+	}
+	if strings.Contains(secondBody, `"temperature"`) {
+		t.Fatalf("retry should omit temperature, got %s", secondBody)
 	}
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ These seed `app_settings` and `ai_providers` when the singleton record does not 
 | `OCR_TIMEOUT_SEC` | `40` | OCR request timeout |
 | `PROCESSING_RESULT_LANGUAGE` | empty | ISO 639-1 code (e.g. `en`, `de`). When set, `title`, `summary`, `purpose`, and `document_type` are stored in this language; originals go in `*_original` fields. |
 | `OPENAI_API_KEY` | empty | Seeds an OpenAI-compatible provider (used for extraction, chat, search, and optional LLM OCR). If unset, a seeded Mistral provider is bound for those tasks instead. |
-| `OPENAI_MODEL` | `gpt-4o-mini` | Model ID for metadata extraction |
+| `OPENAI_MODEL` | `gpt-5.6-luna` | Model ID for metadata extraction |
 | `OPENAI_CHAT_MODEL` | `OPENAI_MODEL` | Optional model ID for document chat |
 | `OPENAI_SEARCH_MODEL` | `OPENAI_CHAT_MODEL` | Optional model ID for Deep Search |
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible API base URL |


### PR DESCRIPTION
## Summary
- GPT-5 (and o-series reasoning) chat models only accept the default temperature of 1. Extraction was sending `0.1`, which OpenAI rejects with a 400 (`unsupported_value` on `temperature`).
- Omit `temperature` for `gpt-5*` and o-series model IDs (including OpenRouter prefixes and `ft:` fine-tunes). Keep the existing low values for GPT-4o and other models.
- If a model still rejects temperature, retry the chat completion once without it. LLM OCR uses the same omit rule.

Fixes #25

## Test plan
- [x] `./scripts/test-all.sh` (unit, API e2e, Playwright)
- [ ] In Settings, bind extraction to a GPT-5 model and upload a document; metadata extraction should complete instead of 400
- [ ] Confirm GPT-4o-mini extraction still works (still sends temperature 0.1)