### PR TITLE
Build each architecture on its own runner instead of emulating one

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,22 +39,23 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 # Each architecture is built on a runner of that architecture and the two are
-# merged into one manifest, so nothing here runs under emulation. The x64 machine
-# takes the test job, the amd64 build and the merge; the arm64 machine takes the
-# arm64 build.
+# merged into one manifest, so nothing here runs under emulation. The homelab x64
+# machine takes the test job, the amd64 build and the merge; the arm64 build goes
+# to a GitHub-hosted arm64 runner, which is free for a public repository.
+#
+# The arm64 build is hosted rather than homelab on measured grounds. gh-runner-arm-1
+# can take it -- set CI_RUNNER_LABELS_ARM64 to
+# ["self-hosted", "linux", "arm64", "linux-arm64"] and it will -- but that machine
+# compiles FAISS in 699s and the Go backend in 413s where the x64 box
+# cross-compiles them in roughly 44s and 76s (run 34135193438). It even builds the
+# frontend slower natively, 186s, than the x64 box did emulating it at 158s. Native
+# is only faster when the native machine is not the slow one.
 #
 # Two repository variables move the jobs without editing this file, each a JSON
 # array of runner labels: CI_RUNNER_LABELS for the x64 jobs and
-# CI_RUNNER_LABELS_ARM64 for the arm64 build. ["ubuntu-latest"] and
-# ["ubuntu-24.04-arm"] put CI back on GitHub's runners while the homelab is down
-# -- both are free for a public repository -- and unsetting them brings CI home
-# again.
-#
-# Set both or neither. They are separate variables because the two machines carry
-# different labels, but they fail as a pair: with only the x64 one moved, the
-# arm64 build sits unassigned until the job timeout and takes `merge` -- and so
-# the whole publish -- down with it, which reads as a hang rather than as a
-# missing variable.
+# CI_RUNNER_LABELS_ARM64 for the arm64 build. ["ubuntu-latest"] puts the x64 work
+# on GitHub's runners while the homelab is down, and unsetting it brings that work
+# home again.
 #
 # A self-hosted runner needs Docker with buildx usable by the runner user, and
 # nothing else: the test job runs verification inside Docker rather than
@@ -279,11 +280,12 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             runner: ${{ vars.CI_RUNNER_LABELS || '["self-hosted", "linux", "x64", "homelab"]' }}
-          # gh-runner-arm-1 carries neither `homelab` nor `docker`, so the arm64
-          # label set is not the x64 one with the architecture swapped.
+          # Hosted, for the reasons in the comment above this job block. Note that
+          # gh-runner-arm-1 carries neither `homelab` nor `docker`, so its label
+          # set is not the x64 one with the architecture swapped.
           - arch: arm64
             platform: linux/arm64
-            runner: ${{ vars.CI_RUNNER_LABELS_ARM64 || '["self-hosted", "linux", "arm64", "linux-arm64"]' }}
+            runner: ${{ vars.CI_RUNNER_LABELS_ARM64 || '["ubuntu-24.04-arm"]' }}
     runs-on: ${{ fromJSON(matrix.runner) }}
     permissions:
       contents: read
@@ -305,12 +307,10 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.37.0
-          # These are persistent machines, so the BuildKit state is worth keeping
-          # between runs: a local cache beats pulling the registry cache, and on
-          # the arm64 box -- where FAISS and the Go build are compiled rather than
-          # cross-compiled -- that is the difference between minutes and seconds.
-          # It also stops the teardown from trying to delete a multi-gigabyte
-          # state volume, which is what timed out on run 34135193438.
+          # Worth keeping on the self-hosted x64 machine, where a local cache
+          # beats pulling the registry cache and the teardown otherwise tries to
+          # delete a multi-gigabyte state volume -- which is what timed out on run
+          # 34135193438. A no-op on a hosted runner, which is discarded either way.
           keep-state: true
 
       - name: Log in to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,11 +24,12 @@ on:
       - "docker-compose.yml"
   workflow_dispatch:
 
