### PR TITLE
Run verification through Docker instead of the host toolchain

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,8 +50,9 @@ jobs:
     # A fork's pull request must never land on the self-hosted runner: the job
     # would execute that fork's code on a machine inside a private network,
     # which is the hazard GitHub warns about for self-hosted runners. Fork PRs
-    # go to a throwaway hosted runner instead, where this workflow already
-    # degrades to unit tests because the private suite's key is withheld.
+    # go to a throwaway hosted runner instead. The private overlay's key is
+    # withheld there, so ./scripts/test-all.sh fails rather than reporting a
+    # green run that never executed e2e.
     runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && fromJSON(vars.CI_RUNNER_LABELS || '["self-hosted", "linux", "x64", "homelab"]') || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -61,9 +62,9 @@ jobs:
 
       # The e2e suites and the verification stack live in a private repository
       # overlaid at dev/. GitHub withholds secrets from fork pull
-      # requests, so this job has to detect that and degrade loudly rather than
-      # report a green run that never executed e2e. secrets.* is not available
-      # in a job-level `if`, which is why the guard is a step.
+      # requests, so this job has to detect that: without the overlay,
+      # ./scripts/test-all.sh fails. secrets.* is not available in a job-level
+      # `if`, which is why the guard is a step.
       - name: Detect private suite access
         id: access
         env:
@@ -133,23 +134,12 @@ jobs:
           show
 
       - name: Run verification suite
-        if: steps.access.outputs.ok == 'true'
         # The wrapper resolves the overlay (checked out at dev/ above, since
         # actions/checkout cannot place a repository outside the workspace) and
         # delegates to it. Running the same entry point developers run is the
-        # point: a wrapper that only CI or only humans exercise rots.
+        # point: a wrapper that only CI or only humans exercise rots. No overlay
+        # is a failure.
         run: ./scripts/test-all.sh
-
-      - name: Run unit tests only (private suite unavailable)
-        if: steps.access.outputs.ok != 'true'
-        run: |
-          echo "::warning::e2e suites skipped - the private dev repository is not reachable from a fork pull request. Go unit tests, go vet, frontend tests and the SPA build ran in official images; API and browser e2e did not."
-          # Finding no overlay, the wrapper runs the reduced set by itself:
-          # Go unit tests, go vet, frontend tests, and the SPA build. That
-          # build matters -- the build job is push-only, so without it a fork
-          # pull request compiles the frontend nowhere and could go green with
-          # tsc, Vite or VitePress broken.
-          ./scripts/test-all.sh
 
   build:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,9 +41,9 @@ env:
 # ["ubuntu-latest"] puts CI back on GitHub's runners while the homelab machine
 # is down, and unsetting it brings CI home again.
 #
-# A self-hosted runner needs Docker with buildx usable by the runner user, and
-# passwordless sudo for the apt steps below (see the runner-smoke workflow,
-# which checks the Docker half).
+# A self-hosted runner needs Docker with buildx usable by the runner user
+# (see the runner-smoke workflow). The test job runs verification inside
+# Docker; it does not install Go, Node, Playwright or poppler on the host.
 jobs:
   test:
     if: github.event_name == 'pull_request'
@@ -132,61 +132,6 @@ jobs:
           echo "::notice::Verification suite: lemmary-dev@$BRANCH"
           show
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          # There is no package.json at the repository root for the action to
-          # read a packageManager field from, so the version is explicit here.
-          # Keep it in step with frontend/package.json and the Dockerfile.
-          version: 11.24.0
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "26"
-          # Must come after pnpm is installed: this step primes pnpm's store
-          # cache and needs the binary to locate it.
-          cache: pnpm
-          # Only the frontend lockfile. A fork pull request gets no dev/, and a
-          # cache path that matches nothing fails this step -- while the dev
-          # suite's single dependency is not worth caching anyway.
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install system dependencies
-        # A self-hosted runner keeps whatever the last run installed, so only
-        # reach for apt (and the sudo it needs) when poppler is actually
-        # missing. pdftoppm is what the preview step shells out to.
-        run: |
-          if command -v pdftoppm >/dev/null 2>&1; then
-            echo "poppler-utils already present: $(pdftoppm -v 2>&1 | head -1)"
-          else
-            sudo apt-get update && sudo apt-get install -y poppler-utils
-          fi
-
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: pnpm install --frozen-lockfile
-
-      - name: Install dev suite dependencies
-        if: steps.access.outputs.ok == 'true'
-        working-directory: dev
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright Chromium
-        if: steps.access.outputs.ok == 'true'
-        working-directory: dev
-        # --with-deps unconditionally: the browser download is cached on a
-        # persistent runner, and only the apt half repeats. Skipping it there
-        # would mean chromium's system libraries had to be provisioned by hand,
-        # which is a worse trade than a few seconds of a satisfied apt run.
-        run: pnpm exec playwright install --with-deps chromium
-
       - name: Run verification suite
         if: steps.access.outputs.ok == 'true'
         # The wrapper resolves the overlay (checked out at dev/ above, since
