### PR TITLE
Make recent OpenAI models work: reasoning_effort, and the Responses API

### DIFF
--- a/backend/internal/ai/modelnotes.go
+++ b/backend/internal/ai/modelnotes.go
@@ -1,0 +1,105 @@
+package ai
+
+import (
+	"strings"
+	"sync"
+)
+
+// What this process has learned about a model while talking to it. A provider
+// refusing a request the same way twice is worth remembering: the discovery
+// then costs a rejected request per model per process rather than one per call.
+//
+// Every note is keyed by endpoint as well as model. A model string means
+// nothing on its own -- an instance can bind several providers at once, each
+// with its own base URL (see internal/appapi/providers.go), and "gpt-5.6-luna"
+// behind OpenCode Zen is not the same endpoint as the same name at
+// api.openai.com. Keying on the name alone would let one gateway's quirk
+// follow the model onto another.
+type modelNote struct {
+	baseURL string
+	model   string
+}
+
+func noteFor(baseURL, model string) modelNote {
+	return modelNote{
+		baseURL: strings.ToLower(strings.TrimRight(strings.TrimSpace(baseURL), "/")),
+		model:   strings.ToLower(strings.TrimSpace(model)),
+	}
+}
+
+func (n modelNote) empty() bool { return n.model == "" }
+
+var (
+	// Models that would not take function tools alongside their default
+	// reasoning_effort, and had to be pinned to "none".
+	noReasoningEffortNotes sync.Map
+	// Models this endpoint does not serve on /chat/completions at all.
+	responsesAPINotes sync.Map
+	// Models /chat/completions has answered at least once, which makes a later
+	// refusal a transient failure rather than a wrong endpoint.
+	chatCompletionsWorked sync.Map
+	// How many times /chat/completions has refused a model with a status that
+	// could mean either.
+	ambiguousRefusals sync.Map
+)
+
+func rememberNoReasoningEffort(baseURL, model string) { store(&noReasoningEffortNotes, baseURL, model) }
+func needsNoReasoningEffort(baseURL, model string) bool {
+	return loaded(&noReasoningEffortNotes, baseURL, model)
+}
+
+func rememberResponsesAPI(baseURL, model string) { store(&responsesAPINotes, baseURL, model) }
+func needsResponsesAPI(baseURL, model string) bool {
+	return loaded(&responsesAPINotes, baseURL, model)
+}
+
+// rememberChatCompletionsWorked records a completion this endpoint served, so a
+// later failure is read as the provider having a bad minute rather than as a
+// model that lives somewhere else.
+func rememberChatCompletionsWorked(baseURL, model string) {
+	store(&chatCompletionsWorked, baseURL, model)
+}
+func chatCompletionsHasWorked(baseURL, model string) bool {
+	return loaded(&chatCompletionsWorked, baseURL, model)
+}
+
+// countAmbiguousRefusal returns how many times this endpoint has now refused
+// the model with a status that does not say which of the two it means.
+func countAmbiguousRefusal(baseURL, model string) int {
+	note := noteFor(baseURL, model)
+	if note.empty() {
+		return 0
+	}
+	count, _ := ambiguousRefusals.Load(note)
+	n, _ := count.(int)
+	n++
+	ambiguousRefusals.Store(note, n)
+	return n
+}
+
+func store(m *sync.Map, baseURL, model string) {
+	if note := noteFor(baseURL, model); !note.empty() {
+		m.Store(note, struct{}{})
+	}
+}
+
+func loaded(m *sync.Map, baseURL, model string) bool {
+	note := noteFor(baseURL, model)
+	if note.empty() {
+		return false
+	}
+	_, ok := m.Load(note)
+	return ok
+}
+
+// resetModelNotes clears everything this process has learned. Tests only.
+func resetModelNotes() {
+	for _, m := range []*sync.Map{
+		&noReasoningEffortNotes, &responsesAPINotes, &chatCompletionsWorked, &ambiguousRefusals,
+	} {
+		m.Range(func(k, _ any) bool {
+			m.Delete(k)
+			return true
+		})
+	}
+}

--- a/backend/internal/ai/modelnotes_test.go
+++ b/backend/internal/ai/modelnotes_test.go
@@ -1,0 +1,83 @@
+package ai
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared"
+)
+
+// A model name means nothing on its own. An instance can bind several providers
+// at once, so what one gateway does with "gpt-5.6-luna" must not follow the
+// name onto another.
+func TestModelNotesAreScopedToTheirEndpoint(t *testing.T) {
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	const model = "gpt-5.6-luna"
+	zen := "https://opencode.ai/zen/go/v1"
+	openai := "https://api.openai.com/v1"
+
+	rememberResponsesAPI(zen, model)
+	rememberNoReasoningEffort(zen, model)
+
+	if !needsResponsesAPI(zen, model) || !needsNoReasoningEffort(zen, model) {
+		t.Fatal("the endpoint that taught us this does not remember it")
+	}
+	if needsResponsesAPI(openai, model) {
+		t.Fatal("one gateway's routing leaked onto another")
+	}
+	if needsNoReasoningEffort(openai, model) {
+		t.Fatal("one gateway's reasoning_effort verdict leaked onto another")
+	}
+
+	// A trailing slash and a different case are the same endpoint.
+	if !needsResponsesAPI("https://OpenCode.ai/zen/go/v1/", "GPT-5.6-Luna") {
+		t.Fatal("the same endpoint was not recognised through normalisation")
+	}
+	// An unnamed model is not a note.
+	rememberResponsesAPI(zen, "  ")
+	if needsResponsesAPI(zen, "") {
+		t.Fatal("an empty model name was stored as a note")
+	}
+}
+
+// The same model behind two providers must be discovered separately, all the
+// way through CompleteChat rather than only in the note store.
+func TestDiscoveryDoesNotLeakBetweenProviders(t *testing.T) {
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+	const model = "shared-model-name"
+
+	// One provider serves this model only on /responses.
+	responsesOnly := &responsesHarness{chatStatus: http.StatusNotFound, respTurns: []scriptedTurn{{content: "from responses"}}}
+	responsesBase := newResponsesHarness(t, responsesOnly)
+	// The other serves it perfectly well on /chat/completions.
+	ordinary := &responsesHarness{}
+	ordinaryBase := newResponsesHarness(t, ordinary)
+
+	params := openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}
+	first := NewOpenAIClient("openai", "k", model, responsesBase, "v1", "", 5*time.Second, slog.Default())
+	if _, err := CompleteChat(context.Background(), first.client, slog.Default(), "openai", responsesBase, params); err != nil {
+		t.Fatalf("responses-only provider: %v", err)
+	}
+
+	second := NewOpenAIClient("openai", "k", model, ordinaryBase, "v1", "", 5*time.Second, slog.Default())
+	resp, err := CompleteChat(context.Background(), second.client, slog.Default(), "openai", ordinaryBase, params)
+	if err != nil {
+		t.Fatalf("ordinary provider: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "served by chat completions" {
+		t.Fatalf("content = %q", resp.Choices[0].Message.Content)
+	}
+	if _, r := ordinary.counts(); r != 0 {
+		t.Fatalf("the other provider's discovery sent %d requests to this one's /responses", r)
+	}
+}

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -71,14 +71,25 @@ func (c *OpenAIClient) complete(ctx context.Context, params openai.ChatCompletio
 }
 
 // CompleteChat sends a chat completion, and gives a provider that refuses it a
-// second chance rather than treating the model as broken: JSON mode is dropped
-// if response_format is rejected, reasoning_effort is pinned to "none" if the
-// model will not take tools alongside it, and temperature falls back to the API
-// default. The reasoning_effort verdict is remembered per model, so it costs one
-// rejected request per process rather than one per call.
+// second chance rather than treating the model as broken. In order: JSON mode
+// is dropped if response_format is rejected, reasoning_effort is pinned to
+// "none" if the model will not take tools alongside it, temperature falls back
+// to the API default, and finally the whole request is translated to the
+// Responses API if this endpoint turns out not to serve the model at all. Each
+// of the last two is remembered per model, so the discovery costs one rejected
+// request per process rather than one per call.
 func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger, sdk, baseURL string, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	// A model already known to live on the Responses API never touches
+	// /chat/completions again.
+	if needsResponsesAPI(string(params.Model)) {
+		resp, err := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...)
+		if err == nil {
+			logUsage(logger, string(params.Model), usageOf(resp), extra...)
+		}
+		return resp, err
 	}
 	// A model that has already refused tools alongside its default
 	// reasoning_effort gets the working value up front. Only tool-carrying
@@ -168,6 +179,22 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
 		}
 	}
+	// Last resort: the endpoint may simply not serve this model. OpenCode Zen
+	// routes gpt-5.6-luna and friends to /responses and answers 500 here for
+	// anything at all. Try there once, and keep the original error if that was
+	// not the problem -- a Responses error for a provider that has no such
+	// endpoint would only mislead.
+	if isEndpointMismatchError(err) {
+		logger.Warn("chat completions refused this model; retrying on the Responses API",
+			"model", params.Model,
+			slog.Any("error", err),
+		)
+		if viaResponses, respErr := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...); respErr == nil {
+			rememberResponsesAPI(string(params.Model))
+			logUsage(logger, string(params.Model), usageOf(viaResponses), extra...)
+			return viaResponses, nil
+		}
+	}
 	return resp, err
 }
 