-# One self-hosted runner takes these jobs one at a time, so a superseded run
-# would sit in the queue ahead of the push that replaced it. Pushes to main and
-# tags are never cancelled -- those publish the images everything else pulls.
-# A superseded pull request build is cancelled with the rest of its run: its
-# image is a preview of a commit nobody is looking at any more.
+# The build fans out over two self-hosted runners, one per architecture, and
+# there is exactly one of each -- so a superseded run still occupies the machines
+# the run that replaced it needs. Pushes to main and tags are never cancelled:
+# those publish the images everything else pulls. A superseded pull request build
+# is cancelled with the rest of its run, since its image is a preview of a commit
+# nobody is looking at any more.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -37,14 +38,28 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-# Both jobs run on the self-hosted runner by default. Set the CI_RUNNER_LABELS
-# repository variable to a JSON array to move them without editing this file:
-# ["ubuntu-latest"] puts CI back on GitHub's runners while the homelab machine
-# is down, and unsetting it brings CI home again.
+# Each architecture is built on a runner of that architecture and the two are
+# merged into one manifest, so nothing here runs under emulation. The x64 machine
+# takes the test job, the amd64 build and the merge; the arm64 machine takes the
+# arm64 build.
 #
-# A self-hosted runner needs Docker with buildx usable by the runner user
-# (see the runner-smoke workflow). The test job runs verification inside
-# Docker; it does not install Go, Node, Playwright or poppler on the host.
+# Two repository variables move the jobs without editing this file, each a JSON
+# array of runner labels: CI_RUNNER_LABELS for the x64 jobs and
+# CI_RUNNER_LABELS_ARM64 for the arm64 build. ["ubuntu-latest"] and
+# ["ubuntu-24.04-arm"] put CI back on GitHub's runners while the homelab is down
+# -- both are free for a public repository -- and unsetting them brings CI home
+# again.
+#
+# Set both or neither. They are separate variables because the two machines carry
+# different labels, but they fail as a pair: with only the x64 one moved, the
+# arm64 build sits unassigned until the job timeout and takes `merge` -- and so
+# the whole publish -- down with it, which reads as a hang rather than as a
+# missing variable.
+#
+# A self-hosted runner needs Docker with buildx usable by the runner user, and
+# nothing else: the test job runs verification inside Docker rather than
+# installing Go, Node, Playwright or poppler on the host, and no runner needs
+# QEMU now that neither build crosses architectures.
 jobs:
   test:
     if: github.event_name == 'pull_request'
@@ -142,49 +157,22 @@ jobs:
         # is a failure.
         run: ./scripts/test-all.sh
 
-  build:
-    # Never publish an image for a red pull request: the tag moves with the
-    # branch, so pushing one for a failed run would leave whoever pulls it
-    # running code the suite rejected, with nothing in the tag to say so.
-    needs: test
-    # `always()` so this is evaluated at all when `test` did not succeed --
-    # without it a failed dependency skips the job silently instead of on the
-    # terms below. A push or tag skips `test` outright (it is pull-request
-    # only), and a skipped dependency must not block the release build, hence
-    # accepting "skipped" alongside "success".
-    #
-    # A fork's pull request never builds either. The job holds a package-write
-    # token and runs on the self-hosted runner, and a fork's code must have
-    # neither; skipping is the only safe answer, since there is no fork
-    # equivalent of the test job's throwaway-runner fallback once GHCR push is
-    # involved.
-    if: >-
-      always()
-      && (needs.test.result == 'success' || needs.test.result == 'skipped')
-      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    # Otherwise only push, tag and manual dispatch from this repository, so
-    # there is no untrusted code to keep off the runner.
-    runs-on: ${{ fromJSON(vars.CI_RUNNER_LABELS || '["self-hosted", "linux", "x64", "homelab"]') }}
-    permissions:
-      contents: read
-      packages: write
+  # The tags every architecture's image will end up under, resolved once. This
+  # job is the reason a branch named `latest` costs seconds rather than two
+  # builds: it runs alongside `test`, needs no checkout and no runner of ours,
+  # and the branch-name guard below fails it before anything is built.
+  #
+  # A fork's pull request stops here, which is what skips the builds and the
+  # merge: those jobs require this one to have succeeded.
+  meta:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      labels: ${{ steps.meta.outputs.labels }}
+      json: ${{ steps.meta.outputs.json }}
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       # A branch name may contain characters a Docker tag may not -- "/" above
       # all, which every feat/… branch has. metadata-action sanitizes the refs
       # it derives itself, but not a type=raw value, so the branch tag is