@@ -198,7 +143,7 @@ jobs:
       - name: Run unit tests only (private suite unavailable)
         if: steps.access.outputs.ok != 'true'
         run: |
-          echo "::warning::e2e suites skipped - the private dev repository is not reachable from a fork pull request. Go unit tests, go vet, frontend tests and the SPA build ran; API and browser e2e did not."
+          echo "::warning::e2e suites skipped - the private dev repository is not reachable from a fork pull request. Go unit tests, go vet, frontend tests and the SPA build ran in official images; API and browser e2e did not."
           # Finding no overlay, the wrapper runs the reduced set by itself:
           # Go unit tests, go vet, frontend tests, and the SPA build. That
           # build matters -- the build job is push-only, so without it a fork

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ The PR job uses the overlay branch named like the PR, else `main`. A mismatched 
 
 - `LEMMARY_DEV` overrides the path; `LEMMARY_NO_SYNC=1` skips attaching worktrees.
 - The sandbox may refuse git against the overlay (it sits outside this checkout). Ask before working around that.
+- Verification runs in Docker and bind-mounts this tree and the overlay. The daemon must be able to see both paths.
 
 ## Verification (required)
 
@@ -27,7 +28,7 @@ The PR job uses the overlay branch named like the PR, else `main`. A mismatched 
 ./scripts/test-all.sh
 ```
 
-That is the only command. With no overlay it runs Go tests, `go vet`, frontend tests and the SPA build, and prints what it skipped. Report that API and browser e2e did not run. Do not claim a task complete if any stage fails, or claim e2e that did not run.
+That is the only command. It locates the overlay and delegates; the overlay runs the suite in Docker. With no overlay it runs Go tests, `go vet`, frontend tests and the SPA build in official images, and prints what it skipped. Report that API and browser e2e did not run. Do not claim a task complete if any stage fails, or claim e2e that did not run.
 
 ## Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ The PR job uses the overlay branch named like the PR, else `main`. A mismatched 
 ./scripts/test-all.sh
 ```
 
-That is the only command. It locates the overlay and delegates; the overlay runs the suite in Docker. With no overlay it runs Go tests, `go vet`, frontend tests and the SPA build in official images, and prints what it skipped. Report that API and browser e2e did not run. Do not claim a task complete if any stage fails, or claim e2e that did not run.
+That is the only command. It locates the overlay and delegates; the overlay runs the suite in Docker. No overlay is a failure, not a reduced pass. Do not claim a task complete if the script fails.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ cd frontend && pnpm test
 
 The end-to-end suites, the dev runner and the full verification stack live in a
 separate private repository and are not part of this one. `./scripts/test-all.sh`
-runs everything available here either way, and reports which suites it could
-not run.
+requires that overlay; without it the command fails.
 
 ## License
 

--- a/scripts/overlay.sh
+++ b/scripts/overlay.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Resolve the verification overlay for this checkout and print its path.
 #
-# The e2e suites and the verification stack live in a separate repository. A
-# clone of this one does not have it, so every caller must cope with it being
-# absent: this script exits 3 and prints nothing when there is none.
+# The e2e suites and the verification stack live in a separate repository.
+# A clone of this one does not have it. Callers must handle absence:
+# scripts/test-all.sh treats it as failure; scripts/dev.sh explains and exits.
+# This script exits 3 and prints nothing on stdout when there is none.
 #
 # It used to be checked out *inside* this tree, at dev/. That put a second git
 # repository in the working tree, so anything that answers "which repository am

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -38,39 +38,55 @@ echo "No verification overlay found: running unit tests and the frontend build."
 echo "API and browser e2e will NOT run."
 
 stage "Unit tests"