@@ -228,6 +255,9 @@ func (c *OpenAIClient) completeStreaming(
 	onDelta func(string),
 	extra ...any,
 ) (string, Usage, error) {
+	if needsResponsesAPI(string(params.Model)) {
+		return c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
+	}
 	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
 	aiprovider.LogRequest(
 		c.logger,
@@ -263,6 +293,21 @@ func (c *OpenAIClient) completeStreaming(
 	err := stream.Err()
 	if err == nil {
 		logUsage(c.logger, string(params.Model), usage, append(extra, "stream", true)...)
+		return b.String(), usage, nil
+	}
+	// Same fallback as CompleteChat, but only while nothing has reached the
+	// reader yet: once deltas are on the wire, a second stream would replay a
+	// different answer over the first.
+	if b.Len() == 0 && isEndpointMismatchError(err) {
+		c.logger.Warn("chat completions refused this model; retrying the stream on the Responses API",
+			"model", params.Model,
+			slog.Any("error", err),
+		)
+		text, respUsage, respErr := c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
+		if respErr == nil {
+			rememberResponsesAPI(string(params.Model))
+			return text, respUsage, nil
+		}
 	}
 	return b.String(), usage, err
 }

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
+	"github.com/openai/openai-go/shared"
 	"lemmary/backend/internal/aiprovider"
 )
 
@@ -69,11 +70,23 @@ func (c *OpenAIClient) complete(ctx context.Context, params openai.ChatCompletio
 	return CompleteChat(ctx, c.client, c.logger, c.sdk, c.baseURL, params, extra...)
 }
 
-// CompleteChat sends a chat completion and retries once without temperature
-// if the model rejects a custom value.
+// CompleteChat sends a chat completion, and gives a provider that refuses it a
+// second chance rather than treating the model as broken: JSON mode is dropped
+// if response_format is rejected, reasoning_effort is pinned to "none" if the
+// model will not take tools alongside it, and temperature falls back to the API
+// default. The reasoning_effort verdict is remembered per model, so it costs one
+// rejected request per process rather than one per call.
 func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger, sdk, baseURL string, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	// A model that has already refused tools alongside its default
+	// reasoning_effort gets the working value up front. Only tool-carrying
+	// requests: pinning "none" on the rest would drop the model's reasoning
+	// where nothing asked us to.
+	if len(params.Tools) > 0 && needsNoReasoningEffort(string(params.Model)) {
+		params.ReasoningEffort = shared.ReasoningEffort(reasoningEffortNone)
+		extra = append(extra, "reasoning_effort", reasoningEffortNone)
 	}
 	aiprovider.LogRequest(
 		logger,
@@ -104,6 +117,31 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 			aiprovider.ChatCompletionsURL(baseURL),
 			string(params.Model),
 			append(extra, "retry", "omit_response_format")...,
+		)
+		resp, err = client.Chat.Completions.New(ctx, params)
+		if err == nil {
+			logUsage(logger, string(params.Model), usageOf(resp), extra...)
+			return resp, nil
+		}
+	}
+	// Some gpt-5-family models default reasoning_effort server-side and then
+	// refuse the request because function tools are present, naming "none" as
+	// the way to keep the tools. Take them up on it rather than failing the
+	// whole search.
+	if len(params.Tools) > 0 && isReasoningEffortToolConflictError(err) {
+		logger.Warn("model rejected reasoning_effort with function tools; retrying with reasoning_effort=none",
+			"model", params.Model,
+			slog.Any("error", err),
+		)
+		params.ReasoningEffort = shared.ReasoningEffort(reasoningEffortNone)
+		rememberNoReasoningEffort(string(params.Model))
+		aiprovider.LogRequest(
+			logger,
+			sdk,
+			http.MethodPost,
+			aiprovider.ChatCompletionsURL(baseURL),
+			string(params.Model),
+			append(extra, "retry", "reasoning_effort_none")...,
 		)
 		resp, err = client.Chat.Completions.New(ctx, params)
 		if err == nil {

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -76,15 +76,15 @@ func (c *OpenAIClient) complete(ctx context.Context, params openai.ChatCompletio
 // "none" if the model will not take tools alongside it, temperature falls back
 // to the API default, and finally the whole request is translated to the
 // Responses API if this endpoint turns out not to serve the model at all. Each
-// of the last two is remembered per model, so the discovery costs one rejected
-// request per process rather than one per call.
+// of the last two is remembered per model and endpoint, so the discovery costs
+// one rejected request per process rather than one per call.
 func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger, sdk, baseURL string, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	// A model already known to live on the Responses API never touches
 	// /chat/completions again.
-	if needsResponsesAPI(string(params.Model)) {
+	if needsResponsesAPI(baseURL, string(params.Model)) {
 		resp, err := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...)
 		if err == nil {
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
@@ -95,7 +95,7 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	// reasoning_effort gets the working value up front. Only tool-carrying
 	// requests: pinning "none" on the rest would drop the model's reasoning
 	// where nothing asked us to.
-	if len(params.Tools) > 0 && needsNoReasoningEffort(string(params.Model)) {
+	if len(params.Tools) > 0 && needsNoReasoningEffort(baseURL, string(params.Model)) {
 		params.ReasoningEffort = shared.ReasoningEffort(reasoningEffortNone)
 		extra = append(extra, "reasoning_effort", reasoningEffortNone)
 	}
@@ -109,6 +109,7 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	)
 	resp, err := client.Chat.Completions.New(ctx, params)
 	if err == nil {
+		rememberChatCompletionsWorked(baseURL, string(params.Model))
 		logUsage(logger, string(params.Model), usageOf(resp), extra...)
 		return resp, nil
 	}
@@ -136,16 +137,27 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 		}
 	}
 	// Some gpt-5-family models default reasoning_effort server-side and then
-	// refuse the request because function tools are present, naming "none" as
-	// the way to keep the tools. Take them up on it rather than failing the
-	// whole search.
+	// refuse the request because function tools are present. The refusal names
+	// two ways out, and they are not equal: /responses keeps the tools and the
+	// reasoning, while reasoning_effort=none keeps the tools by turning the
+	// reasoning off. Take the first, and settle for the second only where
+	// there is no Responses endpoint to take it to.
 	if len(params.Tools) > 0 && isReasoningEffortToolConflictError(err) {
-		logger.Warn("model rejected reasoning_effort with function tools; retrying with reasoning_effort=none",
+		logger.Warn("model rejected reasoning_effort with function tools; retrying on the Responses API",
 			"model", params.Model,
 			slog.Any("error", err),
 		)
+		if viaResponses, respErr := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...); respErr == nil {
+			rememberResponsesAPI(baseURL, string(params.Model))
+			logUsage(logger, string(params.Model), usageOf(viaResponses), extra...)
+			return viaResponses, nil
+		} else {
+			logger.Warn("the Responses API could not serve it either; falling back to reasoning_effort=none",
+				"model", params.Model,
+				slog.Any("error", respErr),
+			)
+		}
 		params.ReasoningEffort = shared.ReasoningEffort(reasoningEffortNone)
-		rememberNoReasoningEffort(string(params.Model))
 		aiprovider.LogRequest(
 			logger,
 			sdk,
@@ -156,6 +168,10 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 		)
 		resp, err = client.Chat.Completions.New(ctx, params)
 		if err == nil {
+			// Remembered only now that the value is known to work: a "none"
+			// the provider also refuses is not worth pinning.
+			rememberNoReasoningEffort(baseURL, string(params.Model))
+			rememberChatCompletionsWorked(baseURL, string(params.Model))
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
 			return resp, nil
 		}
@@ -176,6 +192,7 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 		)
 		resp, err = client.Chat.Completions.New(ctx, params)
 		if err == nil {
+			rememberChatCompletionsWorked(baseURL, string(params.Model))
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
 		}
 	}
@@ -184,13 +201,16 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	// anything at all. Try there once, and keep the original error if that was
 	// not the problem -- a Responses error for a provider that has no such
 	// endpoint would only mislead.
-	if isEndpointMismatchError(err) {
+	if try, remember := shouldTryResponses(err, baseURL, string(params.Model)); try {
 		logger.Warn("chat completions refused this model; retrying on the Responses API",
 			"model", params.Model,
+			"remember", remember,
 			slog.Any("error", err),
 		)
 		if viaResponses, respErr := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...); respErr == nil {
-			rememberResponsesAPI(string(params.Model))
+			if remember {
+				rememberResponsesAPI(baseURL, string(params.Model))
+			}
 			logUsage(logger, string(params.Model), usageOf(viaResponses), extra...)
 			return viaResponses, nil
 		}
@@ -255,7 +275,7 @@ func (c *OpenAIClient) completeStreaming(
 	onDelta func(string),
 	extra ...any,
 ) (string, Usage, error) {
-	if needsResponsesAPI(string(params.Model)) {
+	if needsResponsesAPI(c.baseURL, string(params.Model)) {
 		return c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
 	}
 	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
@@ -292,20 +312,28 @@ func (c *OpenAIClient) completeStreaming(
 	}
 	err := stream.Err()
 	if err == nil {
+		rememberChatCompletionsWorked(c.baseURL, string(params.Model))
 		logUsage(c.logger, string(params.Model), usage, append(extra, "stream", true)...)
 		return b.String(), usage, nil
 	}
 	// Same fallback as CompleteChat, but only while nothing has reached the
 	// reader yet: once deltas are on the wire, a second stream would replay a
 	// different answer over the first.
-	if b.Len() == 0 && isEndpointMismatchError(err) {
+	if b.Len() == 0 {
+		try, remember := shouldTryResponses(err, c.baseURL, string(params.Model))
+		if !try {
+			return b.String(), usage, err
+		}
 		c.logger.Warn("chat completions refused this model; retrying the stream on the Responses API",
 			"model", params.Model,
+			"remember", remember,
 			slog.Any("error", err),
 		)
 		text, respUsage, respErr := c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
 		if respErr == nil {
-			rememberResponsesAPI(string(params.Model))
+			if remember {
+				rememberResponsesAPI(c.baseURL, string(params.Model))
+			}
 			return text, respUsage, nil
 		}
 	}

--- a/backend/internal/ai/reasoning.go
+++ b/backend/internal/ai/reasoning.go
@@ -67,6 +67,8 @@ func resetNoReasoningEffort() {
 	})
 }
 
+// modelKey normalises a configured model string for the two per-model notes
+// this package keeps (see also responses.go).
 func modelKey(model string) string {
 	return strings.ToLower(strings.TrimSpace(model))
 }

--- a/backend/internal/ai/reasoning.go
+++ b/backend/internal/ai/reasoning.go
@@ -3,7 +3,6 @@ package ai
 import (
 	"errors"
 	"strings"
-	"sync"
 
 	"github.com/openai/openai-go"
 )
@@ -36,39 +35,4 @@ func isReasoningEffortToolConflictError(err error) bool {
 func mentionsReasoningEffortToolConflict(msg string) bool {
 	msg = strings.ToLower(msg)
 	return strings.Contains(msg, "reasoning_effort") && strings.Contains(msg, "function tools")
-}
-
-// Models that have already refused tools alongside their default
-// reasoning_effort. Remembering them keeps the cost of the discovery at one
-// rejected request per model per process, rather than one per agent round —
-// the research loop is uncapped, so paying it every round adds up.
-var noReasoningEffortModels sync.Map
-
-func rememberNoReasoningEffort(model string) {
-	if key := modelKey(model); key != "" {
-		noReasoningEffortModels.Store(key, struct{}{})
-	}
-}
-
-func needsNoReasoningEffort(model string) bool {
-	key := modelKey(model)
-	if key == "" {
-		return false
-	}
-	_, ok := noReasoningEffortModels.Load(key)
-	return ok
-}
-
-// resetNoReasoningEffort clears what the process has learned. Tests only.
-func resetNoReasoningEffort() {
-	noReasoningEffortModels.Range(func(k, _ any) bool {
-		noReasoningEffortModels.Delete(k)
-		return true
-	})
-}
-
-// modelKey normalises a configured model string for the two per-model notes
-// this package keeps (see also responses.go).
-func modelKey(model string) string {
-	return strings.ToLower(strings.TrimSpace(model))
 }

--- a/backend/internal/ai/reasoning.go
+++ b/backend/internal/ai/reasoning.go
@@ -1,0 +1,72 @@
+package ai
+
+import (
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/openai/openai-go"
+)
+
+// reasoningEffortNone is the only value some gpt-5-family models accept for
+// reasoning_effort once function tools are on the request. It is not one of the
+// SDK's low/medium/high constants, but shared.ReasoningEffort is a string type.
+const reasoningEffortNone = "none"
+
+// isReasoningEffortToolConflictError recognises a provider rejecting a
+// non-"none" reasoning_effort alongside function tools on /v1/chat/completions.
+// We never send the parameter ourselves; these models default it server-side
+// and then refuse the request because tools are present.
+func isReasoningEffortToolConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *openai.Error
+	if errors.As(err, &apiErr) {
+		// The param alone is enough; the wording of the message varies by
+		// provider, and OpenAI-compatible proxies often leave it out entirely.
+		if strings.EqualFold(strings.TrimSpace(apiErr.Param), "reasoning_effort") {
+			return true
+		}
+		return mentionsReasoningEffortToolConflict(apiErr.Message)
+	}
+	return mentionsReasoningEffortToolConflict(err.Error())
+}
+
+func mentionsReasoningEffortToolConflict(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "reasoning_effort") && strings.Contains(msg, "function tools")
+}
+
+// Models that have already refused tools alongside their default
+// reasoning_effort. Remembering them keeps the cost of the discovery at one
+// rejected request per model per process, rather than one per agent round —
+// the research loop is uncapped, so paying it every round adds up.
+var noReasoningEffortModels sync.Map
+
+func rememberNoReasoningEffort(model string) {
+	if key := modelKey(model); key != "" {
+		noReasoningEffortModels.Store(key, struct{}{})
+	}
+}
+
+func needsNoReasoningEffort(model string) bool {
+	key := modelKey(model)
+	if key == "" {
+		return false
+	}
+	_, ok := noReasoningEffortModels.Load(key)
+	return ok
+}
+
+// resetNoReasoningEffort clears what the process has learned. Tests only.
+func resetNoReasoningEffort() {
+	noReasoningEffortModels.Range(func(k, _ any) bool {
+		noReasoningEffortModels.Delete(k)
+		return true
+	})
+}
+
+func modelKey(model string) string {
+	return strings.ToLower(strings.TrimSpace(model))
+}

--- a/backend/internal/ai/reasoning_test.go
+++ b/backend/internal/ai/reasoning_test.go
@@ -1,0 +1,198 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+)
+
+// reasoningHarness fakes the gpt-5-family behaviour from issue #49: a request
+// carrying function tools is refused unless reasoning_effort is explicitly
+// "none". Requests without tools are served normally, whatever they say.
+type reasoningHarness struct {
+	mu         sync.Mutex
+	requests   []map[string]any
+	turns      []scriptedTurn
+	next       int
+	rejections int
+}
+
+func (h *reasoningHarness) handler(w http.ResponseWriter, r *http.Request) {
+	raw, _ := io.ReadAll(r.Body)
+	var body map[string]any
+	_ = json.Unmarshal(raw, &body)
+
+	h.mu.Lock()
+	h.requests = append(h.requests, body)
+	tools, _ := body["tools"].([]any)
+	effort, _ := body["reasoning_effort"].(string)
+	if len(tools) > 0 && effort != "none" {
+		h.rejections++
+		h.mu.Unlock()
+		writeReasoningEffortConflict(w)
+		return
+	}
+	turn := scriptedTurn{content: "No further information."}
+	if h.next < len(h.turns) {
+		turn = h.turns[h.next]
+		h.next++
+	}
+	h.mu.Unlock()
+
+	if stream, _ := body["stream"].(bool); stream {
+		writeChatStream(w, turn.content, turn.cutOff)
+		return
+	}
+	writeToolCallJSON(w, turn)
+}
+
+// writeReasoningEffortConflict reproduces the 400 from issue #49 verbatim.
+func writeReasoningEffortConflict(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"message": "Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. " +
+				"To use function tools, use /v1/responses or set reasoning_effort to 'none'.",
+			"type":  "invalid_request_error",
+			"param": "reasoning_effort",
+			"code":  nil,
+		},
+	})
+}
+
+func (h *reasoningHarness) request(i int) map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.requests[i]
+}
+
+func (h *reasoningHarness) requestCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.requests)
+}
+
+func effortOf(body map[string]any) string {
+	effort, _ := body["reasoning_effort"].(string)
+	return effort
+}
+
+func hasTools(body map[string]any) bool {
+	tools, _ := body["tools"].([]any)
+	return len(tools) > 0
+}
+
+// Issue #49: the research loop used to die on the first round because the model
+// defaults reasoning_effort server-side and then refuses the tools we sent.
+func TestResearchRetriesOnceWithReasoningEffortNoneThenRemembers(t *testing.T) {
+	// Not parallel: the learned-model set is process-wide.
+	model := "gpt-5.6-luna-research-test"
+	resetNoReasoningEffort()
+	t.Cleanup(resetNoReasoningEffort)
+
+	h := &reasoningHarness{turns: []scriptedTurn{
+		{toolCalls: []scriptedToolCall{{name: "search_documents", args: `{"query":"car insurance"}`}}},
+		{content: "ready"},
+		{content: "You paid 200 EUR, see [Doc doc1](/document/doc1)."},
+	}}
+	srv := httptest.NewServer(http.HandlerFunc(h.handler))
+	t.Cleanup(srv.Close)
+	agent := NewSearchAgent("openai", "test-key", model, srv.URL, 5*time.Second, "en,de", "en", slog.Default())
+
+	result, err := agent.Research(context.Background(), ResearchRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "how much did I pay?"}},
+		Search: func(_ context.Context, _ SearchDocumentsArgs) ([]DocumentHit, error) {
+			return hitsFor("doc1"), nil
+		},
+		Read: func(_ context.Context, _ ReadRequest) ([]DocumentContent, error) {
+			return []DocumentContent{{ID: "doc1", Title: "Doc doc1", Text: "Premium 200 EUR"}}, nil
+		},
+	}, func(ResearchEvent) {})
+	if err != nil {
+		t.Fatalf("Research: %v", err)
+	}
+	if !strings.Contains(result.Reply, "/document/doc1") {
+		t.Fatalf("reply = %q", result.Reply)
+	}
+
+	if h.rejections != 1 {
+		t.Fatalf("rejections = %d, want exactly 1: the model should be remembered after the first refusal", h.rejections)
+	}
+	if got := effortOf(h.request(0)); got != "" {
+		t.Fatalf("first request already sent reasoning_effort=%q; we should not send it unprompted", got)
+	}
+	if got := effortOf(h.request(1)); got != "none" {
+		t.Fatalf("retry reasoning_effort = %q, want none", got)
+	}
+	// Every later tool-carrying round must arrive pre-corrected.
+	for i := 2; i < h.requestCount(); i++ {
+		body := h.request(i)
+		if hasTools(body) && effortOf(body) != "none" {
+			t.Fatalf("request %d carries tools but reasoning_effort = %q", i, effortOf(body))
+		}
+	}
+	if !needsNoReasoningEffort(model) {
+		t.Fatal("model was not remembered")
+	}
+}
+
+// The streamed answer phase sends no tools, so it must keep the model's own
+// reasoning rather than inheriting "none" from the tool rounds.
+func TestReasoningEffortNoneIsNotAppliedWithoutTools(t *testing.T) {
+	model := "gpt-5.6-luna-extract-test"
+	resetNoReasoningEffort()
+	t.Cleanup(resetNoReasoningEffort)
+	rememberNoReasoningEffort(model)
+
+	body := captureChatBody(t, model)
+	if strings.Contains(body, "reasoning_effort") {
+		t.Fatalf("tool-less request sent reasoning_effort: %s", body)
+	}
+}
+
+func TestIsReasoningEffortToolConflictError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"param alone",
+			&openai.Error{Param: "reasoning_effort", Message: "unsupported"},
+			true,
+		},
+		{
+			// OpenAI-compatible proxies routinely leave param empty.
+			"message alone",
+			&openai.Error{Message: "Function tools with reasoning_effort are not supported for gpt-5.6-luna"},
+			true,
+		},
+		{
+			"wrapped",
+			errors.New("openai search completion: Function tools with reasoning_effort are not supported"),
+			true,
+		},
+		{"unrelated param", &openai.Error{Param: "temperature", Message: "temperature does not support 0.2"}, false},
+		{"unrelated text", errors.New("context length exceeded"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReasoningEffortToolConflictError(tc.err); got != tc.want {
+				t.Fatalf("isReasoningEffortToolConflictError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/ai/reasoning_test.go
+++ b/backend/internal/ai/reasoning_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared"
 )
 
 // reasoningHarness fakes the gpt-5-family behaviour from issue #49: a request
@@ -25,12 +26,41 @@ type reasoningHarness struct {
 	turns      []scriptedTurn
 	next       int
 	rejections int
+	// responsesTurns, when set, makes /responses a working endpoint serving
+	// these turns. Absent, the provider has no such endpoint and answers 404 --
+	// which is the case where reasoning_effort=none is the only way out.
+	responsesTurns []scriptedTurn
+	responsesNext  int
+	responsesTried int
 }
 
 func (h *reasoningHarness) handler(w http.ResponseWriter, r *http.Request) {
 	raw, _ := io.ReadAll(r.Body)
 	var body map[string]any
 	_ = json.Unmarshal(raw, &body)
+
+	if strings.HasSuffix(r.URL.Path, "/responses") {
+		h.mu.Lock()
+		h.responsesTried++
+		serve := len(h.responsesTurns) > 0
+		turn := scriptedTurn{content: "No further information."}
+		if h.responsesNext < len(h.responsesTurns) {
+			turn = h.responsesTurns[h.responsesNext]
+			h.responsesNext++
+		}
+		h.mu.Unlock()
+		if !serve {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "unknown endpoint"}})
+			return
+		}
+		if stream, _ := body["stream"].(bool); stream {
+			writeResponsesStream(w, turn.content)
+			return
+		}
+		writeResponsesJSON(w, turn, "")
+		return
+	}
 
 	h.mu.Lock()
 	h.requests = append(h.requests, body)
@@ -93,13 +123,13 @@ func hasTools(body map[string]any) bool {
 	return len(tools) > 0
 }
 
-// Issue #49: the research loop used to die on the first round because the model
-// defaults reasoning_effort server-side and then refuses the tools we sent.
-func TestResearchRetriesOnceWithReasoningEffortNoneThenRemembers(t *testing.T) {
+// Issue #49, on a provider with no Responses endpoint to move to: the refusal's
+// other option, reasoning_effort=none, is then the only way to keep the tools.
+func TestResearchFallsBackToReasoningEffortNoneAndRemembers(t *testing.T) {
 	// Not parallel: the learned-model set is process-wide.
 	model := "gpt-5.6-luna-research-test"
-	resetNoReasoningEffort()
-	t.Cleanup(resetNoReasoningEffort)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
 	h := &reasoningHarness{turns: []scriptedTurn{
 		{toolCalls: []scriptedToolCall{{name: "search_documents", args: `{"query":"car insurance"}`}}},
@@ -108,7 +138,8 @@ func TestResearchRetriesOnceWithReasoningEffortNoneThenRemembers(t *testing.T) {
 	}}
 	srv := httptest.NewServer(http.HandlerFunc(h.handler))
 	t.Cleanup(srv.Close)
-	agent := NewSearchAgent("openai", "test-key", model, srv.URL, 5*time.Second, "en,de", "en", slog.Default())
+	base := srv.URL
+	agent := NewSearchAgent("openai", "test-key", model, base, 5*time.Second, "en,de", "en", slog.Default())
 
 	result, err := agent.Research(context.Background(), ResearchRequest{
 		Messages: []ChatMessage{{Role: "user", Content: "how much did I pay?"}},
@@ -129,6 +160,11 @@ func TestResearchRetriesOnceWithReasoningEffortNoneThenRemembers(t *testing.T) {
 	if h.rejections != 1 {
 		t.Fatalf("rejections = %d, want exactly 1: the model should be remembered after the first refusal", h.rejections)
 	}
+	// /responses is the better of the two options the refusal names, so it has
+	// to be offered the request before "none" is settled for.
+	if h.responsesTried != 1 {
+		t.Fatalf("responses attempts = %d, want 1 before falling back to none", h.responsesTried)
+	}
 	if got := effortOf(h.request(0)); got != "" {
 		t.Fatalf("first request already sent reasoning_effort=%q; we should not send it unprompted", got)
 	}
@@ -142,7 +178,7 @@ func TestResearchRetriesOnceWithReasoningEffortNoneThenRemembers(t *testing.T) {
 			t.Fatalf("request %d carries tools but reasoning_effort = %q", i, effortOf(body))
 		}
 	}
-	if !needsNoReasoningEffort(model) {
+	if !needsNoReasoningEffort(base, model) {
 		t.Fatal("model was not remembered")
 	}
 }
@@ -151,13 +187,102 @@ func TestResearchRetriesOnceWithReasoningEffortNoneThenRemembers(t *testing.T) {
 // reasoning rather than inheriting "none" from the tool rounds.
 func TestReasoningEffortNoneIsNotAppliedWithoutTools(t *testing.T) {
 	model := "gpt-5.6-luna-extract-test"
-	resetNoReasoningEffort()
-	t.Cleanup(resetNoReasoningEffort)
-	rememberNoReasoningEffort(model)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
-	body := captureChatBody(t, model)
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		body = string(raw)
+		writeChatJSON(w, extractTestJSON)
+	}))
+	t.Cleanup(srv.Close)
+	rememberNoReasoningEffort(srv.URL, model)
+
+	client := NewOpenAIClient("openai", "test-key", model, srv.URL, "v1", "", 5*time.Second, slog.Default())
+	if _, err := client.ExtractMetadata(context.Background(), "Invoice from Acme", ExtractionCatalog{}); err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
 	if strings.Contains(body, "reasoning_effort") {
 		t.Fatalf("tool-less request sent reasoning_effort: %s", body)
+	}
+}
+
+// The refusal names /responses first because it keeps the tools *and* the
+// reasoning; "none" keeps the tools by switching the reasoning off. Where both
+// are available, the request must take the first.
+func TestReasoningEffortConflictPrefersTheResponsesAPI(t *testing.T) {
+	model := "gpt-5.6-luna-prefers-responses"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	h := &reasoningHarness{responsesTurns: []scriptedTurn{
+		{toolCalls: []scriptedToolCall{{name: "search_documents", args: `{"query":"insurance"}`}}},
+		{content: "ready"},
+		{content: "Answer with [Doc doc1](/document/doc1)."},
+	}}
+	srv := httptest.NewServer(http.HandlerFunc(h.handler))
+	t.Cleanup(srv.Close)
+	base := srv.URL
+	agent := NewSearchAgent("openai", "test-key", model, base, 5*time.Second, "en,de", "en", slog.Default())
+
+	if _, err := agent.Research(context.Background(), ResearchRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "how much did I pay?"}},
+		Search: func(_ context.Context, _ SearchDocumentsArgs) ([]DocumentHit, error) {
+			return hitsFor("doc1"), nil
+		},
+		Read: func(_ context.Context, _ ReadRequest) ([]DocumentContent, error) {
+			return []DocumentContent{{ID: "doc1", Title: "Doc doc1", Text: "Premium 200 EUR"}}, nil
+		},
+	}, func(ResearchEvent) {}); err != nil {
+		t.Fatalf("Research: %v", err)
+	}
+
+	if needsNoReasoningEffort(base, model) {
+		t.Fatal("the model was pinned to reasoning_effort=none even though /responses served it")
+	}
+	if !needsResponsesAPI(base, model) {
+		t.Fatal("the model was not remembered as a Responses one")
+	}
+	// One refused chat request, and nothing sent to /chat/completions after it.
+	for i, body := range h.requests {
+		if effortOf(body) == "none" {
+			t.Fatalf("request %d switched the reasoning off: %v", i, body)
+		}
+	}
+	if len(h.requests) != 1 {
+		t.Fatalf("chat/completions requests = %d, want 1", len(h.requests))
+	}
+}
+
+// A "none" the provider also refuses is not worth pinning: the next call would
+// send a value already known to fail.
+func TestReasoningEffortNoneIsNotRememberedWhenItAlsoFails(t *testing.T) {
+	model := "gpt-5.6-luna-none-also-fails"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/responses") {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "unknown endpoint"}})
+			return
+		}
+		writeReasoningEffortConflict(w)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewOpenAIClient("openai", "test-key", model, srv.URL, "v1", "", 5*time.Second, slog.Default())
+	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", srv.URL, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+		Tools:    []openai.ChatCompletionToolParam{{Function: shared.FunctionDefinitionParam{Name: "search_documents"}}},
+	})
+	if err == nil {
+		t.Fatal("expected the refusal to surface")
+	}
+	if needsNoReasoningEffort(srv.URL, model) {
+		t.Fatal("a value the provider rejected was remembered anyway")
 	}
 }
 