@@ -205,12 +193,13 @@ jobs:
           fi
 
           # A pull request must not be able to publish over a release tag. The
-          # branch name is the whole tag, this job holds packages:write, and it
-          # runs before any review -- so a branch called `latest` would replace
-          # the image docker-compose.yml and the self-hosting guide tell people
-          # to pull, and one called `1.2` would replace a release line. Refused
-          # rather than silently prefixed: the branch is trivially renamed, and
-          # a tag that did not match its branch would be its own surprise.
+          # branch name is the whole tag, the build jobs hold packages:write, and
+          # they run before any review -- so a branch called `latest` would
+          # replace the image docker-compose.yml and the self-hosting guide tell
+          # people to pull, and one called `1.2` would replace a release line.
+          # Refused rather than silently prefixed: the branch is trivially
+          # renamed, and a tag that did not match its branch would be its own
+          # surprise.
           case "$tag" in
             latest | main | edge)
               echo "::error::Branch '$HEAD_REF' would publish over the release tag '$tag'. Rename the branch."
@@ -255,13 +244,214 @@ jobs:
             org.opencontainers.image.title=Lemmary
             org.opencontainers.image.licenses=PolyForm-Noncommercial-1.0.0
 
-      - name: Build and push
+  # One job per architecture, each on a runner of that architecture, each
+  # pushing an untagged image identified only by its digest. `merge` below turns
+  # the two digests into the tagged manifest lists. Nothing is tagged here: a
+  # tag that pointed at one architecture, even briefly, is a tag someone could
+  # pull.
+  build:
+    # Never publish an image for a red pull request: the tag moves with the
+    # branch, so pushing one for a failed run would leave whoever pulls it
+    # running code the suite rejected, with nothing in the tag to say so.
+    needs: [test, meta]
+    # `always()` so this is evaluated at all when `test` did not succeed --
+    # without it a failed dependency skips the job silently instead of on the
+    # terms below. A push or tag skips `test` outright (it is pull-request
+    # only), and a skipped dependency must not block the release build, hence
+    # accepting "skipped" alongside "success".
+    #
+    # A fork's pull request never builds. These jobs hold a package-write token
+    # and run on the self-hosted runners, and a fork's code must have neither;
+    # skipping is the only safe answer, since there is no fork equivalent of the
+    # test job's throwaway-runner fallback once GHCR push is involved. `meta`
+    # carries that guard, so requiring it here is what enforces it.
+    if: >-
+      always()
+      && (needs.test.result == 'success' || needs.test.result == 'skipped')
+      && needs.meta.result == 'success'
+    strategy:
+      # One architecture failing must not cancel the other: two build logs
+      # localise a break to an architecture, one log leaves you guessing. The
+      # merge requires both to have succeeded either way.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ${{ vars.CI_RUNNER_LABELS || '["self-hosted", "linux", "x64", "homelab"]' }}
+          # gh-runner-arm-1 carries neither `homelab` nor `docker`, so the arm64
+          # label set is not the x64 one with the architecture swapped.
+          - arch: arm64
+            platform: linux/arm64
+            runner: ${{ vars.CI_RUNNER_LABELS_ARM64 || '["self-hosted", "linux", "arm64", "linux-arm64"]' }}
+    runs-on: ${{ fromJSON(matrix.runner) }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # No setup-qemu-action: this job builds only its own architecture. Every
+      # stage of the Dockerfile is native here, including the runtime stage's
+      # apt-get, which used to be emulated.
+      #
+      # The version is pinned because setup-buildx-action has no default for it:
+      # unset, each machine uses whatever buildx it happens to have installed, and
+      # these are two hand-managed hosts. `merge` below depends on buildx keeping
+      # the provenance attestation each of these builds pushes, so the two boxes
+      # agreeing on the buildx version is load-bearing, not hygiene.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.37.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          labels: ${{ needs.meta.outputs.labels }}
+          # push-by-digest publishes the image under no tag at all; the digest
+          # comes back as an output for the merge job. name-canonical records the
+          # repository in the image config so the digest resolves.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          # The layer cache lives in GHCR rather than the Actions cache. It has
+          # to be per-architecture either way -- two parallel builds sharing one
+          # cache manifest overwrite each other every run -- and this repository's
+          # Actions cache is already over its 10 GB limit and evicting, which two
+          # mode=max scopes would only make worse. GHCR has no such cap and needs
+          # no credential this job does not already hold.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.arch }}
+          # Only main and tags write the cache. A pull request reads it -- which
+          # is where nearly all of the value is, since FAISS, `go mod download`
+          # and the frontend install come from main's layers -- but must not
+          # replace it, or whichever branch built last would decide what main
+          # gets to reuse.
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.arch) || '' }}
+
+      # Named by the digest itself rather than written into a file, so the merge
+      # job can glob the filenames straight into an argument list.
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
+
+      # overwrite because an artifact name has to be unique within a run, and
+      # re-running one failed architecture would otherwise collide with the digest
+      # its first attempt uploaded. The name is per-architecture, so the two legs
+      # never race for it.
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  # The two per-architecture images become one manifest list per tag. This is the
+  # step that publishes anything anyone can pull by name.
+  merge:
+    # Deliberately no `if:` at all. The default -- run only when every job in
+    # `needs` succeeded -- is exactly the policy wanted here, and `always()` would
+    # let a cancelled or failed architecture through to publish a tag carrying one
+    # architecture where callers expect two. The `build` job's own guards already
+    # decide whether there is anything to merge.
+    needs: [meta, build]
+    runs-on: ${{ fromJSON(vars.CI_RUNNER_LABELS || '["self-hosted", "linux", "x64", "homelab"]') }}
+    permissions:
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      # Same pin as the build jobs: it is this buildx that has to carry the
+      # per-architecture provenance attestations through into the merged index.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.37.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          METADATA: ${{ needs.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # Each build job uploaded one file named after its image digest.
+          digests=(*)
+
+          # `build` succeeding should mean two of them, but this job publishes the
+          # tags people pull by name -- so it counts rather than trusting the
+          # artifact download, and refuses to publish one architecture under a tag
+          # that is supposed to carry both.
+          if [ "${#digests[@]}" -ne 2 ]; then
+            echo "::error::Expected 2 per-architecture digests, found ${#digests[@]}"
+            ls -la
+            exit 1
+          fi
+
+          # One -t per tag `meta` resolved, one source ref per digest uploaded.
+          args=()
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<<"$METADATA")
+
+          for digest in "${digests[@]}"; do
+            args+=("${REGISTRY}/${IMAGE_NAME}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create "${args[@]}"
+
+      # A merge that silently produced a single-architecture manifest would
+      # publish a tag that fails to pull on half the machines that want it, so
+      # the count is checked rather than assumed.
+      - name: Verify the manifest carries both architectures
+        env:
+          METADATA: ${{ needs.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          tag=$(jq -r '.tags[0]' <<<"$METADATA")
+          echo "::notice::Verifying $tag"
+          raw=$(docker buildx imagetools inspect "$tag" --raw)
+
+          missing=""
+          for want in amd64 arm64; do
+            printf '%s' "$raw" \
+              | jq -e --arg a "$want" \
+                '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == $a)] | length > 0' \
+                >/dev/null || missing="$missing linux/$want"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::$tag is missing:$missing"
+            printf '%s\n' "$raw"
+            exit 1
+          fi
+
+          docker buildx imagetools inspect "$tag"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -305,6 +305,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.37.0
+          # These are persistent machines, so the BuildKit state is worth keeping
+          # between runs: a local cache beats pulling the registry cache, and on
+          # the arm64 box -- where FAISS and the Go build are compiled rather than
+          # cross-compiled -- that is the difference between minutes and seconds.
+          # It also stops the teardown from trying to delete a multi-gigabyte
+          # state volume, which is what timed out on run 34135193438.
+          keep-state: true
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -364,12 +371,18 @@ jobs:
   # The two per-architecture images become one manifest list per tag. This is the
   # step that publishes anything anyone can pull by name.
   merge:
-    # Deliberately no `if:` at all. The default -- run only when every job in
-    # `needs` succeeded -- is exactly the policy wanted here, and `always()` would
-    # let a cancelled or failed architecture through to publish a tag carrying one
-    # architecture where callers expect two. The `build` job's own guards already
-    # decide whether there is anything to merge.
     needs: [meta, build]
+    # `always()` is required, not stylistic: a skip propagates down the whole
+    # dependency chain, and `test` is skipped on every push, tag and dispatch. So
+    # the default `success()` condition skips this job even when both builds
+    # passed -- which is exactly what happened on run 34135193438, a green run
+    # that published nothing.
+    #
+    # The explicit result checks are what `success()` was supposed to give. For a
+    # matrix job `needs.build.result` aggregates: 'success' only when every
+    # architecture succeeded, so a failed or cancelled leg still cannot publish a
+    # tag carrying one architecture where callers expect two.
+    if: always() && needs.meta.result == 'success' && needs.build.result == 'success'
     runs-on: ${{ fromJSON(vars.CI_RUNNER_LABELS || '["self-hosted", "linux", "x64", "homelab"]') }}
     permissions:
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -338,12 +338,19 @@ jobs:
           # mode=max scopes would only make worse. GHCR has no such cap and needs
           # no credential this job does not already hold.
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.arch }}
-          # Only main and tags write the cache. A pull request reads it -- which
+          # Only main and tags write the cache. Everything else reads it -- which
           # is where nearly all of the value is, since FAISS, `go mod download`
           # and the frontend install come from main's layers -- but must not
           # replace it, or whichever branch built last would decide what main
           # gets to reuse.
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.arch) || '' }}
+          #
+          # Gated on the ref rather than the event: `github.event_name !=
+          # 'pull_request'` reads like it means the same thing and does not, since
+          # a workflow_dispatch on a feature branch satisfies it and overwrites
+          # main's cache. Layers stay content-addressed either way, so the cost is
+          # a cold FAISS compile rather than a wrong image -- but it is the exact
+          # failure this gate exists to prevent.
+          cache-to: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.arch) || '' }}
 
       # Named by the digest itself rather than written into a file, so the merge
       # job can glob the filenames straight into an argument list.

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -56,11 +56,18 @@ jobs:
           # image that is still being assembled.
           older-than: 7 days
 