+# apt-get needs root; tests must not run as root (vault Wipe as uid 0 unlinks
+# a chmod-0500 parent that stands in for a tmpfs mount).
 docker run --rm \
   -v "$ROOT:$ROOT" \
   -w "$ROOT/backend" \
-  -e GOCACHE=/tmp/go-build \
-  -e GOMODCACHE=/tmp/go-mod \
-  -e GOTOOLCHAIN=local \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
   golang:1.26.3-bookworm \
   bash -c 'set -euo pipefail
     apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq poppler-utils
-    GOWORK=off go test ./... -count=1
-    echo
-    echo "==> Vet"
-    GOWORK=off go vet ./...
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq poppler-utils gosu
+    mkdir -p /tmp/go-build /tmp/go-mod
+    chown "$HOST_UID:$HOST_GID" /tmp/go-build /tmp/go-mod
+    export GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod GOTOOLCHAIN=local HOME=/tmp
+    run_go() {
+      GOWORK=off go test ./... -count=1
+      echo
+      echo "==> Vet"
+      GOWORK=off go vet ./...
+    }
+    if [[ "$HOST_UID" != 0 ]]; then
+      groupadd -g "$HOST_GID" -o lemmary 2>/dev/null || true
+      useradd -u "$HOST_UID" -g "$HOST_GID" -o -M -d /tmp -s /bin/bash lemmary 2>/dev/null || true
+      exec gosu "$HOST_UID:$HOST_GID" bash -c "$(declare -f run_go); run_go"
+    fi
+    run_go
   ' || fail "unit tests"
 
 stage "Frontend unit tests"
+# Node 26 does not ship corepack. npm install -g needs root if it writes to
+# /usr/local, so install pnpm under $HOME as the bind-mount user: that keeps
+# frontend/node_modules and public/ host-owned, and puts pnpm on PATH for
+# `pnpm run docs:build` inside the build script. Pin matches package.json.
 docker run --rm \
   -u "$(id -u):$(id -g)" \
   -e HOME=/tmp/lemmary-reduced \
-  -e COREPACK_HOME=/tmp/lemmary-reduced/corepack \
-  -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e npm_config_cache=/tmp/lemmary-reduced/npm \
   -v "$ROOT:$ROOT" \
   -w "$ROOT/frontend" \
   node:26-bookworm \
   bash -c 'set -euo pipefail
-    mkdir -p "$HOME" "$COREPACK_HOME"
-    corepack pnpm install --frozen-lockfile
-    corepack pnpm test
+    mkdir -p "$HOME"
+    npm install -g pnpm@11.24.0 --prefix "$HOME"
+    export PATH="$HOME/bin:$PATH"
+    pnpm install --frozen-lockfile
+    pnpm test
     echo
     echo "==> Frontend build"
-    corepack pnpm run build
+    pnpm run build
   ' || fail "frontend unit tests"
 
 echo ""

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -5,6 +5,11 @@
 # and is delegated to when it is present. When it is not -- a plain clone, or a
 # fork pull request, which cannot reach it -- this runs the reduced set and says
 # plainly what did not run. It never reports success for suites it skipped.
+#
+# Docker is required. The overlay builds a verify image (Chromium, Go, pnpm)
+# and runs the stages inside it. With no overlay this script triggers official
+# golang and node images for the reduced set; it has no verify Dockerfile of
+# its own.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -13,12 +18,6 @@ ARGS=()
 [[ "${1:-}" == --no-sync ]] && { ARGS+=(--no-sync); shift; }
 
 if OVERLAY="$("$ROOT/scripts/overlay.sh" "${ARGS[@]+"${ARGS[@]}"}")"; then
-  # Its own dependencies, in its own checkout. pnpm hardlinks from a shared
-  # store, so a per-worktree install costs disk only for what differs.
-  if [[ -f "$OVERLAY/package.json" && ! -d "$OVERLAY/node_modules" ]]; then
-    echo "==> Installing overlay dependencies ($OVERLAY)"
-    (cd "$OVERLAY" && pnpm install --frozen-lockfile)
-  fi
   # LEMMARY_ROOT is how the overlay learns which tree to test. It no longer
   # infers that from its own location, which is what let it move out of the
   # tree in the first place.
