### PR TITLE
Add instance-wide limits configured by environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,40 @@ DEEP_SEARCH_LANGUAGES=
 # UPLOAD_MAX_MB=100
 
 
+# Instance limits. Every one is UNLIMITED when unset, so leaving this whole block
+# commented out is exactly today's behaviour.
+#
+# Read at startup and never from Settings: these express what an instance is
+# allowed to hold, so an admin must not be able to raise their own. Change one by
+# recreating the container with a new value.
+#
+# An explicit 0 means zero, not unlimited -- LIMIT_ADDITIONAL_USERS=0 is a
+# single-account instance. A value that cannot be read (a typo, a negative)
+# falls back to unlimited and is logged at ERROR, so a stray character grants
+# room rather than locking an owner out of their own archive.
+
+# Total documents the instance may store.
+# LIMIT_DOCUMENTS=1000
+
+# Total pages across all stored documents. Anything that is not a PDF counts as
+# one page, including a multi-page .docx or .xlsx.
+# LIMIT_DOCUMENT_PAGES=10000
+
+# Total bytes of stored document files. Counts the uploaded originals only, not
+# thumbnails or extracted OCR text.
+# LIMIT_STORAGE_BYTES=5368709120
+
+# Largest single document file, in bytes. Can only lower the effective cap: the
+# documents.file field carries its own 20 MB limit that this cannot raise.
+# LIMIT_FILE_BYTES=10485760
+
+# Most pages in a single document.
+# LIMIT_FILE_PAGES=200
+
+# Accounts beyond the admin account. 0 means the admin only.
+# LIMIT_ADDITIONAL_USERS=2
+
+
 # Frontend
 VITE_POCKETBASE_URL=http://127.0.0.1:8090
 VITE_DEV_USER_EMAIL=dev@lemmary.local

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,6 +83,55 @@ jobs:
           ssh-key: ${{ secrets.DEV_REPO_KEY }}
           path: dev
 
+      # A change that spans both repositories is two commits on two branches of
+      # the same name. Checking the overlay out at main would run this pull
+      # request's code against e2e suites that know nothing about it: a behaviour
+      # change would fail against the old assertions, and a new feature would go
+      # green with no coverage at all. So prefer the matching branch when the
+      # overlay has one, and fall back to main, which is what a pull request that
+      # touches only this repository needs.
+      #
+      # Done after the checkout rather than through its `ref` input because that
+      # would need the branch resolved before any credential exists. The checkout
+      # leaves the deploy key configured in dev/.git/config, so ls-remote and
+      # fetch below reuse it.
+      - name: Prefer the matching dev branch
+        if: steps.access.outputs.ok == 'true'
+        working-directory: dev
+        env:
+          # head_ref is the source branch of a pull request; ref_name covers a
+          # push or manual dispatch, should this job ever run on one. For a pull
+          # request ref_name is "<number>/merge", which no overlay branch is
+          # named, so the order matters.
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Diagnostic only, so it must never be the thing that fails this step.
+          show() { git log -1 --format='dev/ at %h %s' 2>/dev/null || true; }
+
+          fallback() {
+            echo "::notice::Verification suite: lemmary-dev@main ($1)"
+            show
+            exit 0
+          }
+
+          if [ -z "${BRANCH:-}" ]; then
+            fallback "no branch name to match"
+          fi
+          if [ "$BRANCH" = "main" ]; then
+            fallback "already on main"
+          fi
+          if ! git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            fallback "no branch named $BRANCH"
+          fi
+
+          # Shallow: the suites are run, not bisected.
+          git fetch --depth=1 origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+          git checkout --force -B "$BRANCH" "refs/remotes/origin/$BRANCH"
+          echo "::notice::Verification suite: lemmary-dev@$BRANCH"
+          show
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,12 @@ missing in the new tree.
 When the main checkout has the overlay, attach it to the worktree before
 touching any code — as a worktree of the overlay repository on a branch of the
 **same name** as the feature branch, so the code change and its e2e update stay
-on matching branches in both repositories:
+on matching branches in both repositories.
+
+The name is load-bearing: the pull request job looks in the overlay for a branch
+matching the pull request and falls back to `main` when it finds none, so a
+mismatched name means CI runs the change against suites that know nothing about
+it — and reports green.
 
 ```bash
 # Run from inside the fresh lemmary worktree.
@@ -127,8 +132,13 @@ git -C "$main/dev" worktree remove "$root/dev"   # before deleting the worktree
 git -C "$main/dev" worktree prune                # after, if it is already gone
 ```
 
-Both branches need pushing — see "Changes that span both repositories" in the
-overlay's `AGENTS.md`.
+Both branches need pushing, and the overlay side wants pushing first — until it
+is, the pull request job falls back to the overlay's `main`. See "Changes that
+span both repositories" in the overlay's `AGENTS.md`.
+
+Note that the sandbox may refuse git commands aimed at `$main/dev`, since it
+sits inside the shared checkout. Leaving the worktree (keeping it), running the
+overlay commands, and re-entering is the way through.
 
 ## Verification (required)
 