-          # The layer cache CI builds from. Tagged, so delete-untagged would not
-          # touch it today -- but it is listed because the cost of losing it to
-          # some later rule is a cold FAISS compile on every architecture, and
-          # exclude-tags takes priority over every other rule.
-          exclude-tags: buildcache-amd64,buildcache-arm64
+          # Nothing here is deletable under the single rule above: every one of
+          # these is tagged, and delete-untagged does not consider tagged images
+          # at all. They are named anyway, because that protection is a property
+          # of the rule set rather than of this list, and the day someone adds a
+          # keep-n-tagged or delete-tags rule it evaporates silently. exclude-tags
+          # takes priority over every other rule, so listing them here is what
+          # makes it survive a rule this file does not have yet.
+          #
+          # `latest` and `main` are what docker-compose.yml and the self-hosting
+          # guide tell people to pull; buildcache-* is the layer cache CI builds
+          # from, and losing it costs a cold FAISS compile on both architectures.
+          exclude-tags: latest,main,buildcache-amd64,buildcache-arm64
 
           # Re-reads every multi-architecture image afterwards and fails if one
           # is missing a platform child. This job's failure mode is silent and

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -1,0 +1,70 @@
+name: Prune images
+
+# Publishing a multi-architecture image leaves untagged manifests behind. Each
+# architecture is built and pushed on its own runner as an image identified only
+# by its digest, and the merge job then assembles a fresh manifest list from the
+# two. That list references the platform manifests and their attestations -- but
+# the two intermediate indexes the build jobs pushed are referenced by nothing
+# from that moment on, and GHCR keeps them forever. Two per build adds up.
+#
+# Deleting them is more delicate than "delete untagged versions". Every tag this
+# repository publishes is a manifest list, and the platform manifests and
+# attestation manifests it points at are themselves untagged package versions --
+# so a tool that treats untagged as unreferenced hollows out `latest` while
+# leaving the tag in place, and nothing looks wrong until someone pulls it. This
+# action walks the manifest lists and keeps what they reference, which is the
+# whole reason it is this one and not actions/delete-package-versions.
+on:
+  schedule:
+    # Weekly. There is no urgency -- untagged manifests cost storage, not
+    # correctness -- and a prune that runs rarely is a prune whose blast radius
+    # stays small.
+    - cron: "17 4 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Log what would be deleted without deleting it"
+        type: boolean
+        default: true
+
+# Never two prunes at once, and never a prune racing its own previous run.
+concurrency:
+  group: prune-images
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      # Pinned to a patch rather than the major, unlike every other action in
+      # this repository. The others build things; this one deletes them, and an
+      # unattended weekly job is the wrong place to find out what changed inside
+      # a major version.
+      - uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        with:
+          # owner, package and token all default to this repository and its
+          # GITHUB_TOKEN, which is what we want: no PAT, and no way for this to
+          # reach a package belonging to something else.
+          delete-untagged: true
+
+          # A build in flight has pushed its per-architecture images but may not
+          # have merged them yet, and between those two moments they are
+          # indistinguishable from the orphans this job exists to remove. An age
+          # floor is what keeps a scheduled prune from deleting the halves of an
+          # image that is still being assembled.
+          older-than: 7 days
+
+          # The layer cache CI builds from. Tagged, so delete-untagged would not
+          # touch it today -- but it is listed because the cost of losing it to
+          # some later rule is a cold FAISS compile on every architecture, and
+          # exclude-tags takes priority over every other rule.
+          exclude-tags: buildcache-amd64,buildcache-arm64
+
+          # Re-reads every multi-architecture image afterwards and fails if one
+          # is missing a platform child. This job's failure mode is silent and
+          # only shows up at `docker pull`, so it checks its own work.
+          validate: true
+
+          dry-run: ${{ inputs.dry-run || false }}

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -69,9 +69,65 @@ jobs:
           # from, and losing it costs a cold FAISS compile on both architectures.
           exclude-tags: latest,main,buildcache-amd64,buildcache-arm64
 