@@ -27,11 +26,9 @@ fi
 
 cd "$ROOT"
 
-# pnpm verifies that node_modules matches the lockfile before running a script
-# and fails outright when it does not, so a bare clone needs this first.
-if [[ ! -d frontend/node_modules ]]; then
-  echo "==> Installing frontend dependencies"
-  (cd frontend && pnpm install --frozen-lockfile)
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker is required for verification." >&2
+  exit 1
 fi
 
 stage() { echo ""; echo "==> $1"; }
@@ -41,18 +38,40 @@ echo "No verification overlay found: running unit tests and the frontend build."
 echo "API and browser e2e will NOT run."
 
 stage "Unit tests"
-(cd backend && go test ./... -count=1) || fail "unit tests"
-
-stage "Vet"
-(cd backend && go vet ./...) || fail "vet"
+docker run --rm \
+  -v "$ROOT:$ROOT" \
+  -w "$ROOT/backend" \
+  -e GOCACHE=/tmp/go-build \
+  -e GOMODCACHE=/tmp/go-mod \
+  -e GOTOOLCHAIN=local \
+  golang:1.26.3-bookworm \
+  bash -c 'set -euo pipefail
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq poppler-utils
+    GOWORK=off go test ./... -count=1
+    echo
+    echo "==> Vet"
+    GOWORK=off go vet ./...
+  ' || fail "unit tests"
 
 stage "Frontend unit tests"
-(cd frontend && pnpm test) || fail "frontend unit tests"
-
-stage "Frontend build"
-# Nothing else here compiles the SPA, so without this a broken tsc, Vite or
-# VitePress would go unnoticed on a run that skipped the overlay.
-(cd frontend && pnpm run build) || fail "frontend build"
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -e HOME=/tmp/lemmary-reduced \
+  -e COREPACK_HOME=/tmp/lemmary-reduced/corepack \
+  -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  -e npm_config_cache=/tmp/lemmary-reduced/npm \
+  -v "$ROOT:$ROOT" \
+  -w "$ROOT/frontend" \
+  node:26-bookworm \
+  bash -c 'set -euo pipefail
+    mkdir -p "$HOME" "$COREPACK_HOME"
+    corepack pnpm install --frozen-lockfile
+    corepack pnpm test
+    echo
+    echo "==> Frontend build"
+    corepack pnpm run build
+  ' || fail "frontend unit tests"
 
 echo ""
 echo "Reduced verification passed. API and browser e2e did not run."

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
-# Run every verification stage this checkout can run.
-#
-# The full suite lives in a separate overlay repository (see scripts/overlay.sh)
-# and is delegated to when it is present. When it is not -- a plain clone, or a
-# fork pull request, which cannot reach it -- this runs the reduced set and says
-# plainly what did not run. It never reports success for suites it skipped.
-#
-# Docker is required. The overlay builds a verify image (Chromium, Go, pnpm)
-# and runs the stages inside it. With no overlay this script triggers official
-# golang and node images for the reduced set; it has no verify Dockerfile of
-# its own.
+# Run the verification suite. The stages live in the overlay repository
+# (see scripts/overlay.sh). No overlay is a failure, not a reduced pass.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -17,77 +8,13 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ARGS=()
 [[ "${1:-}" == --no-sync ]] && { ARGS+=(--no-sync); shift; }
 
-if OVERLAY="$("$ROOT/scripts/overlay.sh" "${ARGS[@]+"${ARGS[@]}"}")"; then
-  # LEMMARY_ROOT is how the overlay learns which tree to test. It no longer
-  # infers that from its own location, which is what let it move out of the
-  # tree in the first place.
-  exec env LEMMARY_ROOT="$ROOT" "$OVERLAY/scripts/test-all.sh" "$@"
+if ! OVERLAY="$("$ROOT/scripts/overlay.sh" "${ARGS[@]+"${ARGS[@]}"}")"; then
+  echo "No verification overlay found." >&2
+  echo "scripts/overlay.sh looks in \$LEMMARY_DEV, $ROOT/dev, and the lemmary-dev sibling." >&2
+  exit 3
 fi
 