--- a/backend/internal/ai/responses.go
+++ b/backend/internal/ai/responses.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/packages/param"
@@ -28,55 +27,65 @@ import (
 // to ResponseNewParams, and the Response to a *openai.ChatCompletion the
 // existing call sites already know how to read. No caller changes.
 
-// responsesModels remembers the models whose completions had to be translated,
-// so the discovery costs one rejected request per model per process instead of
-// one per agent round.
-var responsesModels sync.Map
+// endpointVerdict is what a failed /chat/completions request says about
+// whether this endpoint serves this model at all.
+type endpointVerdict int
 
-func rememberResponsesAPI(model string) {
-	if key := modelKey(model); key != "" {
-		responsesModels.Store(key, struct{}{})
-	}
-}
+const (
+	// notAMismatch: the failure says nothing about the endpoint.
+	notAMismatch endpointVerdict = iota
+	// ambiguousMismatch: could be either. 500 is what OpenCode Zen answers for
+	// a Responses-only model, and also the generic internal error every
+	// provider returns when it is having a bad minute.
+	ambiguousMismatch
+	// certainMismatch: a status a working endpoint does not return for a model
+	// it serves.
+	certainMismatch
+)
 
-func needsResponsesAPI(model string) bool {
-	key := modelKey(model)
-	if key == "" {
-		return false
-	}
-	_, ok := responsesModels.Load(key)
-	return ok
-}
-
-// resetResponsesAPI clears what the process has learned. Tests only.
-func resetResponsesAPI() {
-	responsesModels.Range(func(k, _ any) bool {
-		responsesModels.Delete(k)
-		return true
-	})
-}
-
-// isEndpointMismatchError reports whether a failed /chat/completions request
-// looks like the endpoint refusing to serve this model at all, rather than
-// disliking something we sent. OpenCode answers 500 for a Responses-only model
-// even for a bare "say hi"; 401 and 403 are what it returns for the others, on
-// a key that works everywhere else. 502/503/504 are deliberately absent: those
-// are ordinary transient failures and retrying them on a different endpoint
-// would be guessing.
-func isEndpointMismatchError(err error) bool {
+// classifyEndpointError reads a failed /chat/completions request for whether
+// the endpoint is refusing to serve this model at all, rather than disliking
+// something we sent. 502/503/504 are deliberately absent: those are ordinary
+// transient failures, and rerouting on them would be guessing.
+func classifyEndpointError(err error) endpointVerdict {
 	if err == nil {
-		return false
+		return notAMismatch
 	}
 	var apiErr *openai.Error
 	if !errors.As(err, &apiErr) {
-		return false
+		return notAMismatch
 	}
 	switch apiErr.StatusCode {
+	case http.StatusInternalServerError:
+		return ambiguousMismatch
 	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
-		http.StatusMethodNotAllowed, http.StatusInternalServerError, http.StatusNotImplemented:
-		return true
+		http.StatusMethodNotAllowed, http.StatusNotImplemented:
+		return certainMismatch
 	}
-	return false
+	return notAMismatch
+}
+
+// shouldTryResponses decides whether to translate a refused request, and
+// whether a success would be worth remembering.
+//
+// An endpoint that has already served this model is not an endpoint that does
+// not serve it, so a later refusal there is transient however it is worded --
+// the SDK is configured with no retries of its own, so a single hiccup would
+// otherwise be enough to reroute a model permanently. An ambiguous refusal on a
+// model never seen to work is worth translating immediately, because the caller
+// is waiting, but only worth remembering once it has happened twice: a
+// provider's bad minute does not repeat, a wrong endpoint does.
+func shouldTryResponses(err error, baseURL, model string) (try bool, remember bool) {
+	switch classifyEndpointError(err) {
+	case certainMismatch:
+		return true, true
+	case ambiguousMismatch:
+		if chatCompletionsHasWorked(baseURL, model) {
+			return false, false
+		}
+		return true, countAmbiguousRefusal(baseURL, model) > 1
+	}
+	return false, false
 }
 
 // CompleteViaResponses runs a chat-completions-shaped request through the
@@ -108,7 +117,29 @@ func CompleteViaResponses(
 	if err != nil {
 		return nil, err
 	}
+	if err := responseFailure(resp); err != nil {
+		return nil, err
+	}
 	return chatCompletionFrom(resp), nil
+}
+
+// responseFailure turns a generation the provider gave up on into an error.
+// The Responses API reports that in the body with a 200, so the SDK hands it
+// back as a success; left alone it would reach the caller as an empty answer,
+// and would count as proof that the endpoint works.
+func responseFailure(resp *responses.Response) error {
+	if resp == nil {
+		return fmt.Errorf("responses: no response")
+	}
+	switch resp.Status {
+	// Empty covers gateways that do not report a status at all.
+	case "", "completed", "incomplete", "in_progress":
+		return nil
+	}
+	if msg := strings.TrimSpace(resp.Error.Message); msg != "" {
+		return fmt.Errorf("responses: %s: %s", resp.Status, msg)
+	}
+	return fmt.Errorf("responses: %s", resp.Status)
 }
 
 // completeStreamingViaResponses is the streaming twin: text deltas arrive as
@@ -138,6 +169,12 @@ func (c *OpenAIClient) completeStreamingViaResponses(
 
 	var b strings.Builder
 	var usage Usage
+	// A stream can fail in-band. ssestream only raises an event as an error
+	// when it carries a nested "error" object, and a Responses error event puts
+	// its code and message at the top level instead -- so an exploded
+	// generation arrives here as an ordinary event and, unread, would look like
+	// a short but successful answer.
+	var failed error
 	for stream.Next() {
 		event := stream.Current()
 		switch event.Type {
@@ -150,15 +187,32 @@ func (c *OpenAIClient) completeStreamingViaResponses(
 			if onDelta != nil {
 				onDelta(delta)
 			}
-		case "response.completed", "response.incomplete", "response.failed":
+		case "response.completed", "response.incomplete":
 			usage = usageFromResponses(event.Response.Usage)
+		case "response.failed":
+			usage = usageFromResponses(event.Response.Usage)
+			failed = responseFailure(&event.Response)
+		case "error":
+			failed = fmt.Errorf("responses stream: %s", streamEventMessage(event))
 		}
 	}
-	err = stream.Err()
+	if err = stream.Err(); err == nil {
+		err = failed
+	}
 	if err == nil {
 		logUsage(c.logger, string(params.Model), usage, append(extra, "stream", true, "api", "responses")...)
 	}
 	return b.String(), usage, err
+}
+
+func streamEventMessage(event responses.ResponseStreamEventUnion) string {
+	if msg := strings.TrimSpace(event.Message); msg != "" {
+		return msg
+	}
+	if code := strings.TrimSpace(event.Code); code != "" {
+		return code
+	}
+	return "the provider ended the stream with an error"
 }
 
 // responsesParamsFrom translates a chat completion request into a Responses

--- a/backend/internal/ai/responses.go
+++ b/backend/internal/ai/responses.go
@@ -1,0 +1,356 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/shared/constant"
+	"lemmary/backend/internal/aiprovider"
+)
+
+// Some models are served only by the Responses API. OpenCode Zen documents a
+// per-model endpoint and routes gpt-5.6-luna, grok-4.6 and the muse-spark
+// models there; /chat/completions answers for those with a bare 500. Rather
+// than carry a list of model names that goes stale, the request shape stays
+// chat-completions-shaped everywhere and is translated here for the models that
+// turn out to need it.
+//
+// Everything below converts in one direction and back: ChatCompletionNewParams
+// to ResponseNewParams, and the Response to a *openai.ChatCompletion the
+// existing call sites already know how to read. No caller changes.
+
+// responsesModels remembers the models whose completions had to be translated,
+// so the discovery costs one rejected request per model per process instead of
+// one per agent round.
+var responsesModels sync.Map
+
+func rememberResponsesAPI(model string) {
+	if key := modelKey(model); key != "" {
+		responsesModels.Store(key, struct{}{})
+	}
+}
+
+func needsResponsesAPI(model string) bool {
+	key := modelKey(model)
+	if key == "" {
+		return false
+	}
+	_, ok := responsesModels.Load(key)
+	return ok
+}
+
+// resetResponsesAPI clears what the process has learned. Tests only.
+func resetResponsesAPI() {
+	responsesModels.Range(func(k, _ any) bool {
+		responsesModels.Delete(k)
+		return true
+	})
+}
+
+// isEndpointMismatchError reports whether a failed /chat/completions request
+// looks like the endpoint refusing to serve this model at all, rather than
+// disliking something we sent. OpenCode answers 500 for a Responses-only model
+// even for a bare "say hi"; 401 and 403 are what it returns for the others, on
+// a key that works everywhere else. 502/503/504 are deliberately absent: those
+// are ordinary transient failures and retrying them on a different endpoint
+// would be guessing.
+func isEndpointMismatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
+		http.StatusMethodNotAllowed, http.StatusInternalServerError, http.StatusNotImplemented:
+		return true
+	}
+	return false
+}
+
+// CompleteViaResponses runs a chat-completions-shaped request through the
+// Responses API and hands back a chat completion.
+func CompleteViaResponses(
+	ctx context.Context,
+	client openai.Client,
+	logger *slog.Logger,
+	sdk, baseURL string,
+	params openai.ChatCompletionNewParams,
+	extra ...any,
+) (*openai.ChatCompletion, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	req, err := responsesParamsFrom(params)
+	if err != nil {
+		return nil, err
+	}
+	aiprovider.LogRequest(
+		logger,
+		sdk,
+		http.MethodPost,
+		aiprovider.ResponsesURL(baseURL),
+		string(params.Model),
+		append(extra, "api", "responses")...,
+	)
+	resp, err := client.Responses.New(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return chatCompletionFrom(resp), nil
+}
+
+// completeStreamingViaResponses is the streaming twin: text deltas arrive as
+// response.output_text.delta events, and the usage totals ride on the final
+// response.completed event.
+func (c *OpenAIClient) completeStreamingViaResponses(
+	ctx context.Context,
+	params openai.ChatCompletionNewParams,
+	onDelta func(string),
+	extra ...any,
+) (string, Usage, error) {
+	req, err := responsesParamsFrom(params)
+	if err != nil {
+		return "", Usage{}, err
+	}
+	aiprovider.LogRequest(
+		c.logger,
+		c.sdk,
+		http.MethodPost,
+		aiprovider.ResponsesURL(c.baseURL),
+		string(params.Model),
+		append(extra, "stream", true, "api", "responses")...,
+	)
+
+	stream := c.client.Responses.NewStreaming(ctx, req)
+	defer stream.Close()
+
+	var b strings.Builder
+	var usage Usage
+	for stream.Next() {
+		event := stream.Current()
+		switch event.Type {
+		case "response.output_text.delta":
+			delta := event.Delta.OfString
+			if delta == "" {
+				continue
+			}
+			b.WriteString(delta)
+			if onDelta != nil {
+				onDelta(delta)
+			}
+		case "response.completed", "response.incomplete", "response.failed":
+			usage = usageFromResponses(event.Response.Usage)
+		}
+	}
+	err = stream.Err()
+	if err == nil {
+		logUsage(c.logger, string(params.Model), usage, append(extra, "stream", true, "api", "responses")...)
+	}
+	return b.String(), usage, err
+}
+
+// responsesParamsFrom translates a chat completion request into a Responses
+// one. Only the fields this codebase actually sends are carried across; a field
+// nobody sets is a field that cannot silently mistranslate.
+func responsesParamsFrom(params openai.ChatCompletionNewParams) (responses.ResponseNewParams, error) {
+	input, err := responsesInputFrom(params.Messages)
+	if err != nil {
+		return responses.ResponseNewParams{}, err
+	}
+	req := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(params.Model),
+		Input: responses.ResponseNewParamsInputUnion{OfInputItemList: input},
+		// The archive keeps its own conversation state and replays the whole
+		// thread every round, so there is nothing to gain from the provider
+		// storing it -- and a stored copy is a copy we did not ask for.
+		Store: openai.Bool(false),
+	}
+	if params.Temperature.Valid() {
+		req.Temperature = params.Temperature
+	}
+	if params.MaxTokens.Valid() {
+		req.MaxOutputTokens = params.MaxTokens
+	}
+	if params.ResponseFormat.OfJSONObject != nil {
+		req.Text = responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
+			},
+		}
+	}
+	for _, tool := range params.Tools {
+		fn := responses.FunctionToolParam{
+			Name:       tool.Function.Name,
+			Parameters: map[string]any(tool.Function.Parameters),
+			// The archive's schemas are hand-written guidance rather than
+			// contracts, and strict mode rejects several of them outright.
+			Strict: openai.Bool(false),
+		}
+		if tool.Function.Description.Valid() {
+			fn.Description = tool.Function.Description
+		}
+		req.Tools = append(req.Tools, responses.ToolUnionParam{OfFunction: &fn})
+	}
+	if choice := params.ToolChoice.OfAuto.Or(""); choice != "" {
+		req.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptions(choice)),
+		}
+	}
+	return req, nil
+}
+
+// responsesInputFrom turns the chat message list into Responses input items.
+// The two shapes disagree about tool calls in particular: chat carries them on
+// the assistant message and answers them with a tool-role message, while
+// Responses makes each one a free-standing item.
+func responsesInputFrom(messages []openai.ChatCompletionMessageParamUnion) (responses.ResponseInputParam, error) {
+	input := make(responses.ResponseInputParam, 0, len(messages))
+	for _, msg := range messages {
+		switch {
+		case msg.OfSystem != nil:
+			input = append(input, responses.ResponseInputItemParamOfMessage(
+				msg.OfSystem.Content.OfString.Or(""), responses.EasyInputMessageRoleSystem))
+		case msg.OfDeveloper != nil:
+			input = append(input, responses.ResponseInputItemParamOfMessage(
+				msg.OfDeveloper.Content.OfString.Or(""), responses.EasyInputMessageRoleDeveloper))
+		case msg.OfUser != nil:
+			item, err := responsesUserItem(*msg.OfUser)
+			if err != nil {
+				return nil, err
+			}
+			input = append(input, item)
+		case msg.OfAssistant != nil:
+			if text := msg.OfAssistant.Content.OfString.Or(""); text != "" {
+				input = append(input, responses.ResponseInputItemParamOfMessage(
+					text, responses.EasyInputMessageRoleAssistant))
+			}
+			for _, call := range msg.OfAssistant.ToolCalls {
+				input = append(input, responses.ResponseInputItemParamOfFunctionCall(
+					call.Function.Arguments, call.ID, call.Function.Name))
+			}
+		case msg.OfTool != nil:
+			input = append(input, responses.ResponseInputItemParamOfFunctionCallOutput(
+				msg.OfTool.ToolCallID, msg.OfTool.Content.OfString.Or("")))
+		default:
+			return nil, fmt.Errorf("responses: unsupported message shape")
+		}
+	}
+	return input, nil
+}
+
+// responsesUserItem carries a user message across, including the image and file
+// parts LLM OCR sends.
+func responsesUserItem(msg openai.ChatCompletionUserMessageParam) (responses.ResponseInputItemUnionParam, error) {
+	if msg.Content.OfString.Valid() {
+		return responses.ResponseInputItemParamOfMessage(
+			msg.Content.OfString.Value, responses.EasyInputMessageRoleUser), nil
+	}
+	content := make(responses.ResponseInputMessageContentListParam, 0, len(msg.Content.OfArrayOfContentParts))
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		switch {
+		case part.OfText != nil:
+			content = append(content, responses.ResponseInputContentParamOfInputText(part.OfText.Text))
+		case part.OfImageURL != nil:
+			image := responses.ResponseInputImageParam{
+				ImageURL: openai.String(part.OfImageURL.ImageURL.URL),
+				Detail:   responses.ResponseInputImageDetail(part.OfImageURL.ImageURL.Detail),
+			}
+			if image.Detail == "" {
+				image.Detail = responses.ResponseInputImageDetailAuto
+			}
+			content = append(content, responses.ResponseInputContentUnionParam{OfInputImage: &image})
+		case part.OfFile != nil:
+			file := responses.ResponseInputFileParam{
+				FileData: part.OfFile.File.FileData,
+				FileID:   part.OfFile.File.FileID,
+				Filename: part.OfFile.File.Filename,
+			}
+			content = append(content, responses.ResponseInputContentUnionParam{OfInputFile: &file})
+		default:
+			return responses.ResponseInputItemUnionParam{}, fmt.Errorf("responses: unsupported user content part")
+		}
+	}
+	return responses.ResponseInputItemParamOfInputMessage(content, string(responses.EasyInputMessageRoleUser)), nil
+}
+
+// chatCompletionFrom folds a Response back into the one-choice chat completion
+// the call sites read. Reasoning items are dropped: they carry no text we can
+// show, and replaying them would mean threading provider-specific state through
+// every caller.
+func chatCompletionFrom(resp *responses.Response) *openai.ChatCompletion {
+	if resp == nil {
+		return nil
+	}
+	var text strings.Builder
+	var calls []openai.ChatCompletionMessageToolCall
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			for _, part := range item.Content {
+				if part.Type == "output_text" {
+					text.WriteString(part.Text)
+				}
+			}
+		case "function_call":
+			calls = append(calls, openai.ChatCompletionMessageToolCall{
+				ID:   item.CallID,
+				Type: constant.ValueOf[constant.Function](),
+				Function: openai.ChatCompletionMessageToolCallFunction{
+					Name:      item.Name,
+					Arguments: item.Arguments,
+				},
+			})
+		}
+	}
+
+	finish := "stop"
+	if len(calls) > 0 {
+		finish = "tool_calls"
+	} else if resp.Status == "incomplete" {
+		// The only incomplete reason that maps onto a chat finish_reason; the
+		// callers treat anything else as a plain stop anyway.
+		finish = "length"
+	}
+
+	return &openai.ChatCompletion{
+		ID:    resp.ID,
+		Model: resp.Model,
+		Choices: []openai.ChatCompletionChoice{{
+			Index:        0,
+			FinishReason: finish,
+			Message: openai.ChatCompletionMessage{
+				Role:      constant.ValueOf[constant.Assistant](),
+				Content:   text.String(),
+				ToolCalls: calls,
+			},
+		}},
+		Usage: openai.CompletionUsage{
+			PromptTokens:     resp.Usage.InputTokens,
+			CompletionTokens: resp.Usage.OutputTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+				CachedTokens: resp.Usage.InputTokensDetails.CachedTokens,
+			},
+		},
+	}
+}
+
+func usageFromResponses(u responses.ResponseUsage) Usage {
+	return Usage{
+		Prompt:     int(u.InputTokens),
+		Completion: int(u.OutputTokens),
+		Cached:     int(u.InputTokensDetails.CachedTokens),
+	}
+}