-          # Re-reads every multi-architecture image afterwards and fails if one
-          # is missing a platform child. This job's failure mode is silent and
-          # only shows up at `docker pull`, so it checks its own work.
+          # Re-reads every multi-architecture image afterwards and reports any
+          # that lost a platform child. Left on for the log, but it does not
+          # decide anything: the action raises those as core.warning and drops
+          # the result on the floor (image-validator.ts fills in `hasErrors`,
+          # cleanup-orchestrator.ts discards it, nothing calls setFailed), so a
+          # hollowed-out tag would leave this job green. The step below is what
+          # actually gates.
           validate: true
 
           dry-run: ${{ inputs.dry-run || false }}
+
+      # The failure this job risks is silent: a tag that still exists, still
+      # resolves, and no longer has an image for one of its architectures --
+      # visible only when someone pulls it on that architecture. So the tags are
+      # re-read here and the job fails on its own account rather than trusting a
+      # warning nobody reads.
+      - name: Verify every tagged image still resolves on both architectures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+          IMAGE: ghcr.io/${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          tags=$(gh api --paginate \
+            "/users/$OWNER/packages/container/$PACKAGE/versions" \
+            --jq '.[].metadata.container.tags[]' | sort -u)
+
+          if [ -z "$tags" ]; then
+            echo "::error::Could not list tags for $PACKAGE -- verification did not run"
+            exit 1
+          fi
+
+          broken=""
+          checked=0
+          for tag in $tags; do
+            # The buildcache-* tags are BuildKit cache manifests, not images:
+            # they carry no platforms and are not meant to be pulled.
+            case "$tag" in
+              buildcache-*) continue ;;
+            esac
+
+            if ! raw=$(docker buildx imagetools inspect "$IMAGE:$tag" --raw 2>&1); then
+              broken="$broken $tag(unresolvable)"
+              continue
+            fi
+
+            for want in amd64 arm64; do
+              printf '%s' "$raw" \
+                | jq -e --arg a "$want" \
+                  '[.manifests[]? | select(.platform.os == "linux" and .platform.architecture == $a)] | length > 0' \
+                  >/dev/null 2>&1 || broken="$broken $tag(no-linux/$want)"
+            done
+            checked=$((checked + 1))
+          done
+
+          if [ -n "$broken" ]; then
+            echo "::error::Tags left incomplete by the prune:$broken"
+            exit 1
+          fi
+          echo "::notice::$checked tagged images verified, all carrying linux/amd64 and linux/arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,17 @@
 # glibc-based end to end: blevesearch's FAISS fork, go-faiss and bleve are all
 # built and tested against glibc, and musl's 128 KiB default thread stacks are a
 # poor fit for FAISS's OpenMP worker threads. Debian also gives us multiarch,