-cd "$ROOT"
-
-if ! docker info >/dev/null 2>&1; then
-  echo "Docker is required for verification." >&2
-  exit 1
-fi
-
-stage() { echo ""; echo "==> $1"; }
-fail()  { echo ""; echo "FAILED: $1" >&2; exit 1; }
-
-echo "No verification overlay found: running unit tests and the frontend build."
-echo "API and browser e2e will NOT run."
-
-stage "Unit tests"
-# apt-get needs root; tests must not run as root (vault Wipe as uid 0 unlinks
-# a chmod-0500 parent that stands in for a tmpfs mount).
-docker run --rm \
-  -v "$ROOT:$ROOT" \
-  -w "$ROOT/backend" \
-  -e HOST_UID="$(id -u)" \
-  -e HOST_GID="$(id -g)" \
-  golang:1.26.3-bookworm \
-  bash -c 'set -euo pipefail
-    apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq poppler-utils gosu
-    mkdir -p /tmp/go-build /tmp/go-mod
-    chown "$HOST_UID:$HOST_GID" /tmp/go-build /tmp/go-mod
-    export GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod GOTOOLCHAIN=local HOME=/tmp
-    run_go() {
-      GOWORK=off go test ./... -count=1
-      echo
-      echo "==> Vet"
-      GOWORK=off go vet ./...
-    }
-    if [[ "$HOST_UID" != 0 ]]; then
-      groupadd -g "$HOST_GID" -o lemmary 2>/dev/null || true
-      useradd -u "$HOST_UID" -g "$HOST_GID" -o -M -d /tmp -s /bin/bash lemmary 2>/dev/null || true
-      exec gosu "$HOST_UID:$HOST_GID" bash -c "$(declare -f run_go); run_go"
-    fi
-    run_go
-  ' || fail "unit tests"
-
-stage "Frontend unit tests"
-# Node 26 does not ship corepack. npm install -g needs root if it writes to
-# /usr/local, so install pnpm under $HOME as the bind-mount user: that keeps
-# frontend/node_modules and public/ host-owned, and puts pnpm on PATH for
-# `pnpm run docs:build` inside the build script. Pin matches package.json.
-docker run --rm \
-  -u "$(id -u):$(id -g)" \
-  -e HOME=/tmp/lemmary-reduced \
-  -e npm_config_cache=/tmp/lemmary-reduced/npm \
-  -v "$ROOT:$ROOT" \
-  -w "$ROOT/frontend" \
-  node:26-bookworm \
-  bash -c 'set -euo pipefail
-    mkdir -p "$HOME"
-    npm install -g pnpm@11.24.0 --prefix "$HOME"
-    export PATH="$HOME/bin:$PATH"
-    pnpm install --frozen-lockfile
-    pnpm test
-    echo
-    echo "==> Frontend build"
-    pnpm run build
-  ' || fail "frontend unit tests"
-
-echo ""
-echo "Reduced verification passed. API and browser e2e did not run."
+# LEMMARY_ROOT is how the overlay learns which tree to test. It no longer
+# infers that from its own location, which is what let it move out of the
+# tree in the first place.
+exec env LEMMARY_ROOT="$ROOT" "$OVERLAY/scripts/test-all.sh" "$@"


### PR DESCRIPTION
## Summary

- `./scripts/test-all.sh` still only locates the overlay and execs it. The overlay builds `lemmary-verify:local` and runs the suite there, so an agent sandbox no longer downloads Chromium, apt packages, or Go modules into an ephemeral home on every run.
- With no overlay (fork PR / plain clone), the reduced set runs in official `golang:1.26.3-bookworm` and `node:26-bookworm` images. There is no verify Dockerfile in this tree. Docker is required.
- The PR job drops setup-go, Node, pnpm, poppler, and Playwright install and calls the same wrapper.

Matching overlay branch: `verify-docker` on `lemmary/lemmary-dev` (push that first so this job does not fall back to `main`).

## Test plan

- [x] `./scripts/test-all.sh` with overlay: full suite (unit, API e2e, 134 frontend tests, 86 browser e2e)
- [ ] CI test job on this PR: no host toolchain steps, overlay at `verify-docker`
- [ ] Fork / no-overlay path: reduced suite in official images; API and browser e2e reported skipped