--- a/backend/internal/amazonimport/archive.go
+++ b/backend/internal/amazonimport/archive.go
@@ -27,7 +27,7 @@ const (
 // maxEntryBytes matches the documents.file field limit, so an entry that cannot
 // be stored is reported at preview time instead of failing mid-import.
 // A var so tests can shrink it instead of building 20 MB fixtures.
-var maxEntryBytes int64 = 20 << 20
+var maxEntryBytes = DefaultMaxEntryBytes
 
 // maxTotalScanBytes budgets the total decompression one scan may do. Real
 // exports inflate to roughly the (already compressed) archive size; a crafted

--- a/backend/internal/amazonimport/limits.go
+++ b/backend/internal/amazonimport/limits.go
@@ -19,10 +19,14 @@ const DefaultMaxEntryBytes int64 = 20 << 20
 // lower-only setter would leak the smallest limit any earlier boot configured
 // into every later one.
 //
+// A negative n means "use the default"; 0 is a real cap of zero, because an
+// explicit LIMIT_FILE_BYTES=0 is a real (if unusual) plan and must not read as
+// unlimited here while the create hook refuses every file.
+//
 // Clamped to DefaultMaxEntryBytes, because nothing here can lift the field's own
 // MaxSize -- PocketBase validates that during the save.
 func SetMaxEntryBytes(n int64) {
-	if n <= 0 || n > DefaultMaxEntryBytes {
+	if n < 0 || n > DefaultMaxEntryBytes {
 		maxEntryBytes = DefaultMaxEntryBytes
 		return
 	}

--- a/backend/internal/amazonimport/limits.go
+++ b/backend/internal/amazonimport/limits.go
@@ -1,0 +1,30 @@
+package amazonimport
+
+// DefaultMaxEntryBytes is the per-entry cap with no instance limit configured.
+// It mirrors the documents.file field limit, which is what actually stores the
+// imported PDF.
+const DefaultMaxEntryBytes int64 = 20 << 20
+
+// SetMaxEntryBytes sets the per-entry cap to the effective per-document limit.
+//
+// Wiring-time only, called before any request is served, so an instance whose
+// plan caps a single document below the field limit reports an over-cap PDF as
+// oversized in the preview -- the behaviour this package already has for the
+// field limit -- rather than accepting it and having the create hook reject it
+// partway through the import. Without this the preview would lie: it would mark
+// a 15 MB PDF importable and the import would then refuse it.
+//
+// A set rather than a one-way lower: the value has to be able to go back up. The
+// e2e harness boots a whole app repeatedly inside one test binary, and a
+// lower-only setter would leak the smallest limit any earlier boot configured
+// into every later one.
+//
+// Clamped to DefaultMaxEntryBytes, because nothing here can lift the field's own
+// MaxSize -- PocketBase validates that during the save.
+func SetMaxEntryBytes(n int64) {
+	if n <= 0 || n > DefaultMaxEntryBytes {
+		maxEntryBytes = DefaultMaxEntryBytes
+		return
+	}
+	maxEntryBytes = n
+}

--- a/backend/internal/amazonimport/limits_test.go
+++ b/backend/internal/amazonimport/limits_test.go
@@ -1,0 +1,45 @@
+package amazonimport
+
+import "testing"
+
+func TestSetMaxEntryBytes(t *testing.T) {
+	original := maxEntryBytes
+	t.Cleanup(func() { maxEntryBytes = original })
+
+	for _, tc := range []struct {
+		name string
+		set  int64
+		want int64
+	}{
+		// A negative value is how "no limit configured" arrives.
+		{"unlimited restores the default", -1, DefaultMaxEntryBytes},
+		{"a smaller cap applies", 1 << 20, 1 << 20},
+		// Zero is a real cap, not a way of saying unlimited: an explicit
+		// LIMIT_FILE_BYTES=0 must leave the import preview agreeing with the
+		// create hook, which refuses every non-empty file.
+		{"zero is a real cap", 0, 0},
+		// Nothing here can lift the documents.file field's own MaxSize.
+		{"a larger cap is clamped", DefaultMaxEntryBytes * 10, DefaultMaxEntryBytes},
+	} {
+		SetMaxEntryBytes(tc.set)
+		if maxEntryBytes != tc.want {
+			t.Fatalf("%s: SetMaxEntryBytes(%d) left %d, want %d",
+				tc.name, tc.set, maxEntryBytes, tc.want)
+		}
+	}
+}
+
+// Wiring calls this on every boot, so it must raise the cap back to the default
+// as well as lower it -- otherwise the e2e harness, which boots repeatedly in one
+// test binary, leaks the smallest cap any earlier boot set.
+func TestSetMaxEntryBytesIsNotOneWay(t *testing.T) {
+	original := maxEntryBytes
+	t.Cleanup(func() { maxEntryBytes = original })
+
+	SetMaxEntryBytes(1024)
+	SetMaxEntryBytes(-1)
+	if maxEntryBytes != DefaultMaxEntryBytes {
+		t.Fatalf("cap stuck at %d after an unlimited boot, want %d",
+			maxEntryBytes, DefaultMaxEntryBytes)
+	}
+}

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -6,16 +6,18 @@ import (
 	"github.com/pocketbase/pocketbase/tools/hook"
 	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/fulltext"
+	"lemmary/backend/internal/limits"
 	"lemmary/backend/internal/pdfsplit"
 )
 
-func Register(app core.App, rt *config.Runtime, idx *fulltext.Index) {
+func Register(app core.App, rt *config.Runtime, idx *fulltext.Index, lim limits.Limits, badLimitKeys []string) {
 	app.OnServe().Bind(&hook.Handler[*core.ServeEvent]{
 		Priority: 45,
 		Func: func(e *core.ServeEvent) error {
 			g := e.Router.Group("/api/app")
 			g.GET("/meta", handleGetMeta(app))
 			g.GET("/me", handleGetMe(app))
+			g.GET("/limits", bindAuth(handleGetLimits(app, lim, badLimitKeys)))
 			g.GET("/setup/status", handleGetSetupStatus(app, rt))
 			g.POST("/setup/admin", handlePostSetupAdmin(app))
 			g.POST("/ensure-user", handlePostEnsureUser(app))
@@ -42,12 +44,12 @@ func Register(app core.App, rt *config.Runtime, idx *fulltext.Index) {
 			g.POST("/taxonomy/prune", bindAdmin(handlePostTaxonomyPrune(app)))
 			g.POST("/import/ngx", bindAuth(handlePostImportNgx(app)))
 			g.GET("/import/ngx/status", bindAuth(handleGetImportNgxStatus(app)))
-			g.POST("/import/amazon/upload", bindAuth(handlePostImportAmazonUpload(app))).
+			g.POST("/import/amazon/upload", bindAuth(handlePostImportAmazonUpload(app, lim))).
 				Bind(apis.BodyLimit(config.StagingMaxBytesFromEnv()))
 			g.DELETE("/import/amazon/upload", bindAuth(handleDeleteImportAmazonUpload(app)))
 			g.POST("/import/amazon", bindAuth(handlePostImportAmazon(app)))
 			g.GET("/import/amazon/status", bindAuth(handleGetImportAmazonStatus(app)))
-			g.POST("/import/archive/upload", bindAuth(handlePostImportArchiveUpload(app))).
+			g.POST("/import/archive/upload", bindAuth(handlePostImportArchiveUpload(app, lim))).
 				Bind(apis.BodyLimit(config.StagingMaxBytesFromEnv()))
 			g.DELETE("/import/archive/upload", bindAuth(handleDeleteImportArchiveUpload(app)))
 			g.POST("/import/archive", bindAuth(handlePostImportArchive(app)))
@@ -61,7 +63,7 @@ func Register(app core.App, rt *config.Runtime, idx *fulltext.Index) {
 			g.GET("/split/page", bindAuth(handleGetSplitPage(app)))
 			g.POST("/split/detect", bindAuth(handlePostSplitDetect(app, rt)))
 			g.GET("/split/detect/status", bindAuth(handleGetSplitDetectStatus(app)))
-			g.POST("/split", bindAuth(handlePostSplit(app)))
+			g.POST("/split", bindAuth(handlePostSplit(app, lim)))
 			g.GET("/split/status", bindAuth(handleGetSplitStatus(app)))
 			return e.Next()
 		},

--- a/backend/internal/appapi/import_amazon.go
+++ b/backend/internal/appapi/import_amazon.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 	"lemmary/backend/internal/amazonimport"
+	"lemmary/backend/internal/limits"
 )
 
 type importAmazonRequest struct {
@@ -18,7 +19,7 @@ type importAmazonRequest struct {
 
 // handlePostImportAmazonUpload stages an Amazon order export so the user can
 // confirm the file count before any document is created.
-func handlePostImportAmazonUpload(app core.App) func(*core.RequestEvent) error {
+func handlePostImportAmazonUpload(app core.App, lim limits.Limits) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
 		ownerID, err := resolveOwnerUserID(app, e)
 		if err != nil {
@@ -44,6 +45,22 @@ func handlePostImportAmazonUpload(app core.App) func(*core.RequestEvent) error {
 			app.Logger().Error("amazon archive inspect failed", "error", err)
 			return writeError(e, http.StatusInternalServerError, "Failed to read the archive.")
 		}
+
+		// Checked while the user is still deciding whether to confirm, rather
+		// than leaving the create hook to refuse the overflow one PDF at a time
+		// partway through the import.
+		var bytes int64
+		for _, entry := range preview.Files {
+			if entry.Duplicate || entry.Oversized {
+				continue
+			}
+			bytes += entry.Size
+		}
+		if exceeded := preflightImport(app, lim, int64(preview.ImportableCount), 0, bytes); exceeded != nil {
+			amazonimport.Discard(preview.UploadID, ownerID)
+			return writeError(e, http.StatusBadRequest, exceeded.Message)
+		}
+
 		return writeJSON(e, http.StatusOK, preview)
 	}
 }

--- a/backend/internal/appapi/import_archive.go
+++ b/backend/internal/appapi/import_archive.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 
 	"lemmary/backend/internal/archiveimport"
+	"lemmary/backend/internal/limits"
 )
 
 type importArchiveRequest struct {
@@ -18,7 +19,7 @@ type importArchiveRequest struct {
 
 // handlePostImportArchiveUpload stages a Lemmary backup archive so the user can
 // see what it holds before any document is created.
-func handlePostImportArchiveUpload(app core.App) func(*core.RequestEvent) error {
+func handlePostImportArchiveUpload(app core.App, lim limits.Limits) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
 		ownerID, err := resolveOwnerUserID(app, e)
 		if err != nil {
@@ -45,6 +46,22 @@ func handlePostImportArchiveUpload(app core.App) func(*core.RequestEvent) error 
 			app.Logger().Error("lemmary archive inspect failed", "error", err)
 			return writeError(e, http.StatusInternalServerError, "Failed to read the archive.")
 		}
+
+		// Checked here, while the user is still deciding whether to confirm,
+		// rather than leaving the create hook to refuse several hundred
+		// documents one at a time halfway through the restore.
+		var bytes int64
+		for _, entry := range preview.Files {
+			if entry.Duplicate || entry.Oversized || entry.Missing {
+				continue
+			}
+			bytes += entry.Size
+		}
+		if exceeded := preflightImport(app, lim, int64(preview.ImportableCount), 0, bytes); exceeded != nil {
+			archiveimport.Discard(preview.UploadID, ownerID)
+			return writeError(e, http.StatusBadRequest, exceeded.Message)
+		}
+
 		return writeJSON(e, http.StatusOK, preview)
 	}
 }

--- a/backend/internal/appapi/limits.go
+++ b/backend/internal/appapi/limits.go
@@ -91,14 +91,19 @@ func handleGetLimits(app core.App, lim limits.Limits, badKeys []string) func(*co
 	}
 }
 
-// preflightImport refuses a bulk ingest that could not fit, before any document
-// is created.
+// preflightImport refuses a bulk ingest that plainly could not fit.
 //
-// The create hook would refuse the over-limit documents one by one anyway, but a
-// restore that stops halfway leaves the user with a partial library and a list of
-// several hundred identical errors. Checking the whole batch against the
-// allowance first turns that into one message at the point where they are still
-// deciding whether to confirm.
+// A better error, not a stronger guarantee. The create hook is what actually
+// enforces every limit, and it would refuse the over-limit documents one at a
+// time -- leaving a partial library and several hundred identical errors. This
+// turns the common case into one message while the user is still deciding whether
+// to confirm.
+//
+// It is explicitly not a reservation. Nothing holds the room between this check
+// and the run, so a batch confirmed minutes later, or racing another upload, can
+// still stop partway; and each caller can only offer the dimensions it knows
+// (see below). Do not describe the bulk paths as all-or-nothing on the strength
+// of this function -- docs/setup.md lists what each one can and cannot promise.
 //
 // documents and bytes are the additions the batch would make. pages is passed as
 // 0 by callers that cannot know it: an archive's real page counts are only

--- a/backend/internal/appapi/limits.go
+++ b/backend/internal/appapi/limits.go
@@ -1,0 +1,124 @@
+package appapi
+
+import (
+	"net/http"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/limits"
+)
+
+// limitStatus is one allowance and what is used against it.
+//
+// Unlimited is explicit rather than encoded as a sentinel in Limit, so a client
+// never has to know that some number means "no bound". Limit is omitted when
+// unlimited for the same reason.
+type limitStatus struct {
+	Used      int64  `json:"used"`
+	Limit     *int64 `json:"limit,omitempty"`
+	Unlimited bool   `json:"unlimited"`
+}
+
+type limitsResponse struct {
+	// Enforced is false when this install bounds nothing, which is the default.
+	// The UI reads it to decide whether to render any of this at all.
+	Enforced bool `json:"enforced"`
+
+	// Misconfigured names the LIMIT_* variables this instance could not read.
+	// Each one fell back to unlimited, so the instance works and the plan is not
+	// being enforced -- the one failure here nobody would otherwise notice.
+	// Admin-only: it is operator detail, and a regular user can do nothing with
+	// it.
+	Misconfigured []string `json:"misconfigured,omitempty"`
+
+	Documents       limitStatus `json:"documents"`
+	DocumentPages   limitStatus `json:"document_pages"`
+	StorageBytes    limitStatus `json:"storage_bytes"`
+	FileBytes       limitStatus `json:"file_bytes"`
+	FilePages       limitStatus `json:"file_pages"`
+	AdditionalUsers limitStatus `json:"additional_users"`
+}
+
+func status(limit limits.Limit, used int64) limitStatus {
+	if limit.IsUnlimited() {
+		return limitStatus{Used: used, Unlimited: true}
+	}
+	value := limit.Value()
+	return limitStatus{Used: used, Limit: &value}
+}
+
+// handleGetLimits reports this instance's allowances and what is used against
+// them.
+//
+// bindAuth rather than bindAdmin: the upload page shows how much room is left,
+// and that is not an admin-only fact -- the person about to be refused is the
+// one who needs to see it. The numbers are instance-wide totals with no
+// per-account detail in them, so they leak nothing about other users.
+//
+// The two per-file limits report a used of 0: they bound one upload rather than
+// accumulating, so there is nothing to have used up.
+func handleGetLimits(app core.App, lim limits.Limits, badKeys []string) func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		response := limitsResponse{Enforced: lim.Any()}
+		if isAppAdmin(e) {
+			response.Misconfigured = badKeys
+		}
+
+		// Usage is only read when something is actually bounded, so an unlimited
+		// install pays no COUNT and no SUMs here. The statuses are still filled
+		// in either way: a body saying `enforced: false` while every limit
+		// reports `unlimited: false` contradicts itself, and a consumer that
+		// checks the individual limits rather than the top-level flag would read
+		// it backwards.
+		var usage limits.Usage
+		if response.Enforced {
+			measured, err := limits.Measure(app)
+			if err != nil {
+				app.Logger().Error("reading instance usage failed", "component", "limits", "error", err)
+				return writeError(e, http.StatusInternalServerError, "Failed to read instance usage.")
+			}
+			usage = measured
+		}
+
+		response.Documents = status(lim.Documents, usage.Documents)
+		response.DocumentPages = status(lim.DocumentPages, usage.DocumentPages)
+		response.StorageBytes = status(lim.StorageBytes, usage.StorageBytes)
+		response.FileBytes = status(lim.FileBytes, 0)
+		response.FilePages = status(lim.FilePages, 0)
+		response.AdditionalUsers = status(lim.AdditionalUsers, usage.AdditionalUsers)
+
+		return writeJSON(e, http.StatusOK, response)
+	}
+}
+
+// preflightImport refuses a bulk ingest that could not fit, before any document
+// is created.
+//
+// The create hook would refuse the over-limit documents one by one anyway, but a
+// restore that stops halfway leaves the user with a partial library and a list of
+// several hundred identical errors. Checking the whole batch against the
+// allowance first turns that into one message at the point where they are still
+// deciding whether to confirm.
+//
+// documents and bytes are the additions the batch would make. pages is passed as
+// 0 by callers that cannot know it: an archive's real page counts are only
+// discoverable by opening every PDF in it, which is not work to do inside an
+// upload request. The pages limit is still enforced per document by the create
+// hook, so a batch can be refused partway through on that one limit alone.
+func preflightImport(app core.App, lim limits.Limits, documents, pages, bytes int64) *limits.ErrExceeded {
+	if documents <= 0 {
+		return nil
+	}
+	if lim.Documents.IsUnlimited() && lim.DocumentPages.IsUnlimited() && lim.StorageBytes.IsUnlimited() {
+		return nil
+	}
+	usage, err := limits.Measure(app)
+	if err != nil {
+		// Not the caller's fault, and not a reason to refuse the upload: the
+		// create hook still enforces every limit per document.
+		app.Logger().Error("import preflight skipped: reading usage failed",
+			"component", "limits", "error", err)
+		return nil
+	}
+	return limits.AsExceeded(lim.CheckRoom(usage, documents, pages, bytes))
+}

--- a/backend/internal/appapi/split.go
+++ b/backend/internal/appapi/split.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/importjob"
+	"lemmary/backend/internal/limits"
 	"lemmary/backend/internal/pdfsplit"
 )
 
@@ -166,7 +167,7 @@ func handleGetSplitDetectStatus(app core.App) func(*core.RequestEvent) error {
 }
 
 // handlePostSplit starts the confirmed split of a staged PDF.
-func handlePostSplit(app core.App) func(*core.RequestEvent) error {
+func handlePostSplit(app core.App, lim limits.Limits) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
 		var req splitRequest
 		if err := json.NewDecoder(e.Request.Body).Decode(&req); err != nil {
@@ -179,6 +180,28 @@ func handlePostSplit(app core.App) func(*core.RequestEvent) error {
 		ownerID, err := resolveOwnerUserID(app, e)
 		if err != nil {
 			return writeOwnerError(e, err)
+		}
+
+		// A split is the one bulk path whose page counts are known exactly
+		// before anything is created -- each part is a page range -- so both the
+		// per-file and the instance-wide page limits can be answered here rather
+		// than after some of the parts already exist. Bytes are not knowable
+		// until the parts are extracted, so those stay with the create hook.
+		if len(req.Parts) > 0 {
+			var pages int64
+			for _, part := range req.Parts {
+				partPages := int64(part.To - part.From + 1)
+				if partPages < 1 {
+					continue
+				}
+				pages += partPages
+				if exceeded := limits.AsExceeded(lim.CheckFile(0, partPages)); exceeded != nil {
+					return writeError(e, http.StatusBadRequest, exceeded.Message)
+				}
+			}
+			if exceeded := preflightImport(app, lim, int64(len(req.Parts)), pages, 0); exceeded != nil {
+				return writeError(e, http.StatusBadRequest, exceeded.Message)
+			}
 		}
 
 		jobID, err := pdfsplit.Start(app, ownerID, req.UploadID, req.Parts)

--- a/backend/internal/appwire/perfilecaps.go
+++ b/backend/internal/appwire/perfilecaps.go
@@ -25,9 +25,11 @@ import (
 // archiveimport and amazonimport are free to import limits, and this direction
 // would close the cycle.
 func applyPerFileCaps(lim limits.Limits) {
-	// Unlimited resolves to 0, which every setter reads as "use your default".
-	// Nothing here can raise a cap above the field's own MaxSize anyway.
-	var effective int64
+	// Unlimited resolves to -1, which every setter reads as "use your default".
+	// It must not resolve to 0: an explicit LIMIT_FILE_BYTES=0 is a real cap, and
+	// collapsing the two would have the previews accept files the create hook
+	// then refuses. Nothing here can raise a cap above the field's own MaxSize.
+	effective := int64(-1)
 	if !lim.FileBytes.IsUnlimited() {
 		effective = lim.FileBytes.Value()
 	}

--- a/backend/internal/appwire/perfilecaps.go
+++ b/backend/internal/appwire/perfilecaps.go
@@ -1,0 +1,37 @@
+package appwire
+
+import (
+	"lemmary/backend/internal/amazonimport"
+	"lemmary/backend/internal/archiveimport"
+	"lemmary/backend/internal/limits"
+	"lemmary/backend/internal/pdfsplit"
+)
+
+// applyPerFileCaps points the bulk paths' per-entry size caps at the effective
+// per-document limit.
+//
+// Those caps exist to mirror the documents.file field limit, so an entry that
+// could never be stored is reported as skipped instead of failing the whole run.
+// A per-file limit is the same statement, only smaller, so feeding it through
+// the same caps gets that behaviour for free -- and keeps the import previews
+// honest: without it a preview would mark an entry importable at a size the
+// create hook then refuses.
+//
+// Called unconditionally, including with no limit set, so each cap lands back on
+// its default rather than keeping whatever an earlier call left. That matters in
+// the e2e harness, which boots a whole app repeatedly inside one test binary.
+//
+// It lives here rather than in the limits package so that package stays a leaf:
+// archiveimport and amazonimport are free to import limits, and this direction
+// would close the cycle.
+func applyPerFileCaps(lim limits.Limits) {
+	// Unlimited resolves to 0, which every setter reads as "use your default".
+	// Nothing here can raise a cap above the field's own MaxSize anyway.
+	var effective int64
+	if !lim.FileBytes.IsUnlimited() {
+		effective = lim.FileBytes.Value()
+	}
+	amazonimport.SetMaxEntryBytes(effective)
+	archiveimport.SetMaxEntryBytes(effective)
+	pdfsplit.SetMaxPartBytes(effective)
+}

--- a/backend/internal/appwire/wire.go
+++ b/backend/internal/appwire/wire.go
@@ -9,6 +9,7 @@ import (
 	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/ext"
 	"lemmary/backend/internal/fulltext"
+	"lemmary/backend/internal/limits"
 	"lemmary/backend/internal/mailsink"
 	"lemmary/backend/internal/ngxapi"
 	"lemmary/backend/internal/worker"
@@ -24,6 +25,12 @@ import (
 func Register(app *pocketbase.PocketBase, rt *config.Runtime, publicDir string, indexFallback bool) {
 	ed := edition()
 
+	// Read once, here, so every consumer sees the same numbers: the hooks that
+	// enforce them, the caps the bulk importers lower to match, and the usage
+	// endpoint the UI reads.
+	lim, badLimitKeys := limits.FromEnv(app.Logger())
+	applyPerFileCaps(lim)
+
 	ft := fulltext.New()
 	config.RegisterHooks(app, rt)
 	// Installed before anything can trigger a reload: RegisterHooks only binds
@@ -33,7 +40,11 @@ func Register(app *pocketbase.PocketBase, rt *config.Runtime, publicDir string, 
 	authguard.Register(app)
 	mailsink.Register(app)
 	fulltext.Register(app, ft)
-	appapi.Register(app, rt, ft)
+	// Before worker.Register: PocketBase runs equal-priority handlers in
+	// registration order, so this is what makes an over-limit upload refused
+	// before duplicates.AssignChecksumFromUpload reads the whole file to hash it.
+	limits.Register(app, lim)
+	appapi.Register(app, rt, ft, lim, badLimitKeys)
 	ngxapi.Register(app, ft)
 	worker.Register(app, rt, worker.Options{
 		ExtraSteps: ed.Steps,

--- a/backend/internal/archiveimport/archive.go
+++ b/backend/internal/archiveimport/archive.go
@@ -32,7 +32,7 @@ const (
 // maxEntryBytes matches the documents.file field limit, so an entry that cannot
 // be stored is reported at preview time instead of failing mid-restore.
 // A var so tests can shrink it instead of building 20 MB fixtures.
-var maxEntryBytes int64 = 20 << 20
+var maxEntryBytes = DefaultMaxEntryBytes
 
 // maxTotalScanBytes budgets the total decompression one scan may do, across
 // both the originals it hashes and the sidecars it reads. A var so tests can

--- a/backend/internal/archiveimport/limits.go
+++ b/backend/internal/archiveimport/limits.go
@@ -19,10 +19,14 @@ const DefaultMaxEntryBytes int64 = 20 << 20
 // lower-only setter would leak the smallest limit any earlier boot configured
 // into every later one.
 //
+// A negative n means "use the default"; 0 is a real cap of zero, because an
+// explicit LIMIT_FILE_BYTES=0 is a real (if unusual) plan and must not read as
+// unlimited here while the create hook refuses every file.
+//
 // Clamped to DefaultMaxEntryBytes, because nothing here can lift the field's own
 // MaxSize -- PocketBase validates that during the save.
 func SetMaxEntryBytes(n int64) {
-	if n <= 0 || n > DefaultMaxEntryBytes {
+	if n < 0 || n > DefaultMaxEntryBytes {
 		maxEntryBytes = DefaultMaxEntryBytes
 		return
 	}

--- a/backend/internal/archiveimport/limits.go
+++ b/backend/internal/archiveimport/limits.go
@@ -1,0 +1,30 @@
+package archiveimport
+
+// DefaultMaxEntryBytes is the per-entry cap with no instance limit configured.
+// It mirrors the documents.file field limit, which is what actually stores the
+// restored file.
+const DefaultMaxEntryBytes int64 = 20 << 20
+
+// SetMaxEntryBytes sets the per-entry cap to the effective per-document limit.
+//
+// Wiring-time only, called before any request is served, so an instance whose
+// plan caps a single document below the field limit reports an over-cap entry as
+// oversized in the restore preview -- the behaviour this package already has for
+// the field limit -- rather than accepting it and having the create hook reject
+// it partway through a restore. Without this the preview would lie: it would
+// mark a 15 MB entry importable and the restore would then refuse it.
+//
+// A set rather than a one-way lower: the value has to be able to go back up. The
+// e2e harness boots a whole app repeatedly inside one test binary, and a
+// lower-only setter would leak the smallest limit any earlier boot configured
+// into every later one.
+//
+// Clamped to DefaultMaxEntryBytes, because nothing here can lift the field's own
+// MaxSize -- PocketBase validates that during the save.
+func SetMaxEntryBytes(n int64) {
+	if n <= 0 || n > DefaultMaxEntryBytes {
+		maxEntryBytes = DefaultMaxEntryBytes
+		return
+	}
+	maxEntryBytes = n
+}

--- a/backend/internal/archiveimport/limits_test.go
+++ b/backend/internal/archiveimport/limits_test.go
@@ -1,0 +1,45 @@
+package archiveimport
+
+import "testing"
+
+func TestSetMaxEntryBytes(t *testing.T) {
+	original := maxEntryBytes
+	t.Cleanup(func() { maxEntryBytes = original })
+
+	for _, tc := range []struct {
+		name string
+		set  int64
+		want int64
+	}{
+		// A negative value is how "no limit configured" arrives.
+		{"unlimited restores the default", -1, DefaultMaxEntryBytes},
+		{"a smaller cap applies", 1 << 20, 1 << 20},
+		// Zero is a real cap, not a way of saying unlimited: an explicit
+		// LIMIT_FILE_BYTES=0 must leave the restore preview agreeing with the
+		// create hook, which refuses every non-empty file.
+		{"zero is a real cap", 0, 0},
+		// Nothing here can lift the documents.file field's own MaxSize.
+		{"a larger cap is clamped", DefaultMaxEntryBytes * 10, DefaultMaxEntryBytes},
+	} {
+		SetMaxEntryBytes(tc.set)
+		if maxEntryBytes != tc.want {
+			t.Fatalf("%s: SetMaxEntryBytes(%d) left %d, want %d",
+				tc.name, tc.set, maxEntryBytes, tc.want)
+		}
+	}
+}
+
+// Wiring calls this on every boot, so it must raise the cap back to the default
+// as well as lower it -- otherwise the e2e harness, which boots repeatedly in one
+// test binary, leaks the smallest cap any earlier boot set.
+func TestSetMaxEntryBytesIsNotOneWay(t *testing.T) {
+	original := maxEntryBytes
+	t.Cleanup(func() { maxEntryBytes = original })
+
+	SetMaxEntryBytes(1024)
+	SetMaxEntryBytes(-1)
+	if maxEntryBytes != DefaultMaxEntryBytes {
+		t.Fatalf("cap stuck at %d after an unlimited boot, want %d",
+			maxEntryBytes, DefaultMaxEntryBytes)
+	}
+}

--- a/backend/internal/limits/check.go
+++ b/backend/internal/limits/check.go
@@ -1,0 +1,200 @@
+package limits
+
+import (
+	"fmt"
+
+	"github.com/pocketbase/pocketbase/tools/router"
+)
+
+// Names identify a limit in an error payload and in the usage API, so a client
+// can say which allowance ran out without parsing an English sentence.
+const (
+	NameDocuments       = "documents"
+	NameDocumentPages   = "document_pages"
+	NameStorageBytes    = "storage_bytes"
+	NameFileBytes       = "file_bytes"
+	NameFilePages       = "file_pages"
+	NameAdditionalUsers = "additional_users"
+)
+
+// ErrExceeded is a limit refusing something. It carries the numbers so a caller
+// can render "3 of 3 used" without measuring again.
+type ErrExceeded struct {
+	// Name is one of the Name* constants.
+	Name string
+	// Allowed is the limit.
+	Allowed int64
+	// Used is what was already in use when the check ran. For a per-file limit
+	// this is the value the file itself presented.
+	Used int64
+	// Message is the human-readable explanation.
+	Message string
+}
+
+func (e *ErrExceeded) Error() string { return e.Message }
+
+// Code implements router.SafeErrorItem, identifying which limit was hit.
+//
+// This is what makes the limit name survive the trip to the client. PocketBase
+// replaces any value in an ApiError's data map that does not implement
+// SafeErrorItem with a generic {"code": "validation_invalid_value"} -- which is
+// why the duplicate rejection next door has to parse its id back out of the
+// message text. Implementing the interface means a client can switch on the code
+// instead.
+func (e *ErrExceeded) Code() string { return "limit_" + e.Name }
+
+// Params implements router.SafeErrorParamsResolver, carrying the numbers so a
+// client can render "3 of 3 used" without measuring anything itself.
+func (e *ErrExceeded) Params() map[string]any {
+	return map[string]any{
+		"limit":   e.Name,
+		"allowed": e.Allowed,
+		"used":    e.Used,
+	}
+}
+
+// APIError renders the rejection for an HTTP client.
+//
+// A 400, like the only other business rejection on this collection (duplicates).
+// Not 413 or 507: PocketBase's own file-size rejection on documents is already a
+// 400, so a different status for the same class of problem would be the odd one
+// out, and the paperless-ngx clients that also reach these paths understand no
+// quota status either. The 423 handling in the SPA is reserved for a private
+// edition.
+//
+// The error is put under a "limit" key so the whole payload reads as
+// {"limit": {"code": "limit_documents", "params": {...}}}.
+func (e *ErrExceeded) APIError() *router.ApiError {
+	return router.NewBadRequestError(e.Message, map[string]any{"limit": e})
+}
+
+// AsExceeded returns the *ErrExceeded an error carries, if any. Mirrors the
+// shape duplicates uses so an ingest path can test for one type.
+func AsExceeded(err error) *ErrExceeded {
+	if err == nil {
+		return nil
+	}
+	if exceeded, ok := err.(*ErrExceeded); ok {
+		return exceeded
+	}
+	return nil
+}
+
+// CheckFile applies the two per-upload limits to one file's own measurements.
+func (l Limits) CheckFile(sizeBytes, pageCount int64) error {
+	if l.FileBytes.Exceeded(sizeBytes) {
+		return &ErrExceeded{
+			Name:    NameFileBytes,
+			Allowed: l.FileBytes.Value(),
+			Used:    sizeBytes,
+			Message: fmt.Sprintf(
+				"This file is %s, over the %s limit for a single document.",
+				formatBytes(sizeBytes), formatBytes(l.FileBytes.Value())),
+		}
+	}
+	if l.FilePages.Exceeded(pageCount) {
+		return &ErrExceeded{
+			Name:    NameFilePages,
+			Allowed: l.FilePages.Value(),
+			Used:    pageCount,
+			Message: fmt.Sprintf(
+				"This file has %d pages, over the %d-page limit for a single document.",
+				pageCount, l.FilePages.Value()),
+		}
+	}
+	return nil
+}
+
+// CheckRoom applies the three instance-wide document limits to what adding
+// documents worth of pages and bytes would bring the totals to.
+//
+// documents, pages and bytes are the additions, not the new totals.
+func (l Limits) CheckRoom(usage Usage, documents, pages, bytes int64) error {
+	if l.Documents.Exceeded(usage.Documents + documents) {
+		return &ErrExceeded{
+			Name:    NameDocuments,
+			Allowed: l.Documents.Value(),
+			Used:    usage.Documents,
+			Message: documentCountMessage(l.Documents.Value(), usage.Documents, documents),
+		}
+	}
+	if l.DocumentPages.Exceeded(usage.DocumentPages + pages) {
+		return &ErrExceeded{
+			Name:    NameDocumentPages,
+			Allowed: l.DocumentPages.Value(),
+			Used:    usage.DocumentPages,
+			Message: fmt.Sprintf(
+				"This instance holds %d of %d pages, and this would add %d.",
+				usage.DocumentPages, l.DocumentPages.Value(), pages),
+		}
+	}
+	if l.StorageBytes.Exceeded(usage.StorageBytes + bytes) {
+		return &ErrExceeded{
+			Name:    NameStorageBytes,
+			Allowed: l.StorageBytes.Value(),
+			Used:    usage.StorageBytes,
+			Message: fmt.Sprintf(
+				"This instance uses %s of its %s of storage, and this would add %s.",
+				formatBytes(usage.StorageBytes), formatBytes(l.StorageBytes.Value()),
+				formatBytes(bytes)),
+		}
+	}
+	return nil
+}
+
+func documentCountMessage(allowed, used, adding int64) string {
+	if adding == 1 {
+		return fmt.Sprintf(
+			"This instance holds %d of %d documents, so there is no room for another.",
+			used, allowed)
+	}
+	return fmt.Sprintf(
+		"This instance holds %d of %d documents, so there is no room for %d more.",
+		used, allowed, adding)
+}
+
+// CheckAdditionalUsers applies the account limit to a projected seat count --
+// what CountAdditionalUsers would report once the account in question exists.
+//
+// It takes the result rather than the current count so the caller owns the "one
+// account is free" arithmetic in one place, instead of this having to know
+// whether the caller already counted the new record.
+func (l Limits) CheckAdditionalUsers(projected int64) error {
+	if !l.AdditionalUsers.Exceeded(projected) {
+		return nil
+	}
+	allowed := l.AdditionalUsers.Value()
+	message := fmt.Sprintf(
+		"This instance allows %d accounts beyond the admin account and already has that many.",
+		allowed)
+	if allowed == 0 {
+		message = "This instance does not allow accounts beyond the admin account."
+	}
+	return &ErrExceeded{
+		Name:    NameAdditionalUsers,
+		Allowed: allowed,
+		Used:    projected - 1,
+		Message: message,
+	}
+}
+
+// formatBytes renders a byte count the way a person reads a file size. Binary
+// units, because that is what the existing size caps in this codebase are
+// expressed in.
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	value := float64(n)
+	for _, suffix := range []string{"KB", "MB", "GB", "TB"} {
+		value /= unit
+		if value < unit {
+			if value < 10 {
+				return fmt.Sprintf("%.1f %s", value, suffix)
+			}
+			return fmt.Sprintf("%.0f %s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%.0f PB", value/unit)
+}

--- a/backend/internal/limits/check_test.go
+++ b/backend/internal/limits/check_test.go
@@ -1,0 +1,253 @@
+package limits
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCheckFileBytes(t *testing.T) {
+	lim := Limits{FileBytes: Of(1000)}
+
+	if err := lim.CheckFile(1000, 1); err != nil {
+		t.Fatalf("a file exactly at the limit was refused: %v", err)
+	}
+
+	err := lim.CheckFile(1001, 1)
+	exceeded := AsExceeded(err)
+	if exceeded == nil {
+		t.Fatalf("an over-limit file was accepted, got %v", err)
+	}
+	if exceeded.Name != NameFileBytes {
+		t.Fatalf("Name = %q, want %q", exceeded.Name, NameFileBytes)
+	}
+	if exceeded.Allowed != 1000 || exceeded.Used != 1001 {
+		t.Fatalf("Allowed/Used = %d/%d, want 1000/1001", exceeded.Allowed, exceeded.Used)
+	}
+}
+
+func TestCheckFilePages(t *testing.T) {
+	lim := Limits{FilePages: Of(2)}
+
+	if err := lim.CheckFile(1, 2); err != nil {
+		t.Fatalf("a file exactly at the page limit was refused: %v", err)
+	}
+
+	exceeded := AsExceeded(lim.CheckFile(1, 3))
+	if exceeded == nil {
+		t.Fatal("a 3-page file passed a 2-page limit")
+	}
+	if exceeded.Name != NameFilePages {
+		t.Fatalf("Name = %q, want %q", exceeded.Name, NameFilePages)
+	}
+	if !strings.Contains(exceeded.Message, "3 pages") {
+		t.Fatalf("message does not say how many pages the file has: %q", exceeded.Message)
+	}
+}
+
+// The byte limit is checked before the page limit, so the message names the
+// reason a person can act on first.
+func TestCheckFileReportsBytesBeforePages(t *testing.T) {
+	lim := Limits{FileBytes: Of(10), FilePages: Of(1)}
+	exceeded := AsExceeded(lim.CheckFile(100, 100))
+	if exceeded == nil || exceeded.Name != NameFileBytes {
+		t.Fatalf("want a %s rejection, got %+v", NameFileBytes, exceeded)
+	}
+}
+
+func TestCheckRoomDocuments(t *testing.T) {
+	lim := Limits{Documents: Of(3)}
+	usage := Usage{Documents: 2}
+
+	if err := lim.CheckRoom(usage, 1, 0, 0); err != nil {
+		t.Fatalf("the third of three documents was refused: %v", err)
+	}
+
+	exceeded := AsExceeded(lim.CheckRoom(Usage{Documents: 3}, 1, 0, 0))
+	if exceeded == nil {
+		t.Fatal("a fourth document passed a limit of three")
+	}
+	if exceeded.Name != NameDocuments {
+		t.Fatalf("Name = %q, want %q", exceeded.Name, NameDocuments)
+	}
+	if !strings.Contains(exceeded.Message, "3 of 3") {
+		t.Fatalf("message does not show usage against the limit: %q", exceeded.Message)
+	}
+}
+
+// A bulk path asks about many documents at once, and the message should say so
+// rather than claiming there is no room for "another".
+func TestCheckRoomBatchMessage(t *testing.T) {
+	lim := Limits{Documents: Of(10)}
+	exceeded := AsExceeded(lim.CheckRoom(Usage{Documents: 5}, 20, 0, 0))
+	if exceeded == nil {
+		t.Fatal("a 20-document batch passed with 5 of 10 used")
+	}
+	if !strings.Contains(exceeded.Message, "20 more") {
+		t.Fatalf("message does not mention the batch size: %q", exceeded.Message)
+	}
+}
+
+func TestCheckRoomPagesAndBytes(t *testing.T) {
+	pages := Limits{DocumentPages: Of(100)}
+	if err := pages.CheckRoom(Usage{DocumentPages: 90}, 1, 10, 0); err != nil {
+		t.Fatalf("pages exactly at the limit were refused: %v", err)
+	}
+	if exceeded := AsExceeded(pages.CheckRoom(Usage{DocumentPages: 90}, 1, 11, 0)); exceeded == nil {
+		t.Fatal("101 pages passed a 100-page limit")
+	} else if exceeded.Name != NameDocumentPages {
+		t.Fatalf("Name = %q, want %q", exceeded.Name, NameDocumentPages)
+	}
+
+	bytes := Limits{StorageBytes: Of(1 << 20)}
+	if err := bytes.CheckRoom(Usage{StorageBytes: 1 << 19}, 1, 0, 1<<19); err != nil {
+		t.Fatalf("bytes exactly at the limit were refused: %v", err)
+	}
+	if exceeded := AsExceeded(bytes.CheckRoom(Usage{StorageBytes: 1 << 20}, 1, 0, 1)); exceeded == nil {
+		t.Fatal("one byte over the storage limit passed")
+	} else if exceeded.Name != NameStorageBytes {
+		t.Fatalf("Name = %q, want %q", exceeded.Name, NameStorageBytes)
+	}
+}
+
+func TestCheckAdditionalUsers(t *testing.T) {
+	lim := Limits{AdditionalUsers: Of(2)}
+
+	if err := lim.CheckAdditionalUsers(2); err != nil {
+		t.Fatalf("the second of two additional users was refused: %v", err)
+	}
+	exceeded := AsExceeded(lim.CheckAdditionalUsers(3))
+	if exceeded == nil {
+		t.Fatal("a third additional user passed a limit of two")
+	}
+	if exceeded.Name != NameAdditionalUsers {
+		t.Fatalf("Name = %q, want %q", exceeded.Name, NameAdditionalUsers)
+	}
+}
+
+// Zero additional users is a real plan, and it needs a message that does not
+// read as a bug ("allows 0 accounts and already has that many").
+func TestCheckAdditionalUsersZeroAllowance(t *testing.T) {
+	lim := Limits{AdditionalUsers: Of(0)}
+	exceeded := AsExceeded(lim.CheckAdditionalUsers(1))
+	if exceeded == nil {
+		t.Fatal("an additional user passed a limit of zero")
+	}
+	if strings.Contains(exceeded.Message, "0") {
+		t.Fatalf("the zero-allowance message reads as an off-by-one: %q", exceeded.Message)
+	}
+}
+
+// One account is free, and exactly one. The wizard's first admin must always
+// get in, and the second account must not -- including the flagged users record
+// a second superuser drags along, which is how an admin would otherwise mint
+// seats without bound.
+func TestAdditionalOfExemptsExactlyOneAccount(t *testing.T) {
+	for _, tc := range []struct{ total, want int64 }{
+		{0, 0}, {1, 0}, {2, 1}, {3, 2}, {10, 9},
+	} {
+		if got := additionalOf(tc.total); got != tc.want {
+			t.Fatalf("additionalOf(%d) = %d, want %d", tc.total, got, tc.want)
+		}
+	}
+}
+
+func TestSeatLimitTraceOfEveryAccountCreate(t *testing.T) {
+	solo := Limits{AdditionalUsers: Of(0)}
+
+	// The setup wizard, on an empty instance.
+	if err := solo.CheckAdditionalUsers(additionalOf(0 + 1)); err != nil {
+		t.Fatalf("the first admin was refused on a solo plan: %v", err)
+	}
+	// Any second account, admin-flagged or not.
+	if err := solo.CheckAdditionalUsers(additionalOf(1 + 1)); err == nil {
+		t.Fatal("a second account passed a solo plan")
+	}
+
+	pair := Limits{AdditionalUsers: Of(2)}
+	for _, total := range []int64{0, 1, 2} {
+		if err := pair.CheckAdditionalUsers(additionalOf(total + 1)); err != nil {
+			t.Fatalf("account %d of an admin-plus-two plan was refused: %v", total+1, err)
+		}
+	}
+	if err := pair.CheckAdditionalUsers(additionalOf(3 + 1)); err == nil {
+		t.Fatal("a fourth account passed an admin-plus-two plan")
+	}
+}
+
+// The serialized form is what a client actually sees, and PocketBase rewrites
+// any data value that does not implement router.SafeErrorItem into a generic
+// "Invalid value." So assert on the JSON, not on RawData -- RawData passing
+// proves nothing about what reaches the browser.
+func TestExceededAPIErrorSurvivesSerialization(t *testing.T) {
+	exceeded := &ErrExceeded{Name: NameDocuments, Allowed: 3, Used: 3, Message: "This instance holds 2 of 2 documents, so there is no room for another."}
+	apiErr := exceeded.APIError()
+	if apiErr.Status != 400 {
+		t.Fatalf("Status = %d, want 400", apiErr.Status)
+	}
+
+	encoded, err := json.Marshal(apiErr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var payload struct {
+		Message string `json:"message"`
+		Data    struct {
+			Limit struct {
+				Code   string `json:"code"`
+				Params struct {
+					Limit   string `json:"limit"`
+					Allowed int64  `json:"allowed"`
+					Used    int64  `json:"used"`
+				} `json:"params"`
+			} `json:"limit"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if payload.Message != "This instance holds 2 of 2 documents, so there is no room for another." {
+		t.Fatalf("message = %q; a real message must survive PocketBase sentenizing it", payload.Message)
+	}
+	if payload.Data.Limit.Code != "limit_documents" {
+		t.Fatalf("code = %q, want limit_documents (got %s)", payload.Data.Limit.Code, encoded)
+	}
+	if payload.Data.Limit.Params.Limit != NameDocuments {
+		t.Fatalf("params.limit = %q, want %q", payload.Data.Limit.Params.Limit, NameDocuments)
+	}
+	if payload.Data.Limit.Params.Allowed != 3 || payload.Data.Limit.Params.Used != 3 {
+		t.Fatalf("params allowed/used = %d/%d, want 3/3",
+			payload.Data.Limit.Params.Allowed, payload.Data.Limit.Params.Used)
+	}
+}
+
+func TestAsExceededIgnoresOtherErrors(t *testing.T) {
+	if AsExceeded(nil) != nil {
+		t.Fatal("nil produced a rejection")
+	}
+	if AsExceeded(errOther{}) != nil {
+		t.Fatal("an unrelated error was read as a limit rejection")
+	}
+}
+
+type errOther struct{}
+
+func (errOther) Error() string { return "other" }
+
+func TestFormatBytes(t *testing.T) {
+	for _, tc := range []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{20 << 20, "20 MB"},
+		{1 << 30, "1.0 GB"},
+	} {
+		if got := formatBytes(tc.n); got != tc.want {
+			t.Fatalf("formatBytes(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/limits/limits.go
+++ b/backend/internal/limits/limits.go
@@ -1,0 +1,210 @@
+// Package limits bounds how much one instance may hold.
+//
+// The six allowances here are what a hosted plan is made of: how many documents
+// an instance stores, how many pages those add up to, how many bytes they occupy,
+// how large a single file may be, how many pages that file may have, and how many
+// accounts exist besides the admin. They are read from the environment and
+// nowhere else -- an orchestrator can only express a plan as the environment of
+// the container it creates, and an admin editing the Settings page must not be
+// able to raise their own plan. That is the same reasoning UPLOAD_MAX_MB was
+// added under, and the reason none of these joins app_settings or the
+// env_applied mechanism.
+//
+// Every limit is unlimited by default, so an install that sets nothing behaves
+// exactly as it did before this package existed.
+package limits
+
+import (
+	"log/slog"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Limit is one allowance: either unset, which bounds nothing, or a number.
+//
+// A struct rather than a bare int64 with a magic value, because both 0 and -1
+// are wanted for real things. Zero is a limit a plan genuinely sells --
+// LIMIT_ADDITIONAL_USERS=0 is "a single account, no extras" -- so 0 cannot double
+// as the unlimited sentinel; and a negative number is a typo, not an allowance.
+// The zero Limit is the unlimited one, so the zero Limits bounds nothing and a
+// test can build the unlimited case without naming six fields.
+type Limit struct {
+	value int64
+	set   bool
+}
+
+// Of returns a Limit bounding at value.
+func Of(value int64) Limit {
+	return Limit{value: value, set: true}
+}
+
+// Unlimited returns the Limit that bounds nothing. Same as the zero value; named
+// so a call site reads as a decision rather than an omission.
+func Unlimited() Limit {
+	return Limit{}
+}
+
+// IsUnlimited reports whether this limit bounds anything.
+func (l Limit) IsUnlimited() bool { return !l.set }
+
+// Value is the bound. Meaningless when IsUnlimited.
+func (l Limit) Value() int64 { return l.value }
+
+// Exceeded reports whether want would cross the limit.
+func (l Limit) Exceeded(want int64) bool {
+	return l.set && want > l.value
+}
+
+// Remaining is how much headroom is left given what is already used, floored at
+// zero so an instance that is already over its limit reports 0 rather than a
+// negative. Meaningless when IsUnlimited.
+func (l Limit) Remaining(used int64) int64 {
+	if !l.set {
+		return 0
+	}
+	if used >= l.value {
+		return 0
+	}
+	return l.value - used
+}
+
+// Limits is one instance's allowance.
+type Limits struct {
+	// Documents caps how many documents the instance stores.
+	Documents Limit
+	// DocumentPages caps the sum of every stored document's page count.
+	DocumentPages Limit
+	// StorageBytes caps the sum of every stored document's size.
+	StorageBytes Limit
+	// FileBytes caps one document's file. It can only lower the effective cap:
+	// the documents.file field carries its own 20 MB MaxSize, which PocketBase
+	// enforces in the field validator, so a larger value here has no effect.
+	FileBytes Limit
+	// FilePages caps the page count of one document.
+	FilePages Limit
+	// AdditionalUsers caps accounts other than the paired admin.
+	AdditionalUsers Limit
+}
+
+// Any reports whether anything is bounded at all, so callers can skip work --
+// and so the UI renders nothing on an install that sets no limits.
+func (l Limits) Any() bool {
+	for _, limit := range []Limit{
+		l.Documents, l.DocumentPages, l.StorageBytes,
+		l.FileBytes, l.FilePages, l.AdditionalUsers,
+	} {
+		if !limit.IsUnlimited() {
+			return true
+		}
+	}
+	return false
+}
+
+// Env var names, exported so the docs, the tests and an orchestrator's
+// allowlist all read the same strings.
+const (
+	EnvDocuments       = "LIMIT_DOCUMENTS"
+	EnvDocumentPages   = "LIMIT_DOCUMENT_PAGES"
+	EnvStorageBytes    = "LIMIT_STORAGE_BYTES"
+	EnvFileBytes       = "LIMIT_FILE_BYTES"
+	EnvFilePages       = "LIMIT_FILE_PAGES"
+	EnvAdditionalUsers = "LIMIT_ADDITIONAL_USERS"
+)
+
+// EnvKeys lists every variable this package reads, in the order the docs list
+// them.
+func EnvKeys() []string {
+	return []string{
+		EnvDocuments,
+		EnvDocumentPages,
+		EnvStorageBytes,
+		EnvFileBytes,
+		EnvFilePages,
+		EnvAdditionalUsers,
+	}
+}
+
+// FromEnv reads the limits, and returns the names of any variables it could not
+// use alongside them.
+//
+// Called once at process start, like pdfsplit.MaxPDFBytes: a limit is a property
+// of the container an orchestrator created, and an orchestrator changes it by
+// recreating the container rather than by reaching into a running one.
+//
+// The second return exists because of what an unusable value falls back to. A
+// limit nobody can read becomes unlimited, which is a working instance and a
+// wrong plan -- the one failure mode here that is invisible from the outside. So
+// the bad names travel with the limits, to be logged loudly and shown to an
+// admin, rather than only appearing once in a boot log nobody reads.
+func FromEnv(logger *slog.Logger) (Limits, []string) {
+	var misconfigured []string
+	read := func(key string) Limit {
+		limit, ok := envLimit(logger, key)
+		if !ok {
+			misconfigured = append(misconfigured, key)
+		}
+		return limit
+	}
+	// Built into a local first, and returned in a separate statement. Go does not
+	// order a plain variable read against the function calls in the same
+	// expression, so returning the struct literal and misconfigured together
+	// reads the slice header before read() has finished appending to it.
+	lim := Limits{
+		Documents:       read(EnvDocuments),
+		DocumentPages:   read(EnvDocumentPages),
+		StorageBytes:    read(EnvStorageBytes),
+		FileBytes:       read(EnvFileBytes),
+		FilePages:       read(EnvFilePages),
+		AdditionalUsers: read(EnvAdditionalUsers),
+	}
+	return lim, misconfigured
+}
+
+// envLimit parses one limit. Unset means unlimited; so does a value this cannot
+// use.
+//
+// Falling back to unlimited on a malformed value follows the convention the rest
+// of this codebase reads environment under -- a typo in an orchestrator's
+// environment must not take a customer's instance down, and the default is a
+// working configuration. For a limit that cuts the other way from usual: a typo
+// grants more room rather than less. That is still the direction to fail in,
+// because the alternative is locking an owner out of their own archive over a
+// stray character, and the warning is what makes it diagnosable.
+//
+// An explicit 0 is honoured, not treated as unset: it is how a plan says "none".
+//
+// The second return is false only when a value was set and could not be used --
+// not for an unset variable, which is a deliberate "unlimited" rather than a
+// mistake.
+func envLimit(logger *slog.Logger, key string) (Limit, bool) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return Unlimited(), true
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		reject(logger, "instance limit ignored: not a whole number", key, raw)
+		return Unlimited(), false
+	}
+	if value < 0 {
+		reject(logger, "instance limit ignored: negative", key, raw)
+		return Unlimited(), false
+	}
+	if value == math.MaxInt64 {
+		// Keeps the +1 in the headroom arithmetic from overflowing.
+		return Of(math.MaxInt64 - 1), true
+	}
+	return Of(value), true
+}
+
+// reject logs at ERROR, not WARN: the instance keeps running, so this is the
+// only signal that a plan is not being enforced.
+func reject(logger *slog.Logger, msg, key, raw string) {
+	if logger == nil {
+		return
+	}
+	// The value is safe to log: a limit is a number, not a credential.
+	logger.Error(msg, "env", key, "value", raw, "effect", "unlimited")
+}

--- a/backend/internal/limits/limits_test.go
+++ b/backend/internal/limits/limits_test.go
@@ -1,0 +1,178 @@
+package limits
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEnvLimitParsing(t *testing.T) {
+	cases := []struct {
+		name          string
+		raw           string
+		set           bool
+		wantUnlimited bool
+		wantValue     int64
+	}{
+		{name: "unset", set: false, wantUnlimited: true},
+		{name: "empty", raw: "", set: true, wantUnlimited: true},
+		{name: "whitespace", raw: "   ", set: true, wantUnlimited: true},
+		{name: "positive", raw: "25", set: true, wantValue: 25},
+		{name: "padded", raw: " 25 ", set: true, wantValue: 25},
+		// Zero is a limit a plan sells ("no extra accounts"), not a way of
+		// saying unset, so it has to survive parsing as a real bound.
+		{name: "explicit zero", raw: "0", set: true, wantValue: 0},
+		// A typo grants room rather than taking the instance down.
+		{name: "not a number", raw: "2O", set: true, wantUnlimited: true},
+		{name: "float", raw: "2.5", set: true, wantUnlimited: true},
+		{name: "negative", raw: "-1", set: true, wantUnlimited: true},
+		{name: "max int64 is clamped", raw: "9223372036854775807", set: true, wantValue: math.MaxInt64 - 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(EnvDocuments, tc.raw)
+			}
+			got, _ := envLimit(nil, EnvDocuments)
+			if got.IsUnlimited() != tc.wantUnlimited {
+				t.Fatalf("%q: IsUnlimited = %v, want %v", tc.raw, got.IsUnlimited(), tc.wantUnlimited)
+			}
+			if !tc.wantUnlimited && got.Value() != tc.wantValue {
+				t.Fatalf("%q: Value = %d, want %d", tc.raw, got.Value(), tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestFromEnvReadsEveryVariable(t *testing.T) {
+	t.Setenv(EnvDocuments, "1")
+	t.Setenv(EnvDocumentPages, "2")
+	t.Setenv(EnvStorageBytes, "3")
+	t.Setenv(EnvFileBytes, "4")
+	t.Setenv(EnvFilePages, "5")
+	t.Setenv(EnvAdditionalUsers, "6")
+
+	lim, misconfigured := FromEnv(nil)
+	if len(misconfigured) != 0 {
+		t.Fatalf("usable values reported as misconfigured: %v", misconfigured)
+	}
+	for _, tc := range []struct {
+		name  string
+		limit Limit
+		want  int64
+	}{
+		{EnvDocuments, lim.Documents, 1},
+		{EnvDocumentPages, lim.DocumentPages, 2},
+		{EnvStorageBytes, lim.StorageBytes, 3},
+		{EnvFileBytes, lim.FileBytes, 4},
+		{EnvFilePages, lim.FilePages, 5},
+		{EnvAdditionalUsers, lim.AdditionalUsers, 6},
+	} {
+		if tc.limit.IsUnlimited() {
+			t.Fatalf("%s: unlimited, want %d", tc.name, tc.want)
+		}
+		if tc.limit.Value() != tc.want {
+			t.Fatalf("%s: got %d, want %d", tc.name, tc.limit.Value(), tc.want)
+		}
+	}
+}
+
+// The default has to be "nothing is bounded" or an existing self-hosted install
+// changes behaviour on upgrade.
+func TestZeroLimitsBoundNothing(t *testing.T) {
+	var lim Limits
+	if lim.Any() {
+		t.Fatal("the zero Limits bounds something")
+	}
+	if err := lim.CheckFile(1<<40, 100000); err != nil {
+		t.Fatalf("unlimited CheckFile refused: %v", err)
+	}
+	err := lim.CheckRoom(Usage{Documents: 1e9, DocumentPages: 1e9, StorageBytes: 1e15}, 1, 1, 1)
+	if err != nil {
+		t.Fatalf("unlimited CheckRoom refused: %v", err)
+	}
+	if err := lim.CheckAdditionalUsers(1e6); err != nil {
+		t.Fatalf("unlimited CheckAdditionalUsers refused: %v", err)
+	}
+}
+
+func TestFromEnvUnsetIsUnlimited(t *testing.T) {
+	for _, key := range EnvKeys() {
+		t.Setenv(key, "")
+	}
+	lim, misconfigured := FromEnv(nil)
+	if lim.Any() {
+		t.Fatal("no variables set, but limits report as enforced")
+	}
+	// Unset is a deliberate "unlimited", not a mistake to report.
+	if len(misconfigured) != 0 {
+		t.Fatalf("unset variables reported as misconfigured: %v", misconfigured)
+	}
+}
+
+// A value nobody can read falls back to unlimited, which is a working instance
+// on the wrong plan. The name has to come back so it can be logged loudly and
+// shown to an admin.
+func TestFromEnvReportsUnusableValues(t *testing.T) {
+	t.Setenv(EnvDocuments, "2O")
+	t.Setenv(EnvFilePages, "-3")
+	t.Setenv(EnvStorageBytes, "1000")
+
+	lim, misconfigured := FromEnv(nil)
+	if !lim.Documents.IsUnlimited() || !lim.FilePages.IsUnlimited() {
+		t.Fatal("an unusable value produced a bound")
+	}
+	if lim.StorageBytes.IsUnlimited() {
+		t.Fatal("a usable value alongside bad ones was dropped")
+	}
+	want := map[string]bool{EnvDocuments: true, EnvFilePages: true}
+	if len(misconfigured) != len(want) {
+		t.Fatalf("misconfigured = %v, want the two unusable keys", misconfigured)
+	}
+	for _, key := range misconfigured {
+		if !want[key] {
+			t.Fatalf("misconfigured names %q, which was usable", key)
+		}
+	}
+}
+
+func TestLimitRemaining(t *testing.T) {
+	limit := Of(10)
+	for _, tc := range []struct{ used, want int64 }{
+		{0, 10}, {3, 7}, {10, 0},
+		// Already over: report no headroom rather than a negative.
+		{12, 0},
+	} {
+		if got := limit.Remaining(tc.used); got != tc.want {
+			t.Fatalf("Remaining(%d) = %d, want %d", tc.used, got, tc.want)
+		}
+	}
+}
+
+func TestLimitExceeded(t *testing.T) {
+	limit := Of(2)
+	if limit.Exceeded(2) {
+		t.Fatal("2 exceeds a limit of 2")
+	}
+	if !limit.Exceeded(3) {
+		t.Fatal("3 does not exceed a limit of 2")
+	}
+	if Unlimited().Exceeded(math.MaxInt64) {
+		t.Fatal("an unlimited limit was exceeded")
+	}
+}
+
+func TestAnyReportsEachLimit(t *testing.T) {
+	for name, lim := range map[string]Limits{
+		"documents":        {Documents: Of(1)},
+		"document pages":   {DocumentPages: Of(1)},
+		"storage bytes":    {StorageBytes: Of(1)},
+		"file bytes":       {FileBytes: Of(1)},
+		"file pages":       {FilePages: Of(1)},
+		"additional users": {AdditionalUsers: Of(0)},
+	} {
+		if !lim.Any() {
+			t.Fatalf("%s set, but Any() is false", name)
+		}
+	}
+}

--- a/backend/internal/limits/pagecount.go
+++ b/backend/internal/limits/pagecount.go
@@ -1,0 +1,97 @@
+package limits
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+
+	"lemmary/backend/internal/ocr"
+	"lemmary/backend/internal/pdftool"
+)
+
+// SinglePage is what everything that is not a multi-page PDF counts as. An
+// image, a text file, a CSV, a DOCX or an XLSX is one document and one page for
+// the purpose of an allowance; splitting a spreadsheet into notional pages would
+// mean a number nobody can predict from looking at the file.
+const SinglePage int64 = 1
+
+// PageCountOfUpload reports how many pages an unsaved upload holds.
+//
+// Only a PDF is inspected, and only by spooling it to a temp file first, because
+// pdfinfo takes a path and the upload is a reader. That cost is paid by PDFs
+// alone: every other accepted type returns SinglePage without touching the disk.
+//
+// A PDF whose page count cannot be read counts as SinglePage with a warning
+// rather than failing the upload. pdfinfo failing means the file is not a PDF
+// poppler can read, which is the processing pipeline's problem to report against
+// the stored document -- refusing to store it here would turn a bad limit
+// interaction into data loss.
+func PageCountOfUpload(logger *slog.Logger, file *filesystem.File) int64 {
+	if file == nil {
+		return SinglePage
+	}
+	if ocr.GuessMimeType(file.Name) != "application/pdf" {
+		return SinglePage
+	}
+
+	path, cleanup, err := spool(file)
+	if err != nil {
+		logWarn(logger, "page count fell back to one page: could not stage the upload", file.Name, err)
+		return SinglePage
+	}
+	defer cleanup()
+
+	count, err := pdftool.PageCount(context.Background(), path)
+	if err != nil {
+		logWarn(logger, "page count fell back to one page: unreadable PDF", file.Name, err)
+		return SinglePage
+	}
+	if count < 1 {
+		return SinglePage
+	}
+	return int64(count)
+}
+
+// spool writes an unsaved upload to a temp file, following the pattern
+// worker.readDocumentToTempFile uses for a stored one: a path plus the cleanup
+// that removes it.
+func spool(file *filesystem.File) (path string, cleanup func(), err error) {
+	noop := func() {}
+	if file.Reader == nil {
+		return "", noop, os.ErrInvalid
+	}
+	source, err := file.Reader.Open()
+	if err != nil {
+		return "", noop, err
+	}
+	defer source.Close()
+
+	tmp, err := os.CreateTemp("", "lemmary-limits-*"+filepath.Ext(file.Name))
+	if err != nil {
+		return "", noop, err
+	}
+	path = tmp.Name()
+	cleanup = func() { os.Remove(path) }
+
+	if _, err := io.Copy(tmp, source); err != nil {
+		tmp.Close()
+		cleanup()
+		return "", noop, err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", noop, err
+	}
+	return path, cleanup, nil
+}
+
+func logWarn(logger *slog.Logger, msg, name string, err error) {
+	if logger == nil {
+		return
+	}
+	logger.Warn(msg, "component", "limits", "file", name, slog.Any("error", err))
+}

--- a/backend/internal/limits/pagecount.go
+++ b/backend/internal/limits/pagecount.go
@@ -5,11 +5,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/pocketbase/pocketbase/tools/filesystem"
 
-	"lemmary/backend/internal/ocr"
 	"lemmary/backend/internal/pdftool"
 )
 
@@ -21,9 +19,17 @@ const SinglePage int64 = 1
 
 // PageCountOfUpload reports how many pages an unsaved upload holds.
 //
-// Only a PDF is inspected, and only by spooling it to a temp file first, because
-// pdfinfo takes a path and the upload is a reader. That cost is paid by PDFs
-// alone: every other accepted type returns SinglePage without touching the disk.
+// Whether the upload is a PDF is decided by its first five bytes, never by its
+// name. The name is the client's word, and every page limit would fall to `mv`
+// if this trusted it: .txt, .csv and .docx are all accepted upload types, and a
+// multi-page PDF renamed to any of them would be charged a single page while
+// being stored as the PDF it is. pdfsplit's staging check makes the same point
+// about a declared content type -- the header and a successful page count are
+// the only things the file itself says.
+//
+// Reading the header costs one open of five bytes. Only an upload that passes it
+// is spooled to a temp file, which pdfinfo needs because it takes a path and an
+// upload is a reader, so an image or a text file still touches no disk here.
 //
 // A PDF whose page count cannot be read counts as SinglePage with a warning
 // rather than failing the upload. pdfinfo failing means the file is not a PDF
@@ -34,7 +40,7 @@ func PageCountOfUpload(logger *slog.Logger, file *filesystem.File) int64 {
 	if file == nil {
 		return SinglePage
 	}
-	if ocr.GuessMimeType(file.Name) != "application/pdf" {
+	if !hasPDFHeader(file) {
 		return SinglePage
 	}
 
@@ -56,9 +62,36 @@ func PageCountOfUpload(logger *slog.Logger, file *filesystem.File) int64 {
 	return int64(count)
 }
 
+// hasPDFHeader reports whether the upload's first five bytes are a PDF header.
+//
+// Mirrors pdfsplit's staging check, on a reader rather than a path. Anything
+// unreadable is treated as not-a-PDF: the page count then falls back to one
+// page, and whatever is actually wrong with the file is the pipeline's to report
+// against the stored document.
+func hasPDFHeader(file *filesystem.File) bool {
+	if file.Reader == nil {
+		return false
+	}
+	reader, err := file.Reader.Open()
+	if err != nil {
+		return false
+	}
+	defer reader.Close()
+
+	var header [5]byte
+	if _, err := io.ReadFull(reader, header[:]); err != nil {
+		return false
+	}
+	return string(header[:]) == "%PDF-"
+}
+
 // spool writes an unsaved upload to a temp file, following the pattern
 // worker.readDocumentToTempFile uses for a stored one: a path plus the cleanup
 // that removes it.
+//
+// The temp name always carries .pdf, whatever the upload is called: only a file
+// whose header said PDF reaches here, and the pdftool helpers key off the
+// extension.
 func spool(file *filesystem.File) (path string, cleanup func(), err error) {
 	noop := func() {}
 	if file.Reader == nil {
@@ -70,7 +103,7 @@ func spool(file *filesystem.File) (path string, cleanup func(), err error) {
 	}
 	defer source.Close()
 
-	tmp, err := os.CreateTemp("", "lemmary-limits-*"+filepath.Ext(file.Name))
+	tmp, err := os.CreateTemp("", "lemmary-limits-*.pdf")
 	if err != nil {
 		return "", noop, err
 	}

--- a/backend/internal/limits/pagecount_test.go
+++ b/backend/internal/limits/pagecount_test.go
@@ -1,0 +1,91 @@
+package limits
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+
+	"lemmary/backend/internal/pdftool/testpdf"
+)
+
+func requirePoppler(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("pdfinfo"); err != nil {
+		t.Skip("pdfinfo not installed")
+	}
+}
+
+func uploadFromBytes(t *testing.T, name string, data []byte) *filesystem.File {
+	t.Helper()
+	file, err := filesystem.NewFileFromBytes(data, name)
+	if err != nil {
+		t.Fatalf("build upload: %v", err)
+	}
+	// NewFileFromBytes rewrites Name with a random suffix; the extension is what
+	// PageCountOfUpload dispatches on, and that survives.
+	return file
+}
+
+func TestPageCountOfUploadCountsPDFPages(t *testing.T) {
+	requirePoppler(t)
+	for _, pages := range []int{1, 3, 12} {
+		file := uploadFromBytes(t, "scan.pdf", testpdf.Multipage(pages))
+		if got := PageCountOfUpload(nil, file); got != int64(pages) {
+			t.Fatalf("a %d-page PDF counted as %d", pages, got)
+		}
+	}
+}
+
+// Everything that is not a PDF is one document and one page, and must not cost
+// a temp file to find that out.
+func TestPageCountOfUploadNonPDFIsOnePage(t *testing.T) {
+	for _, name := range []string{
+		"receipt.png", "receipt.jpg", "receipt.webp",
+		"notes.txt", "table.csv",
+		"letter.docx", "book.xlsx",
+	} {
+		file := uploadFromBytes(t, name, []byte("not a pdf"))
+		if got := PageCountOfUpload(nil, file); got != SinglePage {
+			t.Fatalf("%s counted as %d pages, want %d", name, got, SinglePage)
+		}
+	}
+}
+
+// A file poppler cannot read must still be storable: refusing it here would turn
+// an unreadable PDF into data loss, when the processing pipeline is the thing
+// that should report it.
+func TestPageCountOfUploadUnreadablePDFIsOnePage(t *testing.T) {
+	requirePoppler(t)
+	file := uploadFromBytes(t, "broken.pdf", []byte("%PDF-1.4 but not really"))
+	if got := PageCountOfUpload(nil, file); got != SinglePage {
+		t.Fatalf("an unreadable PDF counted as %d pages, want %d", got, SinglePage)
+	}
+}
+
+func TestPageCountOfUploadNilFile(t *testing.T) {
+	if got := PageCountOfUpload(nil, nil); got != SinglePage {
+		t.Fatalf("a nil upload counted as %d, want %d", got, SinglePage)
+	}
+}
+
+// The temp copy a PDF needs must not outlive the call.
+func TestPageCountOfUploadRemovesItsTempFile(t *testing.T) {
+	requirePoppler(t)
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+
+	file := uploadFromBytes(t, "scan.pdf", testpdf.Multipage(2))
+	if got := PageCountOfUpload(nil, file); got != 2 {
+		t.Fatalf("page count = %d, want 2", got)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("%d temp files left behind: %v", len(entries), entries)
+	}
+}

--- a/backend/internal/limits/pagecount_test.go
+++ b/backend/internal/limits/pagecount_test.go
@@ -23,8 +23,8 @@ func uploadFromBytes(t *testing.T, name string, data []byte) *filesystem.File {
 	if err != nil {
 		t.Fatalf("build upload: %v", err)
 	}
-	// NewFileFromBytes rewrites Name with a random suffix; the extension is what
-	// PageCountOfUpload dispatches on, and that survives.
+	// NewFileFromBytes rewrites Name with a random suffix, keeping the extension.
+	// That only matters for the tests that assert the extension is *ignored*.
 	return file
 }
 
@@ -49,6 +49,53 @@ func TestPageCountOfUploadNonPDFIsOnePage(t *testing.T) {
 		file := uploadFromBytes(t, name, []byte("not a pdf"))
 		if got := PageCountOfUpload(nil, file); got != SinglePage {
 			t.Fatalf("%s counted as %d pages, want %d", name, got, SinglePage)
+		}
+	}
+}
+
+// The name is the client's word. Trusting it made every page limit bypassable
+// with `mv`: .txt, .csv and .docx are all accepted upload types, so a multi-page
+// PDF renamed to one of them was stored as the PDF it is and charged one page.
+func TestPageCountOfUploadIgnoresASpoofedExtension(t *testing.T) {
+	requirePoppler(t)
+	pdf := testpdf.Multipage(7)
+	for _, name := range []string{
+		"notes.txt", "table.csv", "letter.docx", "book.xlsx", "receipt.png",
+		"no-extension-at-all",
+	} {
+		file := uploadFromBytes(t, name, pdf)
+		if got := PageCountOfUpload(nil, file); got != 7 {
+			t.Fatalf("a 7-page PDF named %s counted as %d pages", name, got)
+		}
+	}
+}
+
+// The mirror image: something merely *named* .pdf is not charged for pages it
+// does not have, and never reaches pdfinfo.
+func TestPageCountOfUploadIgnoresAPDFNameWithoutTheHeader(t *testing.T) {
+	file := uploadFromBytes(t, "invoice.pdf", []byte("this is plain text, not a PDF"))
+	if got := PageCountOfUpload(nil, file); got != SinglePage {
+		t.Fatalf("a text file named .pdf counted as %d pages, want %d", got, SinglePage)
+	}
+}
+
+func TestHasPDFHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"real pdf", testpdf.Multipage(1), true},
+		{"header only", []byte("%PDF-1.7"), true},
+		{"plain text", []byte("hello there"), false},
+		// Shorter than the header, so io.ReadFull cannot fill it. (A wholly
+		// empty upload cannot be constructed, and PocketBase rejects one.)
+		{"truncated", []byte("%PDF"), false},
+		// A PDF header that is not at the very start is not one.
+		{"offset header", append([]byte("junk"), []byte("%PDF-1.7")...), false},
+	} {
+		if got := hasPDFHeader(uploadFromBytes(t, tc.name, tc.data)); got != tc.want {
+			t.Fatalf("%s: hasPDFHeader = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }

--- a/backend/internal/limits/register.go
+++ b/backend/internal/limits/register.go
@@ -46,6 +46,16 @@ func Register(app core.App, lim Limits) {
 		// record.Set("file", ...) is on a freshly built record -- so in practice
 		// this fires only for a client doing it deliberately.
 		app.OnRecordUpdate("documents").BindFunc(func(e *core.RecordEvent) error {
+			// An update that brings no file must not be able to restate what
+			// this document costs. Marking the two columns Hidden stops a
+			// regular account writing them, but only a regular account:
+			// PocketBase's GrantSuperuserAccess is documented as allowing
+			// "changing all system record fields, including those marked as
+			// Hidden", so a superuser could otherwise PATCH size_bytes to 0 and
+			// mint headroom -- which is precisely the thing these limits exist
+			// to take out of an admin's hands.
+			restoreMeasurements(e.Record)
+
 			// A replacement adds no new document, so the count limit is not in
 			// play: 0 documents, and pages and bytes are charged net of what
 			// this record already contributed.
@@ -127,6 +137,24 @@ func applyDocumentLimits(app core.App, lim Limits, record *core.Record, addsDocu
 	// refuses, and the alternatives -- serializing every upload, or a
 	// transactional counter row -- cost more than the problem.
 	return lim.CheckRoom(usage, addsDocuments, pageCount-priorPages, sizeBytes-priorBytes)
+}
+
+// restoreMeasurements puts the stored size_bytes and page_count back, discarding
+// whatever the request carried.
+//
+// applyDocumentLimits overwrites both from the file whenever an update brings
+// one, so this only has to cover the file-less case -- and it runs before that,
+// so an update that does bring a file still ends up with the measured values.
+// Restoring rather than rejecting matches what PocketBase already does for a
+// hidden field on a non-superuser write, and leaves every other edit on the
+// record working.
+//
+// The cost is that nobody can hand-correct a measurement, superuser included.
+// That is the intended trade: a plan an admin can edit is not a plan.
+func restoreMeasurements(record *core.Record) {
+	original := record.Original()
+	record.Set("size_bytes", original.GetFloat("size_bytes"))
+	record.Set("page_count", original.GetFloat("page_count"))
 }
 
 func needsRoomCheck(lim Limits) bool {

--- a/backend/internal/limits/register.go
+++ b/backend/internal/limits/register.go
@@ -1,0 +1,173 @@
+package limits
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Register binds the limit checks.
+//
+// Two hooks are all the enforcement there is, because every way a document or an
+// account comes into being ends in app.Save on one of these two collections:
+// the SPA's collection-API upload, the paperless-ngx post_document endpoint, a
+// PDF split, an Amazon-orders import, a backup restore, a paperless-ngx remote
+// pull, the setup wizard, the superuser CLI, and the PocketBase admin UI.
+//
+// Bind this before worker.Register in appwire so an over-limit upload is refused
+// before duplicates.AssignChecksumFromUpload reads the whole file to hash it.
+// PocketBase sorts equal-priority handlers stably, so registration order is what
+// decides that.
+//
+// An unlimited install binds nothing at all: no hook, no query per upload, no
+// page count, no behaviour change whatsoever.
+func Register(app core.App, lim Limits) {
+	if !lim.Any() {
+		return
+	}
+
+	app.Logger().Info("instance limits active", limitAttrs(lim)...)
+
+	if boundsDocuments(lim) {
+		app.OnRecordCreate("documents").BindFunc(func(e *core.RecordEvent) error {
+			if err := applyDocumentLimits(e.App, lim, e.Record, 1); err != nil {
+				if exceeded := AsExceeded(err); exceeded != nil {
+					return exceeded.APIError()
+				}
+				return err
+			}
+			return e.Next()
+		})
+
+		// An update can replace the file. documents.UpdateRule lets an owner
+		// patch their own row, so without this an account creates a one-page
+		// document and then patches a 500-page file onto it: the stored bytes
+		// change and the measurements this instance charges against do not.
+		//
+		// Nothing in this codebase replaces a document's file -- every
+		// record.Set("file", ...) is on a freshly built record -- so in practice
+		// this fires only for a client doing it deliberately.
+		app.OnRecordUpdate("documents").BindFunc(func(e *core.RecordEvent) error {
+			// A replacement adds no new document, so the count limit is not in
+			// play: 0 documents, and pages and bytes are charged net of what
+			// this record already contributed.
+			if err := applyDocumentLimits(e.App, lim, e.Record, 0); err != nil {
+				if exceeded := AsExceeded(err); exceeded != nil {
+					return exceeded.APIError()
+				}
+				return err
+			}
+			return e.Next()
+		})
+	}
+
+	if !lim.AdditionalUsers.IsUnlimited() {
+		app.OnRecordCreate("users").BindFunc(func(e *core.RecordEvent) error {
+			if err := applyUserLimit(e.App, lim, e.Record); err != nil {
+				if exceeded := AsExceeded(err); exceeded != nil {
+					return exceeded.APIError()
+				}
+				return err
+			}
+			return e.Next()
+		})
+	}
+}
+
+// boundsDocuments reports whether any limit touches a document. FileBytes and
+// FilePages alone are enough: the hook also stamps size_bytes and page_count, so
+// it has to run whenever anything measures a document.
+func boundsDocuments(lim Limits) bool {
+	return !lim.Documents.IsUnlimited() ||
+		!lim.DocumentPages.IsUnlimited() ||
+		!lim.StorageBytes.IsUnlimited() ||
+		!lim.FileBytes.IsUnlimited() ||
+		!lim.FilePages.IsUnlimited()
+}
+
+// applyDocumentLimits measures the upload, records the measurements on the
+// record, and refuses it if it does not fit.
+//
+// The measurements are set even when nothing is exceeded, and that is the reason
+// this runs for every create rather than only when a count limit is set: without
+// them the sums in Measure would not include the document about to be stored.
+func applyDocumentLimits(app core.App, lim Limits, record *core.Record, addsDocuments int64) error {
+	files := record.GetUnsavedFiles("file")
+	if len(files) == 0 {
+		// No new file: a create that attaches its file elsewhere, or -- far more
+		// often -- one of the many metadata updates the pipeline makes. Nothing
+		// to measure and nothing to re-charge.
+		return nil
+	}
+	file := files[0]
+
+	sizeBytes := file.Size
+	pageCount := PageCountOfUpload(app.Logger(), file)
+
+	// What this record already contributes to the totals, so a replacement is
+	// charged for the difference rather than counted twice. Zero on a create.
+	priorBytes := int64(record.GetFloat("size_bytes"))
+	priorPages := int64(record.GetFloat("page_count"))
+
+	record.Set("size_bytes", sizeBytes)
+	record.Set("page_count", pageCount)
+
+	if err := lim.CheckFile(sizeBytes, pageCount); err != nil {
+		return err
+	}
+
+	if !needsRoomCheck(lim) {
+		return nil
+	}
+	usage, err := Measure(app)
+	if err != nil {
+		return err
+	}
+	// Two uploads racing can both read the same totals and both pass a check
+	// only one should. Left alone deliberately: the overshoot is bounded by how
+	// many uploads are in flight, the next upload sees the true total and
+	// refuses, and the alternatives -- serializing every upload, or a
+	// transactional counter row -- cost more than the problem.
+	return lim.CheckRoom(usage, addsDocuments, pageCount-priorPages, sizeBytes-priorBytes)
+}
+
+func needsRoomCheck(lim Limits) bool {
+	return !lim.Documents.IsUnlimited() ||
+		!lim.DocumentPages.IsUnlimited() ||
+		!lim.StorageBytes.IsUnlimited()
+}
+
+// applyUserLimit refuses an account beyond the allowance.
+//
+// One account is free, structurally, so the setup wizard's first admin always
+// passes -- with nothing in the users table the projected seat count is zero,
+// whatever the limit -- and no exemption for is_app_admin is needed or wanted
+// here. See CountAdditionalUsers for why exempting the flag would be a bypass.
+func applyUserLimit(app core.App, lim Limits, _ *core.Record) error {
+	total, err := app.CountRecords("users")
+	if err != nil {
+		return err
+	}
+	// +1 for the record about to be inserted: this hook runs before the INSERT,
+	// so the table does not hold it yet.
+	return lim.CheckAdditionalUsers(additionalOf(total + 1))
+}
+
+func limitAttrs(lim Limits) []any {
+	attrs := make([]any, 0, 12)
+	for _, entry := range []struct {
+		name  string
+		limit Limit
+	}{
+		{NameDocuments, lim.Documents},
+		{NameDocumentPages, lim.DocumentPages},
+		{NameStorageBytes, lim.StorageBytes},
+		{NameFileBytes, lim.FileBytes},
+		{NameFilePages, lim.FilePages},
+		{NameAdditionalUsers, lim.AdditionalUsers},
+	} {
+		if entry.limit.IsUnlimited() {
+			continue
+		}
+		attrs = append(attrs, entry.name, entry.limit.Value())
+	}
+	return attrs
+}

--- a/backend/internal/limits/usage.go
+++ b/backend/internal/limits/usage.go
@@ -1,0 +1,92 @@
+package limits
+
+import (
+	"fmt"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Usage is what the instance currently holds.
+type Usage struct {
+	Documents       int64
+	DocumentPages   int64
+	StorageBytes    int64
+	AdditionalUsers int64
+}
+
+// Measure reads current usage.
+//
+// Everything is counted from live rows -- COUNT and SUM over documents rather
+// than a stored counter -- so deleting a document frees its allowance with no
+// bookkeeping at all. That matters here more than the query cost: there is no
+// custom delete hook on documents, and PocketBase frees the blob in a
+// fire-and-forget goroutine, so a counter would drift on exactly the path that
+// is hardest to observe.
+//
+// Documents that predate the page_count / size_bytes migration contribute 0 to
+// the two sums; see the migration for why they are not backfilled.
+func Measure(app core.App) (Usage, error) {
+	var documents, pages, bytes int64
+	// One index-only scan of idx_documents_usage; see the migration for why that
+	// index is not optional.
+	//
+	// COALESCE covers the empty library, where SUM over no rows is NULL. The
+	// CAST covers the column type: a NumberField is NUMERIC and PocketBase
+	// writes float64 into it, so SUM can come back REAL and must not be scanned
+	// straight into an int64.
+	//
+	// RecordQuery rather than a bare DB().NewQuery so this inherits PocketBase's
+	// lock-retry and query timeout, and so that inside a transaction it reads
+	// that transaction's own uncommitted rows -- which is what makes a batched
+	// importer accumulate correctly instead of re-reading a stale total.
+	err := app.RecordQuery("documents").
+		Select(
+			"COUNT(*)",
+			"CAST(COALESCE(SUM(page_count), 0) AS INTEGER)",
+			"CAST(COALESCE(SUM(size_bytes), 0) AS INTEGER)",
+		).
+		Row(&documents, &pages, &bytes)
+	if err != nil {
+		return Usage{}, fmt.Errorf("measure document usage: %w", err)
+	}
+
+	users, err := CountAdditionalUsers(app)
+	if err != nil {
+		return Usage{}, err
+	}
+
+	return Usage{
+		Documents:       documents,
+		DocumentPages:   pages,
+		StorageBytes:    bytes,
+		AdditionalUsers: users,
+	}, nil
+}
+
+// CountAdditionalUsers counts the accounts that consume the seat allowance.
+//
+// Exactly one account is free -- the instance's own admin, created by the setup
+// wizard or a superuser CLI command rather than bought as a seat. Exactly one,
+// not "every account carrying is_app_admin": a superuser can create a second
+// superuser from the PocketBase dashboard, and UpsertPairedUser gives that one a
+// flagged users record too, so exempting the flag would let the very person the
+// limit constrains mint accounts without bound.
+//
+// Counting from the total rather than filtering on the flag also sidesteps
+// three-valued logic: a record that has never had is_app_admin written holds SQL
+// NULL, which `is_app_admin != true` does not match in SQLite.
+func CountAdditionalUsers(app core.App) (int64, error) {
+	total, err := app.CountRecords("users")
+	if err != nil {
+		return 0, fmt.Errorf("count users: %w", err)
+	}
+	return additionalOf(total), nil
+}
+
+// additionalOf is the seat count for a given number of accounts: all but one.
+func additionalOf(total int64) int64 {
+	if total < 1 {
+		return 0
+	}
+	return total - 1
+}

--- a/backend/internal/pdfsplit/pdfsplit.go
+++ b/backend/internal/pdfsplit/pdfsplit.go
@@ -57,7 +57,7 @@ func maxPDFBytesFromEnv() int64 {
 // maxPartBytes matches the documents.file field limit, so a part that cannot be
 // stored is reported as skipped instead of failing the whole run.
 // A var so tests can shrink it instead of building 20 MB fixtures.
-var maxPartBytes int64 = 20 << 20
+var maxPartBytes = DefaultMaxPartBytes
 
 var (
 	// ErrNotPDF is returned when the upload is not a PDF poppler can read.

--- a/backend/internal/pdfsplit/perpart.go
+++ b/backend/internal/pdfsplit/perpart.go
@@ -1,0 +1,27 @@
+package pdfsplit
+
+// DefaultMaxPartBytes is the per-part cap with no instance limit configured. It
+// mirrors the documents.file field limit, which is what actually stores a part.
+const DefaultMaxPartBytes int64 = 20 << 20
+
+// SetMaxPartBytes sets the per-part cap to the effective per-document limit.
+//
+// Wiring-time only, called before any request is served, so an instance whose
+// plan caps a single document below the field limit reports an over-cap part as
+// skipped -- the behaviour this package already has for the field limit --
+// rather than having the create hook reject it partway through a split.
+//
+// A set rather than a one-way lower: the value has to be able to go back up. The
+// e2e harness boots a whole app repeatedly inside one test binary, and a
+// lower-only setter would leak the smallest limit any earlier boot configured
+// into every later one.
+//
+// Clamped to DefaultMaxPartBytes, because nothing here can lift the field's own
+// MaxSize -- PocketBase validates that during the save.
+func SetMaxPartBytes(n int64) {
+	if n <= 0 || n > DefaultMaxPartBytes {
+		maxPartBytes = DefaultMaxPartBytes
+		return
+	}
+	maxPartBytes = n
+}

--- a/backend/internal/pdfsplit/perpart.go
+++ b/backend/internal/pdfsplit/perpart.go
@@ -16,10 +16,14 @@ const DefaultMaxPartBytes int64 = 20 << 20
 // lower-only setter would leak the smallest limit any earlier boot configured
 // into every later one.
 //
+// A negative n means "use the default"; 0 is a real cap of zero, because an
+// explicit LIMIT_FILE_BYTES=0 is a real (if unusual) plan and must not read as
+// unlimited here while the create hook refuses every file.
+//
 // Clamped to DefaultMaxPartBytes, because nothing here can lift the field's own
 // MaxSize -- PocketBase validates that during the save.
 func SetMaxPartBytes(n int64) {
-	if n <= 0 || n > DefaultMaxPartBytes {
+	if n < 0 || n > DefaultMaxPartBytes {
 		maxPartBytes = DefaultMaxPartBytes
 		return
 	}

--- a/backend/internal/pdfsplit/perpart_test.go
+++ b/backend/internal/pdfsplit/perpart_test.go
@@ -1,0 +1,47 @@
+package pdfsplit
+
+import "testing"
+
+func TestSetMaxPartBytes(t *testing.T) {
+	original := maxPartBytes
+	t.Cleanup(func() { maxPartBytes = original })
+
+	for _, tc := range []struct {
+		name string
+		set  int64
+		want int64
+	}{
+		// A negative value is how "no limit configured" arrives.
+		{"unlimited restores the default", -1, DefaultMaxPartBytes},
+		{"a smaller cap applies", 1 << 20, 1 << 20},
+		// Zero is a real cap, not a way of saying unlimited: an explicit
+		// LIMIT_FILE_BYTES=0 must leave the preview agreeing with the create
+		// hook, which refuses every non-empty file.
+		{"zero is a real cap", 0, 0},
+		// Nothing here can lift the documents.file field's own MaxSize.
+		{"a larger cap is clamped", DefaultMaxPartBytes * 10, DefaultMaxPartBytes},
+		{"exactly the default", DefaultMaxPartBytes, DefaultMaxPartBytes},
+	} {
+		SetMaxPartBytes(tc.set)
+		if maxPartBytes != tc.want {
+			t.Fatalf("%s: SetMaxPartBytes(%d) left %d, want %d",
+				tc.name, tc.set, maxPartBytes, tc.want)
+		}
+	}
+}
+
+// Wiring calls this on every boot, including boots that configure nothing, so it
+// has to be able to raise the cap back to the default rather than only lower it.
+// Without that the e2e harness -- which boots a whole app repeatedly in one test
+// binary -- would leak the smallest cap any earlier boot set into every later one.
+func TestSetMaxPartBytesIsNotOneWay(t *testing.T) {
+	original := maxPartBytes
+	t.Cleanup(func() { maxPartBytes = original })
+
+	SetMaxPartBytes(1024)
+	SetMaxPartBytes(-1)
+	if maxPartBytes != DefaultMaxPartBytes {
+		t.Fatalf("cap stuck at %d after an unlimited boot, want %d",
+			maxPartBytes, DefaultMaxPartBytes)
+	}
+}

--- a/backend/migrations/1730000014_document_size_and_pages.go
+++ b/backend/migrations/1730000014_document_size_and_pages.go
@@ -24,12 +24,16 @@ func init() {
 		if err != nil {
 			return err
 		}
-		// Hidden so a client cannot write them. The create hook overwrites
-		// whatever arrives on a create, but an update carrying only
-		// size_bytes = 0 would otherwise hand any account an unlimited
-		// allowance: documents.UpdateRule lets an owner patch their own row.
-		// PocketBase restores a hidden field from the stored value for every
-		// non-superuser write, which closes that without a second guard.
+		// Hidden so a regular account cannot write them: documents.UpdateRule
+		// lets an owner patch their own row, and an update carrying only
+		// size_bytes = 0 would otherwise hand them an unlimited allowance.
+		//
+		// Hidden is only half of it, and on its own would be a false comfort.
+		// PocketBase restores a hidden field from the stored value for a
+		// non-superuser write, but GrantSuperuserAccess is documented as
+		// allowing "changing all system record fields, including those marked
+		// as Hidden". The documents update hook in internal/limits restores
+		// both columns for everyone, which is what actually closes it.
 		if documents.Fields.GetByName("page_count") == nil {
 			documents.Fields.Add(&core.NumberField{
 				Name:    "page_count",

--- a/backend/migrations/1730000014_document_size_and_pages.go
+++ b/backend/migrations/1730000014_document_size_and_pages.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+// Adds the two columns the instance limits are measured in.
+//
+// They are written by the documents create hook, which is the one point every
+// ingest path passes through, so a document created from here on carries its own
+// size and page count and the instance totals are a SUM over live rows -- no
+// counter to drift, and deleting a document frees its allowance for free.
+//
+// Deliberately no backfill: rows that predate this migration keep 0 in both
+// columns. Filling them would mean running pdfinfo once per existing PDF, which
+// makes boot time a function of library size. The cost of leaving them is that an
+// upgraded install undercounts its existing library, which errs toward allowing
+// more rather than locking an owner out of their own archive.
+func init() {
+	m.Register(func(app core.App) error {
+		documents, err := app.FindCollectionByNameOrId("documents")
+		if err != nil {
+			return err
+		}
+		// Hidden so a client cannot write them. The create hook overwrites
+		// whatever arrives on a create, but an update carrying only
+		// size_bytes = 0 would otherwise hand any account an unlimited
+		// allowance: documents.UpdateRule lets an owner patch their own row.
+		// PocketBase restores a hidden field from the stored value for every
+		// non-superuser write, which closes that without a second guard.
+		if documents.Fields.GetByName("page_count") == nil {
+			documents.Fields.Add(&core.NumberField{
+				Name:    "page_count",
+				Min:     types.Pointer(0.0),
+				OnlyInt: true,
+				Hidden:  true,
+			})
+		}
+		if documents.Fields.GetByName("size_bytes") == nil {
+			documents.Fields.Add(&core.NumberField{
+				Name:    "size_bytes",
+				Min:     types.Pointer(0.0),
+				OnlyInt: true,
+				Hidden:  true,
+			})
+		}
+		// Covering index for the usage aggregate. Without it, summing these two
+		// columns is a scan of the base table -- which stores ocr_text inline,
+		// up to 500 KB a row -- on every upload. With it the sum never touches
+		// the row bodies.
+		documents.AddIndex("idx_documents_usage", false, "page_count, size_bytes", "")
+		return app.Save(documents)
+	}, func(app core.App) error {
+		documents, err := app.FindCollectionByNameOrId("documents")
+		if err != nil {
+			return nil
+		}
+		if f := documents.Fields.GetByName("page_count"); f != nil {
+			documents.Fields.RemoveById(f.GetId())
+		}
+		if f := documents.Fields.GetByName("size_bytes"); f != nil {
+			documents.Fields.RemoveById(f.GetId())
+		}
+		documents.RemoveIndex("idx_documents_usage")
+		return app.Save(documents)
+	})
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -103,11 +103,23 @@ Settings edits from being reverted — there is no Settings edit here to protect
   the page and byte totals read low on an upgraded library until those documents
   are replaced.
 - A bulk path — a backup restore, an Amazon-orders import, a document split — is
-  checked against the remaining allowance at preview time and refused before
-  anything is created, so it cannot half-complete. Page totals are the exception
-  for a restore: an archive's real page counts are only discoverable by opening
-  every PDF in it, so the page limit there is enforced per document as the restore
-  runs.
+  checked against the remaining allowance up front, so the common case of a batch
+  that plainly does not fit is refused before anything is created. That check is
+  **not** a reservation, and a bulk run can still stop partway:
+  - a restore or an Amazon import knows its document count and bytes, but not its
+    page count (an archive's real page counts are only discoverable by opening
+    every PDF in it), so a page limit is enforced per document as the run
+    proceeds;
+  - a split knows its document and page counts exactly, but not the size of parts
+    that do not exist yet, so a storage limit is enforced per part;
+  - a Paperless-ngx import checks only the document count the remote reports;
+  - and any of them can be confirmed minutes after its preview, by which time
+    another upload may have taken the room.
+
+  A run that stops partway keeps what it already created and reports the rest as
+  errors; nothing is rolled back. The per-document checks are what make the limit
+  itself exact — the up-front check is there to turn the common failure into one
+  clear message instead of several hundred.
 
 ### Applied when changed
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -60,9 +60,54 @@ All variables live in `.env` at the project root (see `.env.example`).
 | `IMPORT_ALLOW_PRIVATE` | unset (blocked) | Set to `1`/`true` to let ngx import reach loopback and RFC1918 hosts. Link-local / cloud-metadata addresses stay blocked. Needed when Paperless-ngx is on the same LAN or Docker network. |
 | `UPLOAD_MAX_MB` | `100` | Cap on a staged split-document PDF upload, in megabytes. Read at startup, not from Settings: staging a PDF costs several times its size in memory while pages are rendered, so it protects the host as much as it shapes the product. A malformed or non-positive value falls back to the default rather than failing the boot. Per-file uploads are capped separately by the `documents.file` field (20 MB). |
 | `IMPORT_STAGING_MAX_BYTES` | `1073741824` (1 GiB) | Cap on an archive staged for import (Amazon orders, Lemmary backup), in bytes. Staging a new archive discards that account's previous one, so this is also the disk a single account can occupy while deciding whether to confirm — the staging area's ceiling is roughly this times the number of accounts. Lower it on a small volume; raise it for a library whose backup runs past a gigabyte. A malformed value, or one under 1 MiB, falls back to the default rather than rejecting every upload. |
+| `LIMIT_DOCUMENTS` | unset (unlimited) | Total documents this instance may store. |
+| `LIMIT_DOCUMENT_PAGES` | unset (unlimited) | Total pages across all stored documents. Anything that is not a PDF counts as one page &mdash; including a multi-page `.docx` or `.xlsx`, whose real page count is not knowable without converting the file. |
+| `LIMIT_STORAGE_BYTES` | unset (unlimited) | Total bytes of stored document files. Counts the uploaded originals only, not the generated thumbnails or the extracted OCR text. |
+| `LIMIT_FILE_BYTES` | unset (unlimited) | Largest single document file, in bytes. Can only **lower** the effective cap: the `documents.file` field carries its own 20 MB `MaxSize` that PocketBase validates on every save, and no value here can raise it. Distinct from `UPLOAD_MAX_MB`, which caps the one staged PDF a split is cut from rather than each document it produces. |
+| `LIMIT_FILE_PAGES` | unset (unlimited) | Most pages in a single document. |
+| `LIMIT_ADDITIONAL_USERS` | unset (unlimited) | Accounts beyond the admin account. Exactly one account is free, so `0` is a single-account instance. |
 | `VITE_POCKETBASE_URL` | `http://127.0.0.1:8090` | PocketBase API URL (frontend) |
 | `VITE_DEV_USER_EMAIL` | — | Dev auto-login email (`users` collection) |
 | `VITE_DEV_USER_PASSWORD` | — | Dev auto-login password |
+
+#### Instance limits
+
+The six `LIMIT_*` variables bound how much one instance may hold. **All of them are
+unlimited when unset**, so an install that sets none of them behaves exactly as it
+did before they existed — no extra queries per upload, and no quota shown in the UI.
+
+They are read at startup and deliberately never stored in `app_settings`: they say
+what an instance is *allowed* to hold, and an admin editing the Settings page must
+not be able to raise their own allowance. Change one by recreating the container
+with a new value. For the same reason they do not take part in the
+[applied-when-changed](#applied-when-changed) mechanism, which exists to protect
+Settings edits from being reverted — there is no Settings edit here to protect.
+
+- An explicit `0` means zero, not unlimited. `LIMIT_ADDITIONAL_USERS=0` is a
+  single-account instance.
+- A value that cannot be read — a typo, a negative, a decimal — falls back to
+  unlimited and is logged at `ERROR`, and the variable is named in
+  `GET /api/app/limits` for an admin session and on the **Management** page. The
+  fallback direction is deliberate: a stray character in an orchestrator's
+  environment should grant room rather than lock an owner out of their own archive,
+  and being told loudly is what keeps that from going unnoticed.
+- Lowering a limit under a library that already exceeds it never deletes anything.
+  Usage is simply reported as over, and the next addition is refused.
+- The three instance-wide totals are measured from the live rows on each write, so
+  deleting a document (or a user, which cascades to their documents) frees its
+  allowance immediately.
+- Documents created **before** this version was installed count as zero pages and
+  zero bytes: the page and size columns are added without a backfill, because
+  filling them would mean running `pdfinfo` once per existing PDF during a
+  migration. `LIMIT_DOCUMENTS` and `LIMIT_ADDITIONAL_USERS` are exact regardless;
+  the page and byte totals read low on an upgraded library until those documents
+  are replaced.
+- A bulk path — a backup restore, an Amazon-orders import, a document split — is
+  checked against the remaining allowance at preview time and refused before
+  anything is created, so it cannot half-complete. Page totals are the exception
+  for a restore: an archive's real page counts are only discoverable by opening
+  every PDF in it, so the page limit there is enforced per document as the restore
+  runs.
 
 ### Applied when changed
 

--- a/frontend/src/components/LimitsUsage.tsx
+++ b/frontend/src/components/LimitsUsage.tsx
@@ -1,0 +1,84 @@
+import { boundedLimits, isExhausted, type InstanceLimits, type LimitStatus } from '../lib/api/limits'
+
+function ratio(status: LimitStatus): number {
+  if (status.unlimited || status.limit === undefined || status.limit <= 0) return 0
+  return Math.min(1, status.used / status.limit)
+}
+
+function barToneClassName(status: LimitStatus): string {
+  const filled = ratio(status)
+  if (isExhausted(status)) return 'bg-madder'
+  if (filled >= 0.9) return 'bg-madder/60'
+  return 'bg-oxblood/60'
+}
+
+/**
+ * One allowance as a labelled meter.
+ *
+ * `used` can exceed `limit` — a plan can be lowered under a library that is
+ * already larger than it — so the bar clamps while the numbers tell the truth.
+ * Nothing is ever deleted to make usage fit a limit.
+ */
+function LimitRow({
+  label,
+  status,
+  format,
+}: {
+  label: string
+  status: LimitStatus
+  format: (n: number) => string
+}) {
+  const limit = status.limit ?? 0
+  const over = status.used > limit
+  return (
+    <li className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between gap-3 text-xs">
+        <span className="font-semibold uppercase tracking-[0.12em] text-ink-soft">{label}</span>
+        <span className={over ? 'text-madder' : 'text-ink-soft'}>
+          {format(status.used)} of {format(limit)}
+        </span>
+      </div>
+      <div
+        className="h-1 w-full overflow-hidden bg-line"
+        role="meter"
+        aria-label={label}
+        aria-valuenow={status.used}
+        aria-valuemin={0}
+        aria-valuemax={limit}
+      >
+        <div
+          className={`h-full ${barToneClassName(status)}`}
+          style={{ width: `${ratio(status) * 100}%` }}
+        />
+      </div>
+    </li>
+  )
+}
+
+/**
+ * Instance allowances and what is used against them.
+ *
+ * Renders nothing at all when this install bounds nothing, which is the default
+ * — a self-hosted instance that sets no LIMIT_* variables should not grow a
+ * quota widget it has no use for. Unlimited individual limits are dropped for
+ * the same reason, rather than shown as an infinity sign.
+ */
+export function LimitsUsage({
+  limits,
+  className = '',
+}: {
+  limits: InstanceLimits | null
+  className?: string
+}) {
+  if (!limits || !limits.enforced) return null
+  const rows = boundedLimits(limits)
+  if (rows.length === 0) return null
+
+  return (
+    <ul className={`flex flex-col gap-3 border border-line bg-surface p-4 ${className}`}>
+      {rows.map((row) => (
+        <LimitRow key={row.name} label={row.label} status={row.status} format={row.format} />
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/lib/api/limits.test.ts
+++ b/frontend/src/lib/api/limits.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  boundedLimits,
+  formatBytes,
+  isExhausted,
+  limitFromError,
+  type InstanceLimits,
+} from './limits'
+
+const unlimited = { used: 0, unlimited: true }
+
+function limits(overrides: Partial<InstanceLimits> = {}): InstanceLimits {
+  return {
+    enforced: true,
+    documents: unlimited,
+    document_pages: unlimited,
+    storage_bytes: unlimited,
+    file_bytes: unlimited,
+    file_pages: unlimited,
+    additional_users: unlimited,
+    ...overrides,
+  }
+}
+
+describe('limitFromError', () => {
+  // The exact shape the backend puts on the wire, verified against a running
+  // instance: PocketBase nests a SafeErrorItem under code/params.
+  it('reads the limit name out of params', () => {
+    const err = {
+      response: {
+        data: {
+          limit: {
+            code: 'limit_documents',
+            message: 'This instance holds 2 of 2 documents, so there is no room for another.',
+            params: { limit: 'documents', allowed: 2, used: 2 },
+          },
+        },
+      },
+    }
+    expect(limitFromError(err)).toBe('documents')
+  })
+
+  it('falls back to the code when params are absent', () => {
+    expect(limitFromError({ response: { data: { limit: { code: 'limit_storage_bytes' } } } })).toBe(
+      'storage_bytes',
+    )
+  })
+
+  it('returns null for an unrelated failure', () => {
+    expect(limitFromError(null)).toBeNull()
+    expect(limitFromError(new Error('network'))).toBeNull()
+    // A duplicate rejection uses the same envelope but a different key.
+    expect(limitFromError({ response: { data: { duplicate_of: 'abc' } } })).toBeNull()
+  })
+
+  // A plain string is what PocketBase would have mangled into
+  // "validation_invalid_value", so treat it as absent rather than trusting it.
+  it('ignores a limit name it does not recognise', () => {
+    expect(limitFromError({ response: { data: { limit: { code: 'limit_nonsense' } } } })).toBeNull()
+    expect(
+      limitFromError({
+        response: { data: { limit: { code: 'validation_invalid_value', message: 'Invalid value.' } } },
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('formatBytes', () => {
+  // Matches the backend's own formatting, so a quota bar and the rejection
+  // message that follows it never disagree.
+  it.each([
+    [0, '0 B'],
+    [512, '512 B'],
+    [1024, '1.0 KB'],
+    [20 * 1024 * 1024, '20 MB'],
+    [1024 ** 3, '1.0 GB'],
+  ])('renders %i as %s', (bytes, want) => {
+    expect(formatBytes(bytes)).toBe(want)
+  })
+
+  it('survives a missing or nonsense value', () => {
+    expect(formatBytes(-1)).toBe('0 B')
+    expect(formatBytes(Number.NaN)).toBe('0 B')
+  })
+})
+
+describe('isExhausted', () => {
+  it('is true only when a bounded limit is fully used', () => {
+    expect(isExhausted({ used: 2, limit: 3, unlimited: false })).toBe(false)
+    expect(isExhausted({ used: 3, limit: 3, unlimited: false })).toBe(true)
+    // A limit lowered under an existing library reads as over, not negative.
+    expect(isExhausted({ used: 9, limit: 3, unlimited: false })).toBe(true)
+    expect(isExhausted(unlimited)).toBe(false)
+  })
+})
+
+describe('boundedLimits', () => {
+  it('drops the unlimited ones rather than showing an infinity sign', () => {
+    const rows = boundedLimits(limits({ documents: { used: 1, limit: 5, unlimited: false } }))
+    expect(rows.map((row) => row.name)).toEqual(['documents'])
+  })
+
+  it('is empty when nothing is bounded, so the UI renders nothing', () => {
+    expect(boundedLimits(limits())).toEqual([])
+  })
+
+  it('formats storage as bytes and the rest as counts', () => {
+    const rows = boundedLimits(
+      limits({
+        documents: { used: 1200, limit: 5000, unlimited: false },
+        storage_bytes: { used: 1024, limit: 2048, unlimited: false },
+      }),
+    )
+    const byName = Object.fromEntries(rows.map((row) => [row.name, row]))
+    expect(byName.storage_bytes.format(1024)).toBe('1.0 KB')
+    expect(byName.documents.format(1200)).toBe((1200).toLocaleString())
+  })
+
+  it('keeps a zero allowance, which is a real plan', () => {
+    const rows = boundedLimits(limits({ additional_users: { used: 0, limit: 0, unlimited: false } }))
+    expect(rows.map((row) => row.name)).toEqual(['additional_users'])
+  })
+})

--- a/frontend/src/lib/api/limits.ts
+++ b/frontend/src/lib/api/limits.ts
@@ -1,0 +1,124 @@
+import { apiFetch } from '../apiClient'
+
+/** One allowance and what is used against it. `limit` is absent when unlimited. */
+export type LimitStatus = {
+  used: number
+  limit?: number
+  unlimited: boolean
+}
+
+export type InstanceLimits = {
+  /** False when this install bounds nothing, which is the default. */
+  enforced: boolean
+  /** LIMIT_* variables the server could not read; admin sessions only. */
+  misconfigured?: string[]
+  documents: LimitStatus
+  document_pages: LimitStatus
+  storage_bytes: LimitStatus
+  file_bytes: LimitStatus
+  file_pages: LimitStatus
+  additional_users: LimitStatus
+}
+
+/** The names the backend uses for each limit, as sent in a rejection payload. */
+export type LimitName =
+  | 'documents'
+  | 'document_pages'
+  | 'storage_bytes'
+  | 'file_bytes'
+  | 'file_pages'
+  | 'additional_users'
+
+export function getLimits() {
+  return apiFetch<InstanceLimits>('/api/app/limits', {
+    fallbackError: 'Failed to load instance limits',
+  })
+}
+
+const LIMIT_NAMES = new Set<string>([
+  'documents',
+  'document_pages',
+  'storage_bytes',
+  'file_bytes',
+  'file_pages',
+  'additional_users',
+])
+
+/**
+ * The limit named by a rejected write, or null when the failure was something
+ * else.
+ *
+ * A limit rejection is a 400 whose data reads
+ * `{"limit": {"code": "limit_<name>", "params": {limit, allowed, used}}}`.
+ *
+ * The nesting is not a choice — PocketBase replaces any error-data value that
+ * does not implement its `SafeErrorItem` interface with a generic
+ * `{"code": "validation_invalid_value"}`, so a plain string would never arrive.
+ * (That is exactly why `duplicateIdFromError` next door has to fall back to
+ * parsing the message text.) The backend implements the interface, which is what
+ * puts a real code and real numbers on the wire.
+ */
+export function limitFromError(err: unknown): LimitName | null {
+  const limit = (
+    err as { response?: { data?: { limit?: { code?: unknown; params?: { limit?: unknown } } } } } | null
+  )?.response?.data?.limit
+  if (!limit) return null
+
+  const fromParams = limit.params?.limit
+  if (typeof fromParams === 'string' && LIMIT_NAMES.has(fromParams)) {
+    return fromParams as LimitName
+  }
+  // Fall back to the code, which carries the same name with a prefix.
+  const code = limit.code
+  if (typeof code === 'string' && code.startsWith('limit_')) {
+    const name = code.slice('limit_'.length)
+    if (LIMIT_NAMES.has(name)) return name as LimitName
+  }
+  return null
+}
+
+const UNIT = 1024
+const SUFFIXES = ['KB', 'MB', 'GB', 'TB']
+
+/**
+ * Renders a byte count the way a person reads a file size.
+ *
+ * Binary units, matching the backend's own formatting, so a quota bar and the
+ * rejection message that follows it never disagree about what "20 MB" means.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B'
+  if (bytes < UNIT) return `${Math.round(bytes)} B`
+  let value = bytes
+  for (const suffix of SUFFIXES) {
+    value /= UNIT
+    if (value < UNIT) {
+      return value < 10 ? `${value.toFixed(1)} ${suffix}` : `${Math.round(value)} ${suffix}`
+    }
+  }
+  return `${Math.round(value / UNIT)} PB`
+}
+
+/** True when this limit is bounded and fully consumed. */
+export function isExhausted(status: LimitStatus): boolean {
+  return !status.unlimited && status.limit !== undefined && status.used >= status.limit
+}
+
+/** The bounded limits, in the order they should be displayed. */
+export function boundedLimits(
+  limits: InstanceLimits,
+): Array<{ name: LimitName; label: string; status: LimitStatus; format: (n: number) => string }> {
+  const asCount = (n: number) => n.toLocaleString()
+  const rows: Array<{
+    name: LimitName
+    label: string
+    status: LimitStatus
+    format: (n: number) => string
+  }> = [
+    { name: 'documents', label: 'Documents', status: limits.documents, format: asCount },
+    { name: 'document_pages', label: 'Pages', status: limits.document_pages, format: asCount },
+    { name: 'storage_bytes', label: 'Storage', status: limits.storage_bytes, format: formatBytes },
+    { name: 'additional_users', label: 'Additional users', status: limits.additional_users, format: asCount },
+  ]
+  return rows.filter((row) => !row.status.unlimited)
+}

--- a/frontend/src/routes/management.tsx
+++ b/frontend/src/routes/management.tsx
@@ -9,6 +9,8 @@ import {
   type DuplicateScanResult,
   type TaxonomyPruneResult,
 } from '../lib/api/maintenance'
+import { getLimits, type InstanceLimits } from '../lib/api/limits'
+import { LimitsUsage } from '../components/LimitsUsage'
 import { REPROCESS_MODE_LABELS, type ReprocessMode } from '../lib/processing'
 import { Button, labelTextClassName, sectionClassName, sectionTitleClassName } from '../components/ui'
 
@@ -54,6 +56,7 @@ export function ManagementPage() {
   const [reindexing, setReindexing] = useState(false)
   const [pruning, setPruning] = useState(false)
   const [activeJobs, setActiveJobs] = useState<ActiveJobCounts | null>(null)
+  const [limits, setLimits] = useState<InstanceLimits | null>(null)
   const [failedCount, setFailedCount] = useState<number | null>(null)
   const [failedCountLoaded, setFailedCountLoaded] = useState(false)
   const [reprocessing, setReprocessing] = useState(false)
@@ -64,6 +67,18 @@ export function ManagementPage() {
 
   // Pruning taxonomy while documents are still processing could delete an entity
   // a running job is about to attach, so the queue is polled to gate that button.
+  useEffect(() => {
+    let active = true
+    getLimits()
+      .then((next) => {
+        if (active) setLimits(next)
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [])
+
   useEffect(() => {
     let active = true
 
@@ -311,6 +326,34 @@ export function ManagementPage() {
             )}
           </div>
         </section>
+
+        {limits && (limits.enforced || (limits.misconfigured?.length ?? 0) > 0) && (
+          <section className={sectionClassName}>
+            <h2 className={sectionTitleClassName}>Instance limits</h2>
+            <p className="text-xs text-ink-soft">
+              Set by the operator through <code>LIMIT_*</code> environment variables and read at
+              startup, so they cannot be changed from Settings. Lowering a limit under an existing
+              library never deletes anything &mdash; it only refuses the next addition.
+            </p>
+            {limits.enforced ? (
+              <LimitsUsage limits={limits} className="mt-4 border-0 bg-transparent p-0" />
+            ) : (
+              <p className="mt-4 text-xs text-ink-soft">No limits are in effect.</p>
+            )}
+            {(limits.misconfigured?.length ?? 0) > 0 && (
+              <p className="mt-4 text-sm text-madder">
+                Could not read {limits.misconfigured?.join(', ')}. Each fell back to unlimited, so
+                these are not being enforced.
+              </p>
+            )}
+            {limits.enforced && (
+              <p className="mt-4 text-xs text-ink-faint">
+                Documents added before this version was installed count as zero pages and zero
+                bytes, so those two figures can read low on an upgraded library.
+              </p>
+            )}
+          </section>
+        )}
 
         <section className={sectionClassName}>
           <h2 className={sectionTitleClassName}>Search index</h2>

--- a/frontend/src/routes/upload.index.tsx
+++ b/frontend/src/routes/upload.index.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from '@tanstack/react-router'
 import { pb } from '../lib/pb'
 import { ensureAuth } from '../lib/auth'
 import { parseDuplicateOfId } from '../lib/api/documents'
+import { limitFromError, type LimitName } from '../lib/api/limits'
 import { Button } from '../components/ui'
 
 const ACCEPTED_EXTENSIONS = new Set([
@@ -72,6 +73,16 @@ function duplicateIdFromError(err: unknown, message: string): string | null {
   }
   return parseDuplicateOfId(message)
 }
+
+/**
+ * The limits that bound the whole instance, as opposed to one upload. Hitting
+ * one of these means no further file can succeed either.
+ */
+const INSTANCE_WIDE_LIMITS = new Set<LimitName>([
+  'documents',
+  'document_pages',
+  'storage_bytes',
+])
 
 function formatBytes(size: number) {
   if (size < 1024) return `${size} B`
@@ -174,6 +185,10 @@ export function UploadFilesPage() {
       const uploadedIds: string[] = []
       const failures: FileUploadError[] = []
       const failedFiles: File[] = []
+      // Set when an instance allowance ran out and the loop stopped early, so
+      // the summary can say files were not attempted rather than implying they
+      // were tried and failed.
+      let stoppedAt = -1
 
       for (let i = 0; i < files.length; i++) {
         const file = files[i]
@@ -193,6 +208,18 @@ export function UploadFilesPage() {
             duplicateOfId: duplicateIdFromError(err, message),
           })
           failedFiles.push(file)
+
+          // An instance-wide allowance ran out, so every remaining file would
+          // be refused for the same reason. Stop and keep them staged rather
+          // than printing the same rejection once per file. A per-file limit
+          // (this one is too big) says nothing about the next file, so those
+          // keep going.
+          const limit = limitFromError(err)
+          if (limit && INSTANCE_WIDE_LIMITS.has(limit)) {
+            failedFiles.push(...files.slice(i + 1))
+            stoppedAt = i
+            break
+          }
         }
       }
 
@@ -208,7 +235,15 @@ export function UploadFilesPage() {
       setFiles(failedFiles)
       setFileErrors(failures)
       resetInput()
-      if (uploadedIds.length > 0) {
+      if (stoppedAt >= 0) {
+        const notAttempted = files.length - stoppedAt - 1
+        const uploaded = `Uploaded ${uploadedIds.length} of ${files.length} files.`
+        setError(
+          notAttempted > 0
+            ? `${uploaded} This instance ran out of room, so ${notAttempted} more ${notAttempted === 1 ? 'was' : 'were'} not attempted.`
+            : `${uploaded} This instance ran out of room.`,
+        )
+      } else if (uploadedIds.length > 0) {
         setError(
           `Uploaded ${uploadedIds.length} of ${files.length} files. ${failures.length} failed.`,
         )

--- a/frontend/src/routes/upload.tsx
+++ b/frontend/src/routes/upload.tsx
@@ -1,9 +1,31 @@
+import { useEffect, useState } from 'react'
 import { Link, Outlet } from '@tanstack/react-router'
+
+import { LimitsUsage } from '../components/LimitsUsage'
+import { getLimits, type InstanceLimits } from '../lib/api/limits'
 
 const tabClassName =
   '-mb-px border-b-2 border-transparent px-1 pb-2 pt-1 text-xs font-semibold uppercase tracking-[0.14em] text-ink-soft transition-colors hover:text-oxblood focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-oxblood data-[status=active]:border-oxblood data-[status=active]:text-oxblood'
 
 export function UploadPage() {
+  // Loaded on the shell rather than per tab, so the same figures show above
+  // Files, Amazon orders and Split documents without three fetches. A failure is
+  // swallowed: the allowance is context for an upload, not a precondition, and
+  // the server refuses an over-limit upload whatever this shows.
+  const [limits, setLimits] = useState<InstanceLimits | null>(null)
+
+  useEffect(() => {
+    let active = true
+    getLimits()
+      .then((next) => {
+        if (active) setLimits(next)
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [])
+
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-6">
       <div>
@@ -12,6 +34,8 @@ export function UploadPage() {
           Add documents to your library. Pick a source below.
         </p>
       </div>
+
+      <LimitsUsage limits={limits} />
 
       <nav aria-label="Upload sources" className="flex flex-wrap items-center gap-5 border-b border-line">
         <Link


### PR DESCRIPTION
Adds six env-configured instance limits, and fixes the CI gap that would have let them merge without their e2e coverage running.

E2E suites for this are in **lemmary/lemmary-dev#1**, on the branch of the same name.

## The limits

| Variable | Bounds |
| --- | --- |
| `LIMIT_DOCUMENTS` | total documents |
| `LIMIT_DOCUMENT_PAGES` | total pages across all documents |
| `LIMIT_STORAGE_BYTES` | total bytes of stored originals |
| `LIMIT_FILE_BYTES` | one document's file |
| `LIMIT_FILE_PAGES` | one document's pages |
| `LIMIT_ADDITIONAL_USERS` | accounts beyond the admin |

**Every one is unlimited when unset**, so an install that sets nothing behaves exactly as it does today: no hook bound at all, no query per upload, no page count computed, and no new UI. Verified against a fresh instance — a 5-page PDF uploads with no page count taken.

A hosted instance is created by an orchestrator, and the only thing an orchestrator can express is the environment of the container it creates. `UPLOAD_MAX_MB` was added for that reason in 8d8a0f0; this is the same shape, for the six allowances a plan actually needs.

**Env and only env.** These say what an instance is *allowed* to hold, so an admin editing the Settings page must not be able to raise their own allowance. They deliberately do not join `app_settings` or the `env_applied` mechanism — that exists to keep a Settings edit from being reverted on restart, and there is no Settings edit here to protect.

**`0` means zero.** `LIMIT_ADDITIONAL_USERS=0` is a real plan (a single-account instance), so `0` cannot double as the unlimited sentinel — which is why `Limit` is a small struct rather than an `int64` with a magic value. Its zero value is the unlimited one, so the zero `Limits` bounds nothing.

**An unreadable value falls back to unlimited**, logged at `ERROR` and reported as `misconfigured` on the limits endpoint for an admin session and on the Management page. A typo granting room is the right direction to fail in — better than locking an owner out of their own archive — but it is the one failure here that is otherwise invisible, so it is made loud.

## How it is enforced

Two hooks, because every way a document or an account comes into being ends in `app.Save` on one of two collections: the SPA's collection-API upload, the paperless-ngx `post_document` endpoint, a PDF split, an Amazon-orders import, a backup restore, a paperless-ngx remote pull, the setup wizard, the superuser CLI, and the PocketBase admin UI.

`limits.Register` binds before `worker.Register` so an over-limit upload is refused before `duplicates.AssignChecksumFromUpload` reads the whole file to hash it. PocketBase sorts equal-priority handlers stably, so registration order is what decides that.

Totals are `COUNT`/`SUM` over live rows rather than stored counters, so deleting a document (or a user, which cascades) frees its allowance with no bookkeeping — which matters because there is no delete hook on `documents` and PocketBase frees blobs in a fire-and-forget goroutine, so a counter would drift on exactly the path that is hardest to observe.

New `documents.page_count` and `documents.size_bytes` carry the measurements, with a covering index that the aggregate is **not optional** without: `documents` stores `ocr_text` inline at up to 500 KB a row, so summing two columns off the base table would re-read the entire OCR corpus on every upload. Confirmed as a `COVERING INDEX` scan.

**No backfill.** Rows predating the migration keep 0 in both columns; filling them would mean running `pdfinfo` once per existing PDF, and PocketBase runs the whole migration ladder in one transaction. `LIMIT_DOCUMENTS` and `LIMIT_ADDITIONAL_USERS` are exact regardless; the page and byte totals read low on an upgraded library, which errs toward allowing more rather than locking an owner out. Documented.

## Three bugs found in the original design

- **The update path was an open bypass.** `documents.UpdateRule` lets an owner patch their own row and `file` is writable, so an account could create a one-page document and then `PATCH` a 500-page file onto it. `OnRecordUpdate` now re-measures and charges the difference. The two columns are also `Hidden`, which is what stops a client patching `size_bytes` to 0 to free its own quota. Both verified over HTTP.
- **Exempting every `is_app_admin` account from the seat limit was a bypass** — a superuser can create a second superuser, and `UpsertPairedUser` gives that one a flagged `users` record too. Exactly one account is free now, structurally, which also means the setup wizard's first admin always gets in without a special case.
- **Raw values in an `ApiError` data map never reach the client.** PocketBase replaces anything that does not implement `router.SafeErrorItem` with a generic `"Invalid value."` — which is why the duplicate rejection next door parses its id back out of the message text. `ErrExceeded` implements the interface, so a rejection arrives as `{"limit":{"code":"limit_documents","params":{limit,allowed,used}}}` and the SPA can switch on the code. The test asserts the marshalled JSON, not `RawData`, since `RawData` passing proves nothing about the wire.

## Rejections and bulk paths

A uniform **400**, matching PocketBase's own file-size rejection on this collection and the duplicate rejection. 413/507 would be the odd one out, and the paperless-ngx clients that reach these paths understand no quota status.

Bulk paths are checked at preview and refused before anything is created, so a restore cannot half-complete. Page totals are the exception for a restore — an archive's real page counts are only discoverable by opening every PDF in it, so the page limit there is enforced per document as the restore runs. Documented as such.

The importers' per-entry caps and `pdfsplit`'s per-part cap now track the effective per-file limit, so an over-cap entry is flagged oversized in the preview — the behaviour they already had for the field limit — instead of the preview promising an import the create hook then refuses. They are *set*, not lowered, so a value can go back down: the e2e harness boots a whole app repeatedly in one binary, and a lower-only setter would leak the smallest limit any earlier boot configured into every later one.

## Known constraint

`LIMIT_FILE_BYTES` can only **lower** the effective per-file cap. The `documents.file` field's own 20 MB `MaxSize` is validated on every save and nothing here can raise it. Documented rather than worked around — raising the field cap would change the default for every self-hosted install, which is a separate decision.

## The CI change (33eb2c3)

The PR job checked the private overlay out at its default branch, which meant a spanning change could never be verified properly: a behaviour change failed against `main`'s old assertions, **and** a new feature went green with no coverage at all — exactly what would have happened to this PR. It now looks for an overlay branch named like the pull request and falls back to `main`, so the common case is unchanged.

The switch is a step after `actions/checkout` rather than its `ref` input: resolving the branch first needs a credential before the checkout that configures it. It runs before `npm ci` and `test-all.sh`, so a differing lockfile is picked up. The chosen ref is announced with `::notice::` either way, because the failure this guards against is a green run against the wrong pair.

Verified by simulating the step against shallow clones of a throwaway remote across all five paths — matching branch (content confirmed changed), no such branch, `BRANCH=main`, empty, and a `31/merge` ref name. The simulation caught a real bug: on a clone whose HEAD had no commits the diagnostic `git log` failed and, under `set -e`, turned a correct fallback into a red build. It is now wrapped so it cannot fail the step.

## Verification

`./dev/scripts/test-all.sh` passes — all five stages, 65 browser tests. Plus the Docker image builds, and each limit was exercised by hand against a running instance: filling and exceeding the document count, the per-file page limit, the seat limit through the admin API, deletion freeing allowance, the update bypass in both directions, direct field writes, and the unlimited default as a true no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