-# which is what keeps the arm64 image a native-speed cross build instead of an
-# hour under QEMU.
+# which is what lets one machine build the other architecture's image without
+# emulating it.
+#
+# CI does not need that: it builds each architecture on a runner of that
+# architecture and merges the two into one manifest, so every stage there is
+# native. Multiarch is what keeps a local `--platform linux/amd64,linux/arm64`
+# build honest, and every stage below has to work both ways.
 
-# FAISS is compiled on the build machine and cross-compiled for the target, so
-# this stage never runs under emulation. The pinned commit lives in the script;
-# this layer is rebuilt only when the script changes.
+# Cross-compiled rather than emulated when host and target differ, so this stage
+# never runs under QEMU. The pinned commit lives in the script; this layer is
+# rebuilt only when the script changes.
 FROM --platform=$BUILDPLATFORM golang:1.27-trixie AS faiss-build
 
 ARG TARGETARCH
@@ -66,14 +71,29 @@ COPY backend/ .
 
 # -tags vectors is not optional: without it bleve compiles out SearchRequest.KNN
 # and the backend does not build at all (see internal/fulltext/vectors_required.go).
+#
+# The compiler is chosen by whether this is a cross build, not by the target
+# architecture: the aarch64 toolchain is only installed above when host != target,
+# so on a native arm64 builder -- which is how CI builds the arm64 image -- naming
+# it here would point CC at a binary that is not in the image. The library search
+# path is per-architecture either way, and /usr/lib/aarch64-linux-gnu is where the
+# arm64 OpenBLAS lives both natively and under multiarch. Only arm64-on-amd64 is
+# wired up, so the other cross direction has to fail here rather than fall through
+# to a compiler that would emit an object for the wrong architecture.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
     set -eu; \
     case "$TARGETARCH" in \