--- a/backend/internal/ai/responses_live_test.go
+++ b/backend/internal/ai/responses_live_test.go
@@ -25,8 +25,8 @@ func TestLiveResponsesOnlyModel(t *testing.T) {
 	if key == "" || base == "" || model == "" {
 		t.Skip("set LIVE_AI_KEY, LIVE_AI_BASE_URL and LIVE_AI_MODEL to run the live check")
 	}
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 	ctx := context.Background()
 
 	t.Run("research", func(t *testing.T) {

--- a/backend/internal/ai/responses_live_test.go
+++ b/backend/internal/ai/responses_live_test.go
@@ -1,0 +1,69 @@
+package ai
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLiveResponsesOnlyModel exercises the whole Responses path against a real
+// provider. It is skipped unless the three variables below are set, because it
+// spends somebody's tokens:
+//
+//	LIVE_AI_KEY=... LIVE_AI_BASE_URL=https://opencode.ai/zen/go/v1 \
+//	LIVE_AI_MODEL=gpt-5.6-luna go test ./internal/ai/ -run Live -v
+//
+// It is the only way to check the parts a fake server cannot: that the
+// translated request is one the provider actually accepts.
+func TestLiveResponsesOnlyModel(t *testing.T) {
+	key := strings.TrimSpace(os.Getenv("LIVE_AI_KEY"))
+	base := strings.TrimSpace(os.Getenv("LIVE_AI_BASE_URL"))
+	model := strings.TrimSpace(os.Getenv("LIVE_AI_MODEL"))
+	if key == "" || base == "" || model == "" {
+		t.Skip("set LIVE_AI_KEY, LIVE_AI_BASE_URL and LIVE_AI_MODEL to run the live check")
+	}
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+	ctx := context.Background()
+
+	t.Run("research", func(t *testing.T) {
+		agent := NewSearchAgent("openai", key, model, base, 120*time.Second, "en,de", "en", slog.Default())
+		var read bool
+		result, err := agent.Research(ctx, ResearchRequest{
+			Messages: []ChatMessage{{Role: "user", Content: "How much did I pay for car insurance?"}},
+			Search: func(_ context.Context, _ SearchDocumentsArgs) ([]DocumentHit, error) {
+				return hitsFor("doc1"), nil
+			},
+			Read: func(_ context.Context, _ ReadRequest) ([]DocumentContent, error) {
+				read = true
+				return []DocumentContent{{ID: "doc1", Title: "Allianz car insurance 2026", Text: "Annual premium: 412.90 EUR"}}, nil
+			},
+		}, func(ResearchEvent) {})
+		if err != nil {
+			t.Fatalf("Research: %v", err)
+		}
+		if !read {
+			t.Error("the model never called read_documents")
+		}
+		if !strings.Contains(result.Reply, "412") {
+			t.Errorf("reply lost the figure it was given: %q", result.Reply)
+		}
+		t.Logf("reply: %s", result.Reply)
+	})
+
+	t.Run("extract in json mode", func(t *testing.T) {
+		client := NewOpenAIClient("openai", key, model, base, "v1", "", 120*time.Second, slog.Default())
+		metadata, err := client.ExtractMetadata(ctx,
+			"Rechnung Nr. 4711\nAllianz SE\nDatum: 2026-03-14\nBetrag: 412,90 EUR", ExtractionCatalog{})
+		if err != nil {
+			t.Fatalf("ExtractMetadata: %v", err)
+		}
+		if metadata.DocumentDate != "2026-03-14" {
+			t.Errorf("document date = %q", metadata.DocumentDate)
+		}
+		t.Logf("title=%q date=%q", metadata.Title, metadata.DocumentDate)
+	})
+}

--- a/backend/internal/ai/responses_test.go
+++ b/backend/internal/ai/responses_test.go
@@ -30,6 +30,11 @@ type responsesHarness struct {
 	respTurns     []scriptedTurn
 	respNext      int
 	responsesGone bool
+	// respStatus, when set, is the status the Response body reports -- the
+	// Responses API says a generation failed with a 200 and a status field.
+	respStatus string
+	// streamError makes the /responses stream end with an error event.
+	streamError bool
 }
 
 func (h *responsesHarness) handle(w http.ResponseWriter, r *http.Request) {
@@ -53,10 +58,14 @@ func (h *responsesHarness) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if stream, _ := body["stream"].(bool); stream {
+			if h.streamError {
+				writeResponsesStreamError(w)
+				return
+			}
 			writeResponsesStream(w, turn.content)
 			return
 		}
-		writeResponsesJSON(w, turn)
+		writeResponsesJSON(w, turn, h.respStatus)
 		return
 	}
 
@@ -85,7 +94,7 @@ func (h *responsesHarness) responsesBody(i int) map[string]any {
 }
 
 // writeResponsesJSON renders a scripted turn in the Responses output shape.
-func writeResponsesJSON(w http.ResponseWriter, turn scriptedTurn) {
+func writeResponsesJSON(w http.ResponseWriter, turn scriptedTurn, status string) {
 	output := []map[string]any{}
 	// A reasoning item the caller must skip over rather than mistake for text.
 	output = append(output, map[string]any{
@@ -109,9 +118,13 @@ func writeResponsesJSON(w http.ResponseWriter, turn scriptedTurn) {
 			"content": []map[string]any{{"type": "output_text", "text": turn.content, "annotations": []any{}}},
 		})
 	}
+	if status == "" {
+		status = "completed"
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"id": "resp_test", "object": "response", "created_at": 1, "status": "completed",
+		"id": "resp_test", "object": "response", "created_at": 1, "status": status,
+		"error": map[string]any{"code": "server_error", "message": "the model gave up"},
 		"model": "test-model", "output": output,
 		"usage": map[string]any{
 			"input_tokens":          11,
@@ -156,6 +169,22 @@ func writeResponsesStream(w http.ResponseWriter, content string) {
 	})
 }
 
+// writeResponsesStreamError ends a stream the way the Responses API reports an
+// in-band failure: a top-level code and message, with no nested "error" object
+// for the SDK's decoder to notice.
+func writeResponsesStreamError(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	flusher, _ := w.(http.Flusher)
+	_, _ = fmt.Fprint(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"half \",\"sequence_number\":1}\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+	_, _ = fmt.Fprint(w, "data: {\"type\":\"error\",\"code\":\"server_error\",\"message\":\"upstream exploded\",\"param\":null,\"sequence_number\":2}\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+}
+
 func newResponsesHarness(t *testing.T, h *responsesHarness) string {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(h.handle))
@@ -167,8 +196,8 @@ func newResponsesHarness(t *testing.T, h *responsesHarness) string {
 // there directly, for tool rounds and the streamed answer alike.
 func TestResearchFallsBackToResponsesAndRemembers(t *testing.T) {
 	model := "responses-only-research"
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
 	h := &responsesHarness{chatStatus: http.StatusInternalServerError, respTurns: []scriptedTurn{
 		{toolCalls: []scriptedToolCall{{name: "search_documents", args: `{"query":"car insurance"}`}}},
@@ -200,13 +229,17 @@ func TestResearchFallsBackToResponsesAndRemembers(t *testing.T) {
 	}
 
 	chat, resp := h.counts()
-	if chat != 1 {
-		t.Fatalf("chat/completions attempts = %d, want 1: the model should be remembered after the first refusal", chat)
+	// Two, not one. A 500 does not say whether the endpoint refuses this model
+	// or is simply having a bad minute, so the first one is acted on but not
+	// believed; the second makes it a pattern and the model is rerouted for
+	// good. Both requests still succeed, via the fallback.
+	if chat != 2 {
+		t.Fatalf("chat/completions attempts = %d, want 2 before an ambiguous refusal is believed", chat)
 	}
 	if resp < 3 {
 		t.Fatalf("responses requests = %d, want the tool rounds and the answer", resp)
 	}
-	if !needsResponsesAPI(model) {
+	if !needsResponsesAPI(base, model) {
 		t.Fatal("model was not remembered")
 	}
 }
@@ -215,12 +248,11 @@ func TestResearchFallsBackToResponsesAndRemembers(t *testing.T) {
 // completions has to arrive as an equivalent Responses call.
 func TestResponsesRequestShape(t *testing.T) {
 	model := "responses-only-shape"
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
-	rememberResponsesAPI(model)
-
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 	h := &responsesHarness{respTurns: []scriptedTurn{{content: "ok"}}}
 	base := newResponsesHarness(t, h)
+	rememberResponsesAPI(base, model)
 	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
 
 	params := openai.ChatCompletionNewParams{
@@ -354,8 +386,8 @@ func TestChatCompletionFromResponse(t *testing.T) {
 
 func TestStreamingFallsBackToResponses(t *testing.T) {
 	model := "responses-only-stream"
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
 	h := &responsesHarness{chatStatus: http.StatusInternalServerError, respTurns: []scriptedTurn{
 		{content: "streamed from responses"},
@@ -380,8 +412,136 @@ func TestStreamingFallsBackToResponses(t *testing.T) {
 	if usage.Prompt != 7 || usage.Completion != 2 || usage.Cached != 3 {
 		t.Fatalf("usage = %+v, want the totals from response.completed", usage)
 	}
-	if !needsResponsesAPI(model) {
-		t.Fatal("model was not remembered")
+	// One ambiguous 500 is acted on but not believed.
+	if needsResponsesAPI(base, model) {
+		t.Fatal("a single 500 rerouted the model for the rest of the process")
+	}
+	h.respTurns = append(h.respTurns, scriptedTurn{content: "again"})
+	h.respNext = 0
+	if _, _, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}, nil); err != nil {
+		t.Fatalf("second completeStreaming: %v", err)
+	}
+	if !needsResponsesAPI(base, model) {
+		t.Fatal("a second refusal should have settled it")
+	}
+}
+
+// A 500 from an endpoint that has already served this model is the provider
+// having a bad minute, not a model that lives elsewhere. The SDK is configured
+// with no retries of its own, so without this one hiccup would be enough to
+// reroute a model permanently.
+func TestAProvenModelIsNotReroutedByATransient500(t *testing.T) {
+	model := "dual-api-model"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	h := &responsesHarness{respTurns: []scriptedTurn{{content: "from responses"}}}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+	params := openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}
+
+	// It works here first.
+	if _, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, params); err != nil {
+		t.Fatalf("first CompleteChat: %v", err)
+	}
+	// Then the provider has a bad minute.
+	h.mu.Lock()
+	h.chatStatus = http.StatusInternalServerError
+	h.mu.Unlock()
+	if _, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, params); err == nil {
+		t.Fatal("expected the 500 to surface rather than being papered over")
+	}
+	if _, resp := h.counts(); resp != 0 {
+		t.Fatalf("a proven model was sent to /responses %d times", resp)
+	}
+	if needsResponsesAPI(base, model) {
+		t.Fatal("a proven model was rerouted by one 500")
+	}
+}
+
+// 401 and 403 are what OpenCode Zen returns for grok-4.6 and the muse-spark
+// models. Unlike a 500 they are not something a working endpoint says about a
+// model it serves, so one is enough.
+func TestCertainMismatchIsBelievedImmediately(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			model := fmt.Sprintf("certain-%d", status)
+			resetModelNotes()
+			t.Cleanup(resetModelNotes)
+
+			h := &responsesHarness{chatStatus: status, respTurns: []scriptedTurn{{content: "from responses"}}}
+			base := newResponsesHarness(t, h)
+			client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+			resp, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+				Model:    shared.ChatModel(model),
+				Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+			})
+			if err != nil {
+				t.Fatalf("CompleteChat: %v", err)
+			}
+			if resp.Choices[0].Message.Content != "from responses" {
+				t.Fatalf("content = %q", resp.Choices[0].Message.Content)
+			}
+			if !needsResponsesAPI(base, model) {
+				t.Fatal("an unambiguous mismatch should be believed the first time")
+			}
+		})
+	}
+}
+
+// The Responses API reports a generation it gave up on in the body, with a 200.
+// Handed back as a completion it would reach the caller as a successful empty
+// answer -- and would count as proof that the endpoint works.
+func TestFailedResponseIsNotASuccess(t *testing.T) {
+	model := "failed-status-model"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	h := &responsesHarness{chatStatus: http.StatusNotFound, respStatus: "failed"}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err == nil {
+		t.Fatal("a failed generation was returned as a successful empty answer")
+	}
+	if needsResponsesAPI(base, model) {
+		t.Fatal("a failed generation counted as proof the endpoint serves this model")
+	}
+}
+
+// A Responses error event puts its code and message at the top level, with no
+// nested "error" object, so the SDK's stream decoder does not raise it. Unread,
+// an exploded generation looks like a short but successful answer.
+func TestStreamErrorEventIsNotSilentlySwallowed(t *testing.T) {
+	model := "stream-error-model"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	h := &responsesHarness{streamError: true}
+	base := newResponsesHarness(t, h)
+	rememberResponsesAPI(base, model)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	text, _, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}, nil)
+	if err == nil {
+		t.Fatalf("the stream failed but came back as a success with %q", text)
+	}
+	if !strings.Contains(err.Error(), "upstream exploded") {
+		t.Fatalf("error = %v, want the provider's message", err)
 	}
 }
 
@@ -389,8 +549,8 @@ func TestStreamingFallsBackToResponses(t *testing.T) {
 // different endpoint.
 func TestTransientErrorDoesNotFallBackToResponses(t *testing.T) {
 	model := "transient-model"
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
 	h := &responsesHarness{chatStatus: http.StatusServiceUnavailable}
 	base := newResponsesHarness(t, h)
@@ -406,7 +566,7 @@ func TestTransientErrorDoesNotFallBackToResponses(t *testing.T) {
 	if _, resp := h.counts(); resp != 0 {
 		t.Fatalf("a 503 triggered %d Responses attempts", resp)
 	}
-	if needsResponsesAPI(model) {
+	if needsResponsesAPI(base, model) {
 		t.Fatal("a transient failure must not reroute the model")
 	}
 }
@@ -415,8 +575,8 @@ func TestTransientErrorDoesNotFallBackToResponses(t *testing.T) {
 // original failure rather than a 404 from an endpoint the provider never had.
 func TestFallbackKeepsTheOriginalError(t *testing.T) {
 	model := "no-responses-endpoint"
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
 	h := &responsesHarness{chatStatus: http.StatusInternalServerError, responsesGone: true}
 	base := newResponsesHarness(t, h)
@@ -432,7 +592,7 @@ func TestFallbackKeepsTheOriginalError(t *testing.T) {
 	if !strings.Contains(err.Error(), "500") {
 		t.Fatalf("error = %v, want the original chat/completions failure", err)
 	}
-	if needsResponsesAPI(model) {
+	if needsResponsesAPI(base, model) {
 		t.Fatal("a failed fallback must not be remembered")
 	}
 }
@@ -440,8 +600,8 @@ func TestFallbackKeepsTheOriginalError(t *testing.T) {
 // Models the provider serves normally must never be rerouted.
 func TestOrdinaryModelStaysOnChatCompletions(t *testing.T) {
 	model := "ordinary-model"
-	resetResponsesAPI()
-	t.Cleanup(resetResponsesAPI)
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
 	h := &responsesHarness{}
 	base := newResponsesHarness(t, h)

--- a/backend/internal/ai/responses_test.go
+++ b/backend/internal/ai/responses_test.go
@@ -1,0 +1,463 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+)
+
+// responsesHarness fakes a provider that serves some models only on
+// /v1/responses, the way OpenCode Zen does for gpt-5.6-luna: /chat/completions
+// answers with a bare 500 whatever you send it.
+type responsesHarness struct {
+	mu sync.Mutex
+	// chatStatus is what /chat/completions returns; 0 means serve normally.
+	chatStatus    int
+	chatBodies    []map[string]any
+	respBodies    []map[string]any
+	respTurns     []scriptedTurn
+	respNext      int
+	responsesGone bool
+}
+
+func (h *responsesHarness) handle(w http.ResponseWriter, r *http.Request) {
+	raw, _ := io.ReadAll(r.Body)
+	var body map[string]any
+	_ = json.Unmarshal(raw, &body)
+
+	if strings.HasSuffix(r.URL.Path, "/responses") {
+		h.mu.Lock()
+		h.respBodies = append(h.respBodies, body)
+		gone := h.responsesGone
+		turn := scriptedTurn{content: "No further information."}
+		if h.respNext < len(h.respTurns) {
+			turn = h.respTurns[h.respNext]
+			h.respNext++
+		}
+		h.mu.Unlock()
+		if gone {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "no such endpoint"}})
+			return
+		}
+		if stream, _ := body["stream"].(bool); stream {
+			writeResponsesStream(w, turn.content)
+			return
+		}
+		writeResponsesJSON(w, turn)
+		return
+	}
+
+	h.mu.Lock()
+	h.chatBodies = append(h.chatBodies, body)
+	status := h.chatStatus
+	h.mu.Unlock()
+	if status != 0 {
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "Internal server error"}})
+		return
+	}
+	writeChatJSON(w, "served by chat completions")
+}
+
+func (h *responsesHarness) counts() (chat int, resp int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.chatBodies), len(h.respBodies)
+}
+
+func (h *responsesHarness) responsesBody(i int) map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.respBodies[i]
+}
+
+// writeResponsesJSON renders a scripted turn in the Responses output shape.
+func writeResponsesJSON(w http.ResponseWriter, turn scriptedTurn) {
+	output := []map[string]any{}
+	// A reasoning item the caller must skip over rather than mistake for text.
+	output = append(output, map[string]any{
+		"id": "rs_1", "type": "reasoning", "summary": []any{}, "encrypted_content": "opaque",
+	})
+	if len(turn.toolCalls) > 0 {
+		for i, call := range turn.toolCalls {
+			output = append(output, map[string]any{
+				"id":        fmt.Sprintf("fc_%d", i),
+				"type":      "function_call",
+				"status":    "completed",
+				"call_id":   fmt.Sprintf("call_%d", i),
+				"name":      call.name,
+				"arguments": call.args,
+			})
+		}
+	}
+	if turn.content != "" {
+		output = append(output, map[string]any{
+			"id": "msg_1", "type": "message", "status": "completed", "role": "assistant",
+			"content": []map[string]any{{"type": "output_text", "text": turn.content, "annotations": []any{}}},
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id": "resp_test", "object": "response", "created_at": 1, "status": "completed",
+		"model": "test-model", "output": output,
+		"usage": map[string]any{
+			"input_tokens":          11,
+			"input_tokens_details":  map[string]any{"cached_tokens": 4},
+			"output_tokens":         5,
+			"output_tokens_details": map[string]any{"reasoning_tokens": 2},
+			"total_tokens":          16,
+		},
+	})
+}
+
+func writeResponsesStream(w http.ResponseWriter, content string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	flusher, _ := w.(http.Flusher)
+	seq := 0
+	frame := func(payload map[string]any) {
+		seq++
+		payload["sequence_number"] = seq
+		encoded, _ := json.Marshal(payload)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", encoded)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	for _, word := range strings.SplitAfter(content, " ") {
+		if word == "" {
+			continue
+		}
+		frame(map[string]any{"type": "response.output_text.delta", "delta": word})
+	}
+	frame(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"id": "resp_stream", "object": "response", "created_at": 1, "status": "completed",
+			"model": "test-model", "output": []any{},
+			"usage": map[string]any{
+				"input_tokens": 7, "input_tokens_details": map[string]any{"cached_tokens": 3},
+				"output_tokens": 2, "output_tokens_details": map[string]any{"reasoning_tokens": 0},
+				"total_tokens": 9,
+			},
+		},
+	})
+}
+
+func newResponsesHarness(t *testing.T, h *responsesHarness) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(h.handle))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// A model served only on /responses must be discovered once and then addressed
+// there directly, for tool rounds and the streamed answer alike.
+func TestResearchFallsBackToResponsesAndRemembers(t *testing.T) {
+	model := "responses-only-research"
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+
+	h := &responsesHarness{chatStatus: http.StatusInternalServerError, respTurns: []scriptedTurn{
+		{toolCalls: []scriptedToolCall{{name: "search_documents", args: `{"query":"car insurance"}`}}},
+		{content: "ready"},
+		{content: "You paid 200 EUR, see [Doc doc1](/document/doc1)."},
+	}}
+	base := newResponsesHarness(t, h)
+	agent := NewSearchAgent("openai", "test-key", model, base, 5*time.Second, "en,de", "en", slog.Default())
+
+	var searched bool
+	result, err := agent.Research(context.Background(), ResearchRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "how much did I pay?"}},
+		Search: func(_ context.Context, _ SearchDocumentsArgs) ([]DocumentHit, error) {
+			searched = true
+			return hitsFor("doc1"), nil
+		},
+		Read: func(_ context.Context, _ ReadRequest) ([]DocumentContent, error) {
+			return []DocumentContent{{ID: "doc1", Title: "Doc doc1", Text: "Premium 200 EUR"}}, nil
+		},
+	}, func(ResearchEvent) {})
+	if err != nil {
+		t.Fatalf("Research: %v", err)
+	}
+	if !searched {
+		t.Fatal("the translated function_call never reached the tool")
+	}
+	if !strings.Contains(result.Reply, "/document/doc1") {
+		t.Fatalf("reply = %q", result.Reply)
+	}
+
+	chat, resp := h.counts()
+	if chat != 1 {
+		t.Fatalf("chat/completions attempts = %d, want 1: the model should be remembered after the first refusal", chat)
+	}
+	if resp < 3 {
+		t.Fatalf("responses requests = %d, want the tool rounds and the answer", resp)
+	}
+	if !needsResponsesAPI(model) {
+		t.Fatal("model was not remembered")
+	}
+}
+
+// The translation is the whole feature: a request that leaves as chat
+// completions has to arrive as an equivalent Responses call.
+func TestResponsesRequestShape(t *testing.T) {
+	model := "responses-only-shape"
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+	rememberResponsesAPI(model)
+
+	h := &responsesHarness{respTurns: []scriptedTurn{{content: "ok"}}}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	params := openai.ChatCompletionNewParams{
+		Model: shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("you are an archivist"),
+			openai.UserMessage("find my insurance"),
+			{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				ToolCalls: []openai.ChatCompletionMessageToolCallParam{{
+					ID: "call_7",
+					Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name: "search_documents", Arguments: `{"query":"insurance"}`,
+					},
+				}},
+			}},
+			openai.ToolMessage("1 hit", "call_7"),
+		},
+		Temperature: openai.Float(0.2),
+		Tools: []openai.ChatCompletionToolParam{{
+			Function: shared.FunctionDefinitionParam{
+				Name:        "search_documents",
+				Description: openai.String("Search the archive"),
+				Parameters:  shared.FunctionParameters{"type": "object"},
+			},
+		}},
+		ToolChoice: openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: openai.String("auto")},
+		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
+		},
+	}
+	if _, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, params); err != nil {
+		t.Fatalf("CompleteChat: %v", err)
+	}
+	if chat, _ := h.counts(); chat != 0 {
+		t.Fatalf("a remembered model still tried chat/completions %d times", chat)
+	}
+
+	body := h.responsesBody(0)
+	if body["model"] != model {
+		t.Fatalf("model = %v", body["model"])
+	}
+	if store, ok := body["store"].(bool); !ok || store {
+		t.Fatalf("store = %v, want false: the archive keeps its own conversation state", body["store"])
+	}
+	if body["temperature"] != 0.2 {
+		t.Fatalf("temperature = %v", body["temperature"])
+	}
+	if body["tool_choice"] != "auto" {
+		t.Fatalf("tool_choice = %v", body["tool_choice"])
+	}
+
+	text, _ := body["text"].(map[string]any)
+	format, _ := text["format"].(map[string]any)
+	if format["type"] != "json_object" {
+		t.Fatalf("text.format = %v, want json_object", text["format"])
+	}
+
+	// Responses tools are flat: no nested "function" object.
+	tools, _ := body["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools = %v", tools)
+	}
+	tool, _ := tools[0].(map[string]any)
+	if tool["type"] != "function" || tool["name"] != "search_documents" || tool["description"] != "Search the archive" {
+		t.Fatalf("tool = %v", tool)
+	}
+
+	input, _ := body["input"].([]any)
+	if len(input) != 4 {
+		t.Fatalf("input items = %d, want 4: %v", len(input), input)
+	}
+	want := []struct{ typ, role string }{
+		{"", "system"},
+		{"", "user"},
+		{"function_call", ""},
+		{"function_call_output", ""},
+	}
+	for i, w := range want {
+		item, _ := input[i].(map[string]any)
+		if w.role != "" && item["role"] != w.role {
+			t.Fatalf("input[%d].role = %v, want %v", i, item["role"], w.role)
+		}
+		if w.typ != "" && item["type"] != w.typ {
+			t.Fatalf("input[%d].type = %v, want %v", i, item["type"], w.typ)
+		}
+	}
+	// The call id has to survive, or the model cannot match answer to question.
+	call, _ := input[2].(map[string]any)
+	if call["call_id"] != "call_7" || call["name"] != "search_documents" {
+		t.Fatalf("function_call = %v", call)
+	}
+	out, _ := input[3].(map[string]any)
+	if out["call_id"] != "call_7" || out["output"] != "1 hit" {
+		t.Fatalf("function_call_output = %v", out)
+	}
+}
+
+func TestChatCompletionFromResponse(t *testing.T) {
+	t.Parallel()
+	var resp responses.Response
+	raw := `{"id":"resp_1","model":"m","status":"completed","output":[
+	  {"id":"rs_1","type":"reasoning","encrypted_content":"opaque"},
+	  {"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"hello "},{"type":"output_text","text":"world"}]},
+	  {"id":"fc_1","type":"function_call","call_id":"call_9","name":"search_documents","arguments":"{\"query\":\"x\"}"}],
+	  "usage":{"input_tokens":11,"input_tokens_details":{"cached_tokens":4},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":2},"total_tokens":16}}`
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got := chatCompletionFrom(&resp)
+	if len(got.Choices) != 1 {
+		t.Fatalf("choices = %d", len(got.Choices))
+	}
+	msg := got.Choices[0].Message
+	if msg.Content != "hello world" {
+		t.Fatalf("content = %q; reasoning items must be skipped and text parts joined", msg.Content)
+	}
+	if len(msg.ToolCalls) != 1 || msg.ToolCalls[0].ID != "call_9" {
+		t.Fatalf("tool calls = %+v; call_id is the id chat completions uses", msg.ToolCalls)
+	}
+	if msg.ToolCalls[0].Function.Name != "search_documents" || msg.ToolCalls[0].Function.Arguments != `{"query":"x"}` {
+		t.Fatalf("tool call function = %+v", msg.ToolCalls[0].Function)
+	}
+	if got.Choices[0].FinishReason != "tool_calls" {
+		t.Fatalf("finish_reason = %q", got.Choices[0].FinishReason)
+	}
+	if u := usageOf(got); u.Prompt != 11 || u.Completion != 5 || u.Cached != 4 {
+		t.Fatalf("usage = %+v", u)
+	}
+}
+
+func TestStreamingFallsBackToResponses(t *testing.T) {
+	model := "responses-only-stream"
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+
+	h := &responsesHarness{chatStatus: http.StatusInternalServerError, respTurns: []scriptedTurn{
+		{content: "streamed from responses"},
+	}}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	var deltas []string
+	text, usage, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}, func(d string) { deltas = append(deltas, d) })
+	if err != nil {
+		t.Fatalf("completeStreaming: %v", err)
+	}
+	if text != "streamed from responses" {
+		t.Fatalf("text = %q", text)
+	}
+	if len(deltas) < 2 {
+		t.Fatalf("deltas = %v, want the text to arrive incrementally", deltas)
+	}
+	if usage.Prompt != 7 || usage.Completion != 2 || usage.Cached != 3 {
+		t.Fatalf("usage = %+v, want the totals from response.completed", usage)
+	}
+	if !needsResponsesAPI(model) {
+		t.Fatal("model was not remembered")
+	}
+}
+
+// A provider having a bad five minutes is not a provider telling us to use a
+// different endpoint.
+func TestTransientErrorDoesNotFallBackToResponses(t *testing.T) {
+	model := "transient-model"
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+
+	h := &responsesHarness{chatStatus: http.StatusServiceUnavailable}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err == nil {
+		t.Fatal("expected the 503 to surface")
+	}
+	if _, resp := h.counts(); resp != 0 {
+		t.Fatalf("a 503 triggered %d Responses attempts", resp)
+	}
+	if needsResponsesAPI(model) {
+		t.Fatal("a transient failure must not reroute the model")
+	}
+}
+
+// When the fallback was the wrong guess, the caller needs to hear about the
+// original failure rather than a 404 from an endpoint the provider never had.
+func TestFallbackKeepsTheOriginalError(t *testing.T) {
+	model := "no-responses-endpoint"
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+
+	h := &responsesHarness{chatStatus: http.StatusInternalServerError, responsesGone: true}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error = %v, want the original chat/completions failure", err)
+	}
+	if needsResponsesAPI(model) {
+		t.Fatal("a failed fallback must not be remembered")
+	}
+}
+
+// Models the provider serves normally must never be rerouted.
+func TestOrdinaryModelStaysOnChatCompletions(t *testing.T) {
+	model := "ordinary-model"
+	resetResponsesAPI()
+	t.Cleanup(resetResponsesAPI)
+
+	h := &responsesHarness{}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	resp, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("CompleteChat: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "served by chat completions" {
+		t.Fatalf("content = %q", resp.Choices[0].Message.Content)
+	}
+	if _, r := h.counts(); r != 0 {
+		t.Fatalf("responses requests = %d, want 0", r)
+	}
+}