-      amd64) CC=gcc; EXTRA_LDFLAGS= ;; \
-      arm64) CC=aarch64-linux-gnu-gcc; EXTRA_LDFLAGS=-L/usr/lib/aarch64-linux-gnu ;; \
+      amd64 | arm64) ;; \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac; \
+    if [ "$TARGETARCH" = "$(dpkg --print-architecture)" ]; then \
+      CC=gcc; EXTRA_LDFLAGS=; \
+    elif [ "$TARGETARCH" = arm64 ]; then \
+      CC=aarch64-linux-gnu-gcc; EXTRA_LDFLAGS=-L/usr/lib/aarch64-linux-gnu; \
+    else \
+      echo "no cross toolchain for $TARGETARCH on $(dpkg --print-architecture)" >&2; exit 1; \
+    fi; \
     CGO_ENABLED=1 \
     CC="$CC" \
     GOOS="$TARGETOS" \
@@ -82,7 +102,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_LDFLAGS="-L/opt/faiss/lib -Wl,-rpath-link,/opt/faiss/lib $EXTRA_LDFLAGS" \
     go build -tags vectors -o lemmary .
 
-FROM node:26-alpine AS frontend-builder
+# The bundle is static JavaScript, HTML and CSS: identical whatever it is built
+# for. So this stage builds for the host and both target images copy the same
+# result, which in a local two-platform build is the difference between building
+# the frontend once and building it twice with one of them emulated.
+FROM --platform=$BUILDPLATFORM node:26-alpine AS frontend-builder
 
 RUN npm install -g pnpm
 
@@ -107,8 +131,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 # FAISS is only ever loaded by the binary next to it, so the two libraries go to
 # /usr/local/lib and ldconfig makes them findable without an rpath. faiss.ref
-# rides along so a running image can be asked which FAISS it has, the same way
-# CI asks a runner.
+# rides along so a running image can be asked which FAISS it has -- which is how
+# you tell two same-tag images of different architectures apart.
 COPY --from=faiss /lib/libfaiss.so /lib/libfaiss_c.so /lib/faiss.ref /usr/local/lib/
 RUN ldconfig
 WORKDIR /app


### PR DESCRIPTION
## Why