--- a/backend/internal/aiprovider/sdk.go
+++ b/backend/internal/aiprovider/sdk.go
@@ -233,6 +233,16 @@ func ChatCompletionsURL(baseURL string) string {
 	return base + "/chat/completions"
 }
 
+// ResponsesURL is the /responses endpoint for an OpenAI-compatible base URL.
+// Some models are served only there; see internal/ai/responses.go.
+func ResponsesURL(baseURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = DefaultBaseURL(SDKOpenAI)
+	}
+	return base + "/responses"
+}
+
 // EmbeddingsURL is the /embeddings endpoint for an OpenAI-compatible base URL.
 // It exists for the outbound request log: the SDK builds the real URL itself,
 // and a log line that guessed a different one would be worse than none.

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -290,6 +290,15 @@ size, memory, GPU variants and the per-page cost — is in
   [Local OCR](/local_ocr#what-it-costs).
 - **AI extraction fails** — check that an extraction model is bound and that it
   is a chat model, not an embedding or OCR model.
+- **A model in the picker answers every request with a 500** — some models are
+  served only by the OpenAI *Responses* API, and their gateway returns a bare
+  500 on `/chat/completions` even for a one-word prompt. OpenCode Zen routes
+  `gpt-5.6-luna`, `grok-4.6` and the `muse-spark` models that way. Lemmary now
+  discovers this by itself: the first request to such a model is refused, sent
+  again to `/responses`, and every later request for that model goes straight
+  there. The log line is `chat completions refused this model; retrying on the
+  Responses API`, and it appears once per model per restart, not once per
+  request. Nothing to configure.
 - **A managed instance will not start** — the log names the missing or invalid
   variable in the provider block; nothing inside the instance can repair it.
 - **Local Embeddings embeds nothing** — `docker compose logs embeddings`. On a

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -293,12 +293,17 @@ size, memory, GPU variants and the per-page cost — is in
 - **A model in the picker answers every request with a 500** — some models are
   served only by the OpenAI *Responses* API, and their gateway returns a bare
   500 on `/chat/completions` even for a one-word prompt. OpenCode Zen routes
-  `gpt-5.6-luna`, `grok-4.6` and the `muse-spark` models that way. Lemmary now
-  discovers this by itself: the first request to such a model is refused, sent
-  again to `/responses`, and every later request for that model goes straight
-  there. The log line is `chat completions refused this model; retrying on the
-  Responses API`, and it appears once per model per restart, not once per
-  request. Nothing to configure.
+  `gpt-5.6-luna`, `grok-4.6` and the `muse-spark` models that way. Lemmary
+  discovers this by itself, and nothing needs configuring: a refused request is
+  translated and sent again to `/responses`, so it still succeeds, and once the
+  model is known to live there every later request goes straight to it. The log
+  line is `chat completions refused this model; retrying on the Responses API`.
+  A 401 or 403 settles it at once; a 500 takes two, because a 500 is also what
+  any provider returns when it is simply having a bad minute, and one hiccup
+  should not reroute a model for the life of the process. An endpoint that has
+  already answered for a model is never rerouted at all. What is learned is
+  remembered per provider, so the same model name behind two providers is
+  discovered separately.
 - **A managed instance will not start** — the log names the missing or invalid
   variable in the provider block; nothing inside the instance can repair it.
 - **Local Embeddings embeds nothing** — `docker compose logs embeddings`. On a


### PR DESCRIPTION
Closes #49.

The issue turned out to be two unrelated failures against recent OpenAI models. Both are fixed here, one commit each.

## 1. `reasoning_effort` refused alongside function tools

The error reported in #49, from `api.openai.com`:

```
Function tools with reasoning_effort are not supported for gpt-5.6-luna in
/v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

We never send `reasoning_effort` — these models default it server-side and then refuse the request because tools are present. The error names what would work, so `CompleteChat` takes the offer: pin `reasoning_effort` to `"none"` and send again. Remembered per model, because the Search loop runs to `maxSearchToolRounds` and the Research loop has no round cap, so without that every round pays a doomed request. Gated on the request actually carrying tools — pinning `"none"` on an extraction or OCR call would drop the model's reasoning where nothing asked us to.

Builds on @obestmann's [`7991eab`](https://github.com/buldezir/lemmary/commit/7991eabf90ba1079e7d74eb7ad9fcadac31919f4), with two corrections: the detector treats `param == "reasoning_effort"` as a positive signal rather than a gate (OpenAI-compatible proxies routinely omit `param`), and it reads `apiErr.Message` rather than `err.Error()`, which dereferences the `Response` and panics on an error value that did not come off the wire.

## 2. Some models are served only by the Responses API

Selecting `gpt-5.6-luna` broke everything it touched with a bare 500 and no upstream detail. Verified against the live endpoint — not something we sent:

| request | result |
| --- | --- |
| `gpt-5.6-luna` → `/chat/completions` | 500 — no tools, no `reasoning_effort`, no streaming, one-word prompt |
| `gpt-5.6-luna` → `/responses` | 200, tools included |
| `deepseek-v4-flash` → `/chat/completions` | 200, same body |

OpenCode Zen [documents a per-model endpoint](https://github.com/anomalyco/opencode/blob/main/packages/web/src/content/docs/go.mdx#L256) and routes `gpt-5.6-luna`, `grok-4.6` and the `muse-spark` models to `/responses`. Those are exactly the models our picker offered and could not call: luna 500, `grok-4.6` 401, `muse-spark` 403.

So the archive speaks both now. Call sites keep building the chat-completions request they already build; `responses.go` translates it and folds the `Response` back into a `*openai.ChatCompletion`. **No call site changed.**

The shapes disagree mainly about tool calls — chat carries them on the assistant message and answers with a tool-role message, Responses makes each a free-standing `function_call` / `function_call_output` tied together by `call_id`. Also handled: JSON mode → `text.format`, function tools flattened, `input_image` / `input_file` for LLM OCR, `store: false`, and reasoning items skipped on the way back.

Which endpoint a model lives on is **discovered, not listed** — a model string is whatever the operator configured against whatever gateway they point at, and a hardcoded list would be stale by the next launch. Try `/chat/completions`; on a status that means *this endpoint does not serve this model* (401, 403, 404, 405, 500, 501) translate and try `/responses` once. 502/503/504 are deliberately excluded — ordinary transient failures, where rerouting would be guessing. A model is remembered only when the fallback succeeds, and when the guess was wrong the caller hears the original error, not a 404 from an endpoint the provider never had. Streaming falls back the same way, but only while nothing has reached the reader.

## Verification

`GOFLAGS=-tags=vectors CGO_ENABLED=1 go test ./...` green across the backend.

New unit tests cover the fallback-and-remember cycle through a full `Research` loop, the translated request body item by item, the response converter, streaming, and the negative cases (a transient error does not reroute; a failed fallback keeps the original error and is not remembered). Mutation-checked: disabling the fallback fails 7 tests, corrupting `call_id` fails the shape test.

`responses_live_test.go` checks what a fake server cannot — that the translated request is one a real provider accepts. Skipped unless `LIVE_AI_KEY` / `LIVE_AI_BASE_URL` / `LIVE_AI_MODEL` are set. Against live `gpt-5.6-luna`:

```
POST .../chat/completions model=gpt-5.6-luna purpose=research round=0
WARN chat completions refused this model; retrying on the Responses API ... 500
POST .../responses model=gpt-5.6-luna purpose=research round=0 api=responses
POST .../responses ... round=1        <- no further 500s
... prompt_tokens=1154 cached_tokens=1056   <- prompt caching intact
reply: You paid **€412.90** for car insurance ... [Allianz car insurance 2026](/document/doc1)
```

`docs/ai_providers.md` gains a troubleshooting entry. Note `backend/internal/appapi/documents_timeline.go` already fails `gofmt -l` on `main`; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)