The `build` job produced both architectures on the x64 homelab runner via `setup-qemu-action`. The Dockerfile's opening comment claimed that cost nothing — the arm64 image being "a native-speed cross build instead of an hour under QEMU" — but that was only ever true of the FAISS and Go stages. `frontend-builder` and the runtime stage were not `FROM --platform=$BUILDPLATFORM`, and they ran emulated. Measured on run 34118717573:

| Stage | amd64 | arm64 under QEMU |
| --- | --- | --- |
| `frontend-builder` `pnpm run build` | 18.7s | **157.8s** |
| `frontend-builder` `pnpm install` | 53.3s | 47.1s |

For a byte-identical bundle of static assets.

## What changed

`build` becomes a matrix of two single-platform jobs, each on a runner of its own architecture, each pushing an untagged image by digest. A new `merge` job assembles the two digests into the tagged manifest lists. `setup-qemu-action` is gone.

Tag derivation moves into a `meta` job that runs alongside `test` and needs no runner of ours, so a branch named `latest` now fails in seconds rather than after two builds.

The layer cache moves from the Actions cache to GHCR. It had to become per-architecture either way — two parallel builds sharing one cache manifest overwrite each other every run — and the Actions cache was already at 10.83 GB against a 10 GB limit, so two `mode=max` scopes would only have evicted harder. Pull requests read the cache but no longer write it.

`prune-images.yml` is new: publishing this way leaves two unreferenced intermediate indexes per build in GHCR, and they are not the same thing as "untagged versions" — every tag here is a manifest list whose platform and attestation manifests are themselves untagged. See the comment at the top of that file.

### Dockerfile

One fix was a prerequisite for any native arm64 build at all: `CC=aarch64-linux-gnu-gcc` was selected whenever `TARGETARCH` was arm64, while the apt block installing that compiler is guarded by host != target. On an arm64 runner `CC` pointed at a binary that was never installed. The choice now follows whether this is a cross build, and the unsupported cross direction fails loudly instead of reaching for a compiler that would emit objects for the wrong architecture.

`frontend-builder` also gains `--platform=$BUILDPLATFORM`. A no-op for CI now that each job is single-platform, but it stops a local `--platform linux/amd64,linux/arm64` build from building the frontend twice with one of them emulated.

## Why arm64 is hosted, not homelab

The split was built on `gh-runner-arm-1` first and measured (run 34135193438): FAISS 699s, Go backend 413s, against roughly 44s and 76s to cross-compile the same stages on the x64 box. It even built the frontend slower natively — 186s — than the x64 box managed emulating it at 158s. The cold arm64 leg took 25m53s against a ~5m40s baseline for the entire old build.

GitHub's arm64 runners are free for a public repository, so the arm64 build goes there. `CI_RUNNER_LABELS_ARM64` sends it back to `gh-runner-arm-1` for anyone who wants it there.

| Scenario | Before | After |
| --- | --- | --- |
| Warm, no source change | — | ~1m |
| Backend source change | ~5m40s | ~2m (amd64 1m27s ∥ arm64 1m36s, merge 16s) |
| `go build` stage alone | ~76s cross-compiled | 53.3s native on hosted arm64 |

## Verification

Run 34138528664 is green on this tree. The published manifest carries `linux/amd64` and `linux/arm64` plus both provenance attestations, labels are unchanged, the published image boots and answers `/api/health`, the FAISS pin is intact, and `latest` was untouched throughout (still `sha256:cc0c732b…`).

Both Dockerfile paths were built locally before any of this: `--platform linux/arm64` cross from x64, and a full native amd64 build.

`prune-images.yml` was dry-run against the live package on a throwaway branch. With the committed 7-day floor: nothing to delete, validation clean. With the floor removed to prove the mechanism: 13 orphaned images resolving to 21 versions, correctly cascading each orphan index into its platform children and in-toto attestations, with `latest` and its four children kept and validation still clean.

## Not yet exercised

This PR is itself the first run of the `test` → `build` → `merge` path with `test` actually succeeding; every run so far was a `workflow_dispatch`, which skips `test`. Also unexercised: the fast-fail gate on a branch named `latest`, the fork-PR skip, and a release tag's `type=pep440` tags.

One open question: `prune-images.yml` has only ever run dry, and its log printed `token owns package  false` — `lemmary` is a user-owned package. If the first real prune gets a 403 on delete, it needs a PAT with `delete:packages`. Scheduled workflows only run from the default branch, so that cannot be tested until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)