### PR TITLE
Pay for the language model with a ChatGPT seat instead of API credits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,9 +57,14 @@ AI_BASE_URL=https://opencode.ai/zen/go/v1
 # Sign in with a ChatGPT subscription instead of paying per token. Off unless
 # set; refused together with AI_MANAGED=1.
 #
-# It opens the `chatgpt` SDK in Settings: add a provider, sign in with a device
-# code, and bind chat, extraction or Deep Search to it. Embeddings and OCR stay
-# on whatever provider they had -- the endpoint behind this SDK serves neither.
+# It opens the `chatgpt` SDK in Settings and in the setup wizard: add a provider,
+# sign in with a device code, and bind chat, extraction, Deep Search or OCR to
+# it. OCR works as it does on `openai` -- the file goes to the model -- so a
+# ChatGPT seat can be the whole AI configuration. Embeddings stay on whatever
+# provider they had: the endpoint behind this SDK has no /embeddings at all.
+#
+# There is no OCR_SDK=chatgpt, for the same reason there is no AI_SDK=chatgpt:
+# this file can carry a key, not a sign-in. Bind OCR to it from Settings.
 #
 # Read docs/chatgpt_login.md before turning it on. It reaches OpenAI's own Codex
 # endpoints, which are undocumented and meant for OpenAI's clients, so the

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,18 @@ AI_MODEL=deepseek-v4-flash
 # Optional; defaults to the SDK's own endpoint.
 AI_BASE_URL=https://opencode.ai/zen/go/v1
 
+# Sign in with a ChatGPT subscription instead of paying per token. Off unless
+# set; refused together with AI_MANAGED=1.
+#
+# It opens the `chatgpt` SDK in Settings: add a provider, sign in with a device
+# code, and bind chat, extraction or Deep Search to it. Embeddings and OCR stay
+# on whatever provider they had -- the endpoint behind this SDK serves neither.
+#
+# Read docs/chatgpt_login.md before turning it on. It reaches OpenAI's own Codex
+# endpoints, which are undocumented and meant for OpenAI's clients, so the
+# account you sign in with is the one carrying the risk.
+# AI_CHATGPT_LOGIN=1
+
 # Embeddings for Deep Search. Unset (the default) means Deep Search matches
 # keywords only, which is what it did before this existed -- a working
 # configuration, not a broken one. Set it and a question phrased one way finds a

--- a/backend/internal/ai/chat.go
+++ b/backend/internal/ai/chat.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
 
 	"lemmary/backend/internal/aiprovider"
@@ -89,6 +90,6 @@ func (c *OpenAIClient) Chat(ctx context.Context, ocrText string, messages []Chat
 	return strings.TrimSpace(chatResp.Choices[0].Message.Content), nil
 }
 
-func NewChatter(sdk, apiKey, model, baseURL string, timeout time.Duration, logger *slog.Logger) Chatter {
-	return NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger)
+func NewChatter(sdk, apiKey, model, baseURL string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) Chatter {
+	return NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger, extra...)
 }

--- a/backend/internal/ai/extract.go
+++ b/backend/internal/ai/extract.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
 
 	"lemmary/backend/internal/aiprovider"
@@ -242,6 +243,6 @@ func (c *OpenAIClient) ExtractMetadata(ctx context.Context, ocrText string, cata
 	return metadata, nil
 }
 
-func NewExtractor(sdk, apiKey, model, baseURL, promptVer, resultLanguage string, timeout time.Duration, logger *slog.Logger) Extractor {
-	return NewOpenAIClient(sdk, apiKey, model, baseURL, promptVer, resultLanguage, timeout, logger)
+func NewExtractor(sdk, apiKey, model, baseURL, promptVer, resultLanguage string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) Extractor {
+	return NewOpenAIClient(sdk, apiKey, model, baseURL, promptVer, resultLanguage, timeout, logger, extra...)
 }

--- a/backend/internal/ai/helper.go
+++ b/backend/internal/ai/helper.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
 
 	"lemmary/backend/internal/aiprovider"
@@ -89,8 +90,8 @@ type DistillResult struct {
 }
 
 // NewHelper builds a Helper on an OpenAI-compatible chat endpoint.
-func NewHelper(sdk, apiKey, model, baseURL string, timeout time.Duration, logger *slog.Logger) Helper {
-	return &openAIHelper{client: NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger)}
+func NewHelper(sdk, apiKey, model, baseURL string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) Helper {
+	return &openAIHelper{client: NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger, extra...)}
 }
 
 type openAIHelper struct {

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -82,9 +82,16 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
+	// The chatgpt SDK already speaks the Responses API, from underneath: its
+	// middleware rewrites /chat/completions into /responses and only it knows
+	// the Codex auth headers. Translating again up here would post to
+	// /responses with the placeholder key and no originator, so every
+	// degradation path below stays on the endpoint the middleware owns.
+	viaResponses := !aiprovider.RequiresOAuth(sdk)
+
 	// A model already known to live on the Responses API never touches
 	// /chat/completions again.
-	if needsResponsesAPI(baseURL, string(params.Model)) {
+	if viaResponses && needsResponsesAPI(baseURL, string(params.Model)) {
 		resp, err := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...)
 		if err == nil {
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
@@ -142,7 +149,7 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	// reasoning, while reasoning_effort=none keeps the tools by turning the
 	// reasoning off. Take the first, and settle for the second only where
 	// there is no Responses endpoint to take it to.
-	if len(params.Tools) > 0 && isReasoningEffortToolConflictError(err) {
+	if viaResponses && len(params.Tools) > 0 && isReasoningEffortToolConflictError(err) {
 		logger.Warn("model rejected reasoning_effort with function tools; retrying on the Responses API",
 			"model", params.Model,
 			slog.Any("error", err),
@@ -201,7 +208,7 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	// anything at all. Try there once, and keep the original error if that was
 	// not the problem -- a Responses error for a provider that has no such
 	// endpoint would only mislead.
-	if try, remember := shouldTryResponses(err, baseURL, string(params.Model)); try {
+	if try, remember := shouldTryResponses(err, baseURL, string(params.Model)); viaResponses && try {
 		logger.Warn("chat completions refused this model; retrying on the Responses API",
 			"model", params.Model,
 			"remember", remember,
@@ -275,7 +282,11 @@ func (c *OpenAIClient) completeStreaming(
 	onDelta func(string),
 	extra ...any,
 ) (string, Usage, error) {
-	if needsResponsesAPI(c.baseURL, string(params.Model)) {
+	// See CompleteChat: the chatgpt SDK reaches /responses through its own
+	// middleware, which is the only thing holding the Codex headers. Both
+	// reroutes below are off for it -- this one and the one after a refusal.
+	viaResponses := !aiprovider.RequiresOAuth(c.sdk)
+	if viaResponses && needsResponsesAPI(c.baseURL, string(params.Model)) {
 		return c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
 	}
 	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
@@ -319,7 +330,7 @@ func (c *OpenAIClient) completeStreaming(
 	// Same fallback as CompleteChat, but only while nothing has reached the
 	// reader yet: once deltas are on the wire, a second stream would replay a
 	// different answer over the first.
-	if b.Len() == 0 {
+	if viaResponses && b.Len() == 0 {
 		try, remember := shouldTryResponses(err, c.baseURL, string(params.Model))
 		if !try {
 			return b.String(), usage, err

--- a/backend/internal/ai/responses_test.go
+++ b/backend/internal/ai/responses_test.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +17,8 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/responses"
 	"github.com/openai/openai-go/shared"
+
+	"lemmary/backend/internal/aiprovider"
 )
 
 // responsesHarness fakes a provider that serves some models only on
@@ -619,5 +622,77 @@ func TestOrdinaryModelStaysOnChatCompletions(t *testing.T) {
 	}
 	if _, r := h.counts(); r != 0 {
 		t.Fatalf("responses requests = %d, want 0", r)
+	}
+}
+
+// The chatgpt SDK reaches the Responses API from underneath: its middleware
+// rewrites /chat/completions into /responses and is the only thing holding the
+// Codex auth headers. A 403 from that endpoint -- a model the plan does not
+// cover, or a rejected originator -- looks exactly like the endpoint-mismatch
+// this fallback exists for, and taking it would POST /responses directly, past
+// the middleware, with the placeholder key and no originator.
+func TestTheChatGPTSDKNeverTranslatesToResponsesItself(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			model := fmt.Sprintf("chatgpt-%d", status)
+			resetModelNotes()
+			t.Cleanup(resetModelNotes)
+
+			h := &responsesHarness{chatStatus: status, respTurns: []scriptedTurn{{content: "should never be reached"}}}
+			base := newResponsesHarness(t, h)
+			client := NewOpenAIClient(aiprovider.SDKChatGPT, "chatgpt-oauth", model, base, "v1", "", 5*time.Second, slog.Default())
+
+			_, err := CompleteChat(context.Background(), client.client, slog.Default(),
+				aiprovider.SDKChatGPT, base, openai.ChatCompletionNewParams{
+					Model:    shared.ChatModel(model),
+					Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+				})
+			if err == nil {
+				t.Fatal("the refusal was swallowed by a fallback that cannot carry the Codex headers")
+			}
+			// The backend's own message is what an operator needs to see.
+			var apiErr *openai.Error
+			if !errors.As(err, &apiErr) || apiErr.StatusCode != status {
+				t.Fatalf("err = %v, want the original %d", err, status)
+			}
+
+			h.mu.Lock()
+			posted := len(h.respBodies)
+			h.mu.Unlock()
+			if posted != 0 {
+				t.Fatalf("posted %d requests straight to /responses, bypassing the middleware", posted)
+			}
+			if needsResponsesAPI(base, model) {
+				t.Fatal("the chatgpt SDK was pinned to a /responses route its middleware does not serve")
+			}
+		})
+	}
+}
+
+func TestTheChatGPTSDKDoesNotTranslateStreamsEither(t *testing.T) {
+	model := "chatgpt-stream"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
+
+	h := &responsesHarness{chatStatus: http.StatusInternalServerError}
+	base := newResponsesHarness(t, h)
+	// Pinned, as a 500 on any other SDK would pin it: the guard has to hold
+	// even once the note is set, because notes are keyed by endpoint and model
+	// and say nothing about which SDK is reaching them.
+	rememberResponsesAPI(base, model)
+	client := NewOpenAIClient(aiprovider.SDKChatGPT, "chatgpt-oauth", model, base, "v1", "", 5*time.Second, slog.Default())
+
+	if _, _, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}, nil); err == nil {
+		t.Fatal("the stream was rerouted to /responses instead of failing on the endpoint the middleware owns")
+	}
+
+	h.mu.Lock()
+	posted := len(h.respBodies)
+	h.mu.Unlock()
+	if posted != 0 {
+		t.Fatalf("posted %d streams straight to /responses", posted)
 	}
 }

--- a/backend/internal/ai/search.go
+++ b/backend/internal/ai/search.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
 )
 
@@ -156,9 +157,9 @@ type openAISearchAgent struct {
 	resultLanguage string
 }
 
-func NewSearchAgent(sdk, apiKey, model, baseURL string, timeout time.Duration, languages, resultLanguage string, logger *slog.Logger) SearchAgent {
+func NewSearchAgent(sdk, apiKey, model, baseURL string, timeout time.Duration, languages, resultLanguage string, logger *slog.Logger, extra ...option.RequestOption) SearchAgent {
 	return &openAISearchAgent{
-		client:         NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger),
+		client:         NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger, extra...),
 		languages:      strings.TrimSpace(languages),
 		resultLanguage: strings.TrimSpace(resultLanguage),
 	}

--- a/backend/internal/ai/split.go
+++ b/backend/internal/ai/split.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
 	"lemmary/backend/internal/aiprovider"
 	"lemmary/backend/internal/logfmt"
@@ -37,8 +38,8 @@ type Splitter interface {
 	DetectSplitPoints(ctx context.Context, pages []PageText) (*models.SplitSuggestion, error)
 }
 
-func NewSplitter(sdk, apiKey, model, baseURL string, timeout time.Duration, logger *slog.Logger) Splitter {
-	return NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger)
+func NewSplitter(sdk, apiKey, model, baseURL string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) Splitter {
+	return NewOpenAIClient(sdk, apiKey, model, baseURL, "", "", timeout, logger, extra...)
 }
 
 const splitSystemPrompt = `You find document boundaries in a single PDF that holds several separate documents scanned into one file.

--- a/backend/internal/aiprovider/chatgpt_sdk_test.go
+++ b/backend/internal/aiprovider/chatgpt_sdk_test.go
@@ -2,11 +2,11 @@ package aiprovider
 
 import "testing"
 
-// The chatgpt SDK's whole shape in one place: it chats, it cannot embed or read
-// a document, and its credential is a token rather than a pasted key. Each of
+// The chatgpt SDK's whole shape in one place: it chats, it reads documents, it
+// cannot embed, and its credential is a token rather than a pasted key. Each of
 // those answers gates a different binding, and getting one wrong would put a
 // provider somewhere it cannot serve.
-func TestChatGPTSDKChatsAndNothingElse(t *testing.T) {
+func TestChatGPTSDKChatsAndReadsButDoesNotEmbed(t *testing.T) {
 	t.Parallel()
 	if !IsLLM(SDKChatGPT) {
 		t.Error("chatgpt must serve the language-model bindings")
@@ -14,8 +14,14 @@ func TestChatGPTSDKChatsAndNothingElse(t *testing.T) {
 	if CanEmbed(SDKChatGPT) {
 		t.Error("the Codex backend serves no /embeddings")
 	}
-	if CanOCR(SDKChatGPT) {
-		t.Error("the Codex backend reads no documents")
+	// Its models take file and image input like any other LLM's, so OCR runs
+	// on the seat: see internal/chatgpt.messageContent for the parts, and
+	// internal/ocr.NewLLMProvider for the request they go in.
+	if !CanOCR(SDKChatGPT) {
+		t.Error("chatgpt reads documents like the other LLM SDKs")
+	}
+	if RequiresOCRModel(SDKChatGPT) != true {
+		t.Error("an OCR binding on chatgpt names a model, like the other LLM SDKs")
 	}
 	if !RequiresOAuth(SDKChatGPT) {
 		t.Error("chatgpt signs in rather than taking a key")
@@ -54,26 +60,26 @@ func TestChatGPTProviderIsConfiguredByItsToken(t *testing.T) {
 	}
 }
 
-// The Codex backend publishes no catalogue, so the picker is served locally.
-// Asked for anything but a language model it stays empty rather than offering
-// models for a binding CanEmbed and CanOCR already refuse.
+// The Codex backend publishes no catalogue, so the picker is served locally --
+// for chat and for OCR, which bind the same models. Embeddings stay empty
+// rather than offering models for the one binding CanEmbed refuses.
 func TestChatGPTModelsAreServedWithoutTheNetwork(t *testing.T) {
 	t.Parallel()
 	p := Provider{SDK: SDKChatGPT, BaseURL: DefaultBaseURL(SDKChatGPT)}
-	models, err := ListModels(t.Context(), p, PurposeLLM, nil, nil)
-	if err != nil {
-		t.Fatalf("listing models for a signed-in provider failed: %v", err)
-	}
-	if len(models) == 0 {
-		t.Fatal("the model picker would be empty for every ChatGPT provider")
-	}
-	for _, purpose := range []ModelPurpose{PurposeOCR, PurposeEmbedding} {
-		got, err := ListModels(t.Context(), p, purpose, nil, nil)
+	for _, purpose := range []ModelPurpose{PurposeLLM, PurposeOCR} {
+		models, err := ListModels(t.Context(), p, purpose, nil, nil)
 		if err != nil {
-			t.Fatalf("%s: %v", purpose, err)
+			t.Fatalf("%s: listing models for a signed-in provider failed: %v", purpose, err)
 		}
-		if len(got) != 0 {
-			t.Errorf("%s offered %d models for a binding chatgpt cannot serve", purpose, len(got))
+		if len(models) == 0 {
+			t.Fatalf("%s: the model picker would be empty for every ChatGPT provider", purpose)
 		}
+	}
+	got, err := ListModels(t.Context(), p, PurposeEmbedding, nil, nil)
+	if err != nil {
+		t.Fatalf("embedding: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("embedding offered %d models for a binding chatgpt cannot serve", len(got))
 	}
 }

--- a/backend/internal/aiprovider/chatgpt_sdk_test.go
+++ b/backend/internal/aiprovider/chatgpt_sdk_test.go
@@ -1,0 +1,79 @@
+package aiprovider
+
+import "testing"
+
+// The chatgpt SDK's whole shape in one place: it chats, it cannot embed or read
+// a document, and its credential is a token rather than a pasted key. Each of
+// those answers gates a different binding, and getting one wrong would put a
+// provider somewhere it cannot serve.
+func TestChatGPTSDKChatsAndNothingElse(t *testing.T) {
+	t.Parallel()
+	if !IsLLM(SDKChatGPT) {
+		t.Error("chatgpt must serve the language-model bindings")
+	}
+	if CanEmbed(SDKChatGPT) {
+		t.Error("the Codex backend serves no /embeddings")
+	}
+	if CanOCR(SDKChatGPT) {
+		t.Error("the Codex backend reads no documents")
+	}
+	if !RequiresOAuth(SDKChatGPT) {
+		t.Error("chatgpt signs in rather than taking a key")
+	}
+	if RequiresAPIKey(SDKChatGPT) {
+		t.Error("chatgpt has no API key to demand")
+	}
+	// Every other SDK must keep answering the old way: RequiresOAuth is new,
+	// and a stray true would hide a working key behind a sign-in button.
+	for _, sdk := range ValidSDKs {
+		if sdk != SDKChatGPT && RequiresOAuth(sdk) {
+			t.Errorf("%s must not require a sign-in", sdk)
+		}
+	}
+}
+
+// Configured is what the setup wizard, the readiness check and the runtime all
+// ask. For chatgpt the answer lives in a different column than for every other
+// SDK, and the old spelling would have read a signed-in provider as unusable.
+func TestChatGPTProviderIsConfiguredByItsToken(t *testing.T) {
+	t.Parallel()
+	// A base URL is not enough, or the row would read as ready before anyone
+	// signed in -- NormalizeBaseURL fills one in for every provider.
+	signedOut := Provider{SDK: SDKChatGPT, BaseURL: DefaultBaseURL(SDKChatGPT)}
+	if signedOut.Configured() {
+		t.Error("a chatgpt provider with no token is not configured")
+	}
+	signedIn := Provider{SDK: SDKChatGPT, OAuth: `{"access_token":"a"}`}
+	if !signedIn.Configured() {
+		t.Error("a signed-in chatgpt provider is configured")
+	}
+	// An API key is not a substitute: it is not what the transport sends.
+	keyed := Provider{SDK: SDKChatGPT, APIKey: "sk-test"}
+	if keyed.Configured() {
+		t.Error("an API key must not stand in for a ChatGPT sign-in")
+	}
+}
+
+// The Codex backend publishes no catalogue, so the picker is served locally.
+// Asked for anything but a language model it stays empty rather than offering
+// models for a binding CanEmbed and CanOCR already refuse.
+func TestChatGPTModelsAreServedWithoutTheNetwork(t *testing.T) {
+	t.Parallel()
+	p := Provider{SDK: SDKChatGPT, BaseURL: DefaultBaseURL(SDKChatGPT)}
+	models, err := ListModels(t.Context(), p, PurposeLLM, nil, nil)
+	if err != nil {
+		t.Fatalf("listing models for a signed-in provider failed: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("the model picker would be empty for every ChatGPT provider")
+	}
+	for _, purpose := range []ModelPurpose{PurposeOCR, PurposeEmbedding} {
+		got, err := ListModels(t.Context(), p, purpose, nil, nil)
+		if err != nil {
+			t.Fatalf("%s: %v", purpose, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("%s offered %d models for a binding chatgpt cannot serve", purpose, len(got))
+		}
+	}
+}

--- a/backend/internal/aiprovider/collection.go
+++ b/backend/internal/aiprovider/collection.go
@@ -6,6 +6,16 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
+// OAuthField holds the token pair for the SDKs that sign in instead of taking a
+// pasted key. Named rather than spelled inline because three packages read it:
+// the record mapper here, the migration that adds it to installs that predate
+// it, and the sign-in handlers that write it.
+//
+// Sized for a JWT id_token plus two opaque tokens with room to spare. It sits
+// beside api_key in SQLite and is covered by the vault exactly as the key is;
+// like the key it is never returned by the API.
+const OAuthField = "oauth"
+
 func EnsureCollection(app core.App) (*core.Collection, error) {
 	if collection, err := app.FindCollectionByNameOrId(CollectionName); err == nil {
 		return collection, nil
@@ -22,6 +32,7 @@ func EnsureCollection(app core.App) (*core.Collection, error) {
 		&core.TextField{Name: "alias", Required: true, Max: 100},
 		&core.TextField{Name: "base_url", Max: 500},
 		&core.TextField{Name: "api_key", Max: 2000},
+		&core.TextField{Name: OAuthField, Max: 8000},
 		&core.AutodateField{Name: "created", OnCreate: true},
 		&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true},
 	)

--- a/backend/internal/aiprovider/models.go
+++ b/backend/internal/aiprovider/models.go
@@ -153,11 +153,15 @@ func ListModels(ctx context.Context, p Provider, purpose ModelPurpose, client *h
 	// which would otherwise fail it for having no API key -- it has a token
 	// instead -- and turn a working sign-in into an error banner in Settings.
 	if p.SDK == SDKChatGPT {
-		if purpose != PurposeLLM {
-			// CanEmbed and CanOCR already refuse those bindings; returning
-			// nothing keeps the picker honest if one is ever asked for anyway.
+		if purpose == PurposeEmbedding {
+			// CanEmbed already refuses that binding; returning nothing keeps
+			// the picker honest if it is ever asked for anyway.
 			return nil, nil
 		}
+		// The same list for OCR as for chat. The Codex catalogue says nothing
+		// about which models take a file, so this is the openai case rather
+		// than the openrouter one: every name, and a warning in Settings to
+		// pick one that can read a document.
 		return ChatGPTModels(), nil
 	}
 

--- a/backend/internal/aiprovider/models.go
+++ b/backend/internal/aiprovider/models.go
@@ -118,7 +118,49 @@ func ModelsURL(p Provider, purpose ModelPurpose) string {
 	return endpoint
 }
 
+// ChatGPTModels is the catalogue for the chatgpt SDK.
+//
+// Written out because the Codex backend publishes none: it serves one endpoint,
+// /responses, and has no /models to ask. Without this the model picker would be
+// empty for every signed-in operator, and the only way to configure the
+// provider would be the "Custom model id" escape hatch -- which still works,
+// and is what covers a model added after this list was written.
+//
+// Names, not capabilities: which of these an account may actually use depends
+// on its plan, and the backend is the only thing that knows. A model refused
+// there surfaces as a provider error on the first request rather than as a
+// missing entry here.
+//
+// Codex's own descriptions rather than a tidied "GPT-5.6 Sol", because these are
+// the only models whose catalogue Lemmary authors, and the picker renders
+// `id (name)`. Which of six near-identically-named models to bind is a real
+// question, and the sentence is the part that answers it.
+//
+// In Codex's order, most capable first.
+func ChatGPTModels() []Model {
+	return []Model{
+		{ID: "gpt-6-astra", Name: "Our most capable model for complex, demanding work"},
+		{ID: "gpt-5.6-sol", Name: "Reliable agentic workhorse for everyday tasks"},
+		{ID: "gpt-5.6-terra", Name: "Balanced agentic coding model for everyday work"},
+		{ID: DefaultExtractModel, Name: "Fast and affordable agentic coding model"},
+		{ID: "gpt-5.5", Name: "Proven previous-generation model for coding and general work"},
+		{ID: "gpt-5.4-mini", Name: "Small, fast, and cost-efficient model for simpler coding tasks"},
+	}
+}
+
 func ListModels(ctx context.Context, p Provider, purpose ModelPurpose, client *http.Client, logger *slog.Logger) ([]Model, error) {
+	// The one SDK whose catalogue is local. Answered before the checks below,
+	// which would otherwise fail it for having no API key -- it has a token
+	// instead -- and turn a working sign-in into an error banner in Settings.
+	if p.SDK == SDKChatGPT {
+		if purpose != PurposeLLM {
+			// CanEmbed and CanOCR already refuse those bindings; returning
+			// nothing keeps the picker honest if one is ever asked for anyway.
+			return nil, nil
+		}
+		return ChatGPTModels(), nil
+	}
+
 	// An SDK that neither chats nor embeds has no catalogue to list: Google
 	// Vision annotates without a model, and docling serves one pipeline.
 	// Returning nothing here rather than falling through is what keeps the

--- a/backend/internal/aiprovider/provider.go
+++ b/backend/internal/aiprovider/provider.go
@@ -16,19 +16,29 @@ type Provider struct {
 	Alias   string
 	BaseURL string
 	APIKey  string
+
+	// OAuth is the serialized token pair for the SDKs that sign in rather than
+	// take a pasted key -- today only SDKChatGPT. It is opaque here on purpose:
+	// aiprovider must not import internal/chatgpt, which needs these predicates
+	// itself. The shape is chatgpt.Token.
+	OAuth string
 }
 
 // Configured is whether this row can actually serve a request.
 //
-// What that takes differs by SDK: a credential for the hosted ones, an address
-// for the local sidecars, which have no account behind them. Every caller that
-// used to spell this as `p.APIKey != ""` now asks here instead -- otherwise a
-// working sidecar reads as unconfigured and disappears from the OCR picker,
-// the readiness check and the setup wizard's idea of a finished install.
+// What that takes differs by SDK: a credential for the hosted ones, a completed
+// sign-in for the ones that mint their own, an address for the local sidecars,
+// which have no account behind them. Every caller that used to spell this as
+// `p.APIKey != ""` now asks here instead -- otherwise a working sidecar reads
+// as unconfigured and disappears from the OCR picker, the readiness check and
+// the setup wizard's idea of a finished install.
 //
 // The record-level twin of ProviderSpec.Configured, which answers the same
 // question about the environment before any record exists.
 func (p Provider) Configured() bool {
+	if RequiresOAuth(p.SDK) {
+		return strings.TrimSpace(p.OAuth) != ""
+	}
 	if RequiresAPIKey(p.SDK) {
 		return strings.TrimSpace(p.APIKey) != ""
 	}
@@ -43,6 +53,7 @@ func FromRecord(record *core.Record) Provider {
 		Alias:   strings.TrimSpace(record.GetString("alias")),
 		BaseURL: NormalizeBaseURL(sdk, record.GetString("base_url")),
 		APIKey:  strings.TrimSpace(record.GetString("api_key")),
+		OAuth:   strings.TrimSpace(record.GetString(OAuthField)),
 	}
 }
 

--- a/backend/internal/aiprovider/sdk.go
+++ b/backend/internal/aiprovider/sdk.go
@@ -8,6 +8,25 @@ const (
 	SDKGoogleVision = "google_vision"
 	SDKMistral      = "mistral"
 
+	// SDKChatGPT reaches OpenAI's Codex backend with a ChatGPT subscription
+	// instead of a metered API key: the operator signs in once and the
+	// conversation is billed against the seat they already pay for.
+	//
+	// It is the only SDK whose credential is not a string an admin can paste.
+	// The device-code flow in internal/chatgpt mints an OAuth token pair, which
+	// lives in the row's `oauth` column and is refreshed in place -- hence
+	// RequiresOAuth beside RequiresAPIKey.
+	//
+	// It chats and nothing else. The Codex backend serves no /embeddings and
+	// reads no documents, so CanEmbed and CanOCR both refuse it and Deep
+	// Search's vectors and OCR keep whatever provider they had.
+	//
+	// Off unless AI_CHATGPT_LOGIN=1: the endpoints behind it are OpenAI's own
+	// first-party ones, undocumented and reserved for OpenAI's clients, so
+	// whether to point an account at them is the operator's call to make
+	// deliberately. See docs/chatgpt_login.md.
+	SDKChatGPT = "chatgpt"
+
 	// SDKLocal is an OpenAI-compatible embeddings endpoint the operator runs
 	// themselves -- text-embeddings-inference in the compose overlay, though
 	// anything that serves /v1/embeddings will do. It embeds and nothing else:
@@ -29,11 +48,11 @@ const (
 	CollectionName = "ai_providers"
 )
 
-var ValidSDKs = []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKLocal, SDKDocling}
+var ValidSDKs = []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKChatGPT, SDKLocal, SDKDocling}
 
 func ValidSDK(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKLocal, SDKDocling:
+	case SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKChatGPT, SDKLocal, SDKDocling:
 		return true
 	default:
 		return false
@@ -42,7 +61,7 @@ func ValidSDK(sdk string) bool {
 
 func IsLLM(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKOpenAI, SDKOpenRouter, SDKMistral:
+	case SDKOpenAI, SDKOpenRouter, SDKMistral, SDKChatGPT:
 		return true
 	default:
 		return false
@@ -65,16 +84,32 @@ func CanEmbed(sdk string) bool {
 	}
 }
 
-// CanOCR reports whether an SDK can read a document. Everything but SDKLocal
-// can: google_vision and docling are engines OCR exists for, and the three LLM
-// SDKs send the file to a model. A local embeddings endpoint has no way to do
-// it at all.
+// CanOCR reports whether an SDK can read a document. google_vision and docling
+// are engines OCR exists for, and the metered LLM SDKs send the file to a
+// model. A local embeddings endpoint has no way to do it at all, and the Codex
+// backend behind SDKChatGPT accepts no attachments.
 //
 // Without this, ValidSDK would let OCR_SDK=local through -- it is a valid SDK,
 // just not for this job -- and the failure would only appear on the first
 // document uploaded.
 func CanOCR(sdk string) bool {
-	return strings.TrimSpace(sdk) != SDKLocal
+	switch strings.TrimSpace(sdk) {
+	case SDKLocal, SDKChatGPT:
+		return false
+	default:
+		return true
+	}
+}
+
+// RequiresOAuth reports whether an SDK is reached with a token this app minted
+// rather than one an admin typed.
+//
+// Only SDKChatGPT is. It is asked separately from RequiresAPIKey because the
+// two answers differ everywhere it matters: the create handler must not demand
+// an api_key, the Settings form must show a sign-in button instead of a
+// password field, and Configured has to look at a different column.
+func RequiresOAuth(sdk string) bool {
+	return strings.TrimSpace(sdk) == SDKChatGPT
 }
 
 // RequiresAPIKey reports whether an SDK is reached with a credential.
@@ -92,7 +127,7 @@ func CanOCR(sdk string) bool {
 // key.
 func RequiresAPIKey(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKLocal, SDKDocling:
+	case SDKLocal, SDKDocling, SDKChatGPT:
 		return false
 	default:
 		return true
@@ -161,6 +196,16 @@ func LLMSDKs() []string       { return sdksWhere(IsLLM) }
 func EmbeddingSDKs() []string { return sdksWhere(CanEmbed) }
 func OCRSDKs() []string       { return sdksWhere(CanOCR) }
 
+// EnvLLMSDKs names the SDKs AI_SDK accepts, which is LLMSDKs minus the ones
+// whose credential cannot be written down.
+//
+// The environment can carry a key. It cannot carry a sign-in: a chatgpt
+// provider is created and signed in to from Settings, so naming it here would
+// seed a provider row nobody can complete from the file that named it.
+func EnvLLMSDKs() []string {
+	return sdksWhere(func(sdk string) bool { return IsLLM(sdk) && !RequiresOAuth(sdk) })
+}
+
 // ModellessOCRSDKs names the SDKs that read a document without a model, for the
 // error messages that have to list them. Derived rather than written out, so it
 // cannot drift from RequiresOCRModel the way the old message naming only
@@ -183,6 +228,10 @@ func DefaultBaseURL(sdk string) string {
 		return "https://openrouter.ai/api/v1"
 	case SDKMistral:
 		return "https://api.mistral.ai/v1"
+	// Not a /v1 root: the Codex backend serves one endpoint, /responses, which
+	// the chatgpt middleware rewrites the SDK's /chat/completions into.
+	case SDKChatGPT:
+		return "https://chatgpt.com/backend-api/codex"
 	case SDKLocal:
 		// The service name in docker-compose.embeddings.yml, so the default is
 		// already right for the overlay and inert for anyone not running it.
@@ -207,6 +256,8 @@ func DefaultAlias(sdk string) string {
 		return "Google Cloud Vision"
 	case SDKMistral:
 		return "Mistral"
+	case SDKChatGPT:
+		return "ChatGPT subscription"
 	case SDKLocal:
 		return "Local embeddings"
 	case SDKDocling:

--- a/backend/internal/aiprovider/sdk.go
+++ b/backend/internal/aiprovider/sdk.go
@@ -17,9 +17,12 @@ const (
 	// lives in the row's `oauth` column and is refreshed in place -- hence
 	// RequiresOAuth beside RequiresAPIKey.
 	//
-	// It chats and nothing else. The Codex backend serves no /embeddings and
-	// reads no documents, so CanEmbed and CanOCR both refuse it and Deep
-	// Search's vectors and OCR keep whatever provider they had.
+	// It chats and reads documents; it does not embed. The Codex backend
+	// serves no /embeddings, so CanEmbed refuses it and Deep Search's vectors
+	// keep whatever provider they had. Its models do take file and image input,
+	// so OCR runs on the seat like any other LLM OCR provider -- see
+	// internal/ocr.NewLLMProvider and the input_file/input_image parts in
+	// internal/chatgpt.messageContent.
 	//
 	// Off unless AI_CHATGPT_LOGIN=1: the endpoints behind it are OpenAI's own
 	// first-party ones, undocumented and reserved for OpenAI's clients, so
@@ -86,16 +89,16 @@ func CanEmbed(sdk string) bool {
 }
 
 // CanOCR reports whether an SDK can read a document. google_vision and docling
-// are engines OCR exists for, and the metered LLM SDKs send the file to a
-// model. A local embeddings endpoint has no way to do it at all, and the Codex
-// backend behind SDKChatGPT accepts no attachments.
+// are engines OCR exists for, and every LLM SDK sends the file to a model --
+// SDKChatGPT included, since its models take the same file and image input the
+// metered ones do. A local embeddings endpoint has no way to do it at all.
 //
 // Without this, ValidSDK would let OCR_SDK=local through -- it is a valid SDK,
 // just not for this job -- and the failure would only appear on the first
 // document uploaded.
 func CanOCR(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKLocalEmbeddings, SDKChatGPT:
+	case SDKLocalEmbeddings:
 		return false
 	default:
 		return true
@@ -197,14 +200,20 @@ func LLMSDKs() []string       { return sdksWhere(IsLLM) }
 func EmbeddingSDKs() []string { return sdksWhere(CanEmbed) }
 func OCRSDKs() []string       { return sdksWhere(CanOCR) }
 
-// EnvLLMSDKs names the SDKs AI_SDK accepts, which is LLMSDKs minus the ones
-// whose credential cannot be written down.
+// EnvLLMSDKs and EnvOCRSDKs name the SDKs AI_SDK and OCR_SDK accept, which is
+// LLMSDKs and OCRSDKs minus the ones whose credential cannot be written down.
 //
 // The environment can carry a key. It cannot carry a sign-in: a chatgpt
-// provider is created and signed in to from Settings, so naming it here would
-// seed a provider row nobody can complete from the file that named it.
+// provider is created and signed in to from Settings, so naming it in either
+// variable would seed a provider row nobody can complete from the file that
+// named it. That is true of OCR_SDK as much as AI_SDK, even though the SDK can
+// now do the job -- the obstacle is the credential, not the capability.
 func EnvLLMSDKs() []string {
 	return sdksWhere(func(sdk string) bool { return IsLLM(sdk) && !RequiresOAuth(sdk) })
+}
+
+func EnvOCRSDKs() []string {
+	return sdksWhere(func(sdk string) bool { return CanOCR(sdk) && !RequiresOAuth(sdk) })
 }
 
 // ModellessOCRSDKs names the SDKs that read a document without a model, for the

--- a/backend/internal/aiprovider/sdk_test.go
+++ b/backend/internal/aiprovider/sdk_test.go
@@ -186,7 +186,7 @@ func TestSDKListsMatchTheirPredicates(t *testing.T) {
 		got  []string
 		want []string
 	}{
-		"llm":       {LLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral}},
+		"llm":       {LLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKChatGPT}},
 		"embedding": {EmbeddingSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKLocal}},
 		"ocr":       {OCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKDocling}},
 	}

--- a/backend/internal/aiprovider/sdk_test.go
+++ b/backend/internal/aiprovider/sdk_test.go
@@ -188,7 +188,11 @@ func TestSDKListsMatchTheirPredicates(t *testing.T) {
 	}{
 		"llm":       {LLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKChatGPT}},
 		"embedding": {EmbeddingSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKLocalEmbeddings}},
-		"ocr":       {OCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKDocling}},
+		"ocr":       {OCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKChatGPT, SDKDocling}},
+		// The environment lists are the same minus chatgpt, whose credential
+		// is minted by signing in and so cannot be seeded from a file.
+		"env llm": {EnvLLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral}},
+		"env ocr": {EnvOCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKDocling}},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -76,6 +76,11 @@ func Register(
 			g.PATCH("/providers/{id}", bindAdmin(handlePatchProvider(app, rt)))
 			g.DELETE("/providers/{id}", bindAdmin(handleDeleteProvider(app, rt)))
 			g.GET("/providers/{id}/models", bindAdmin(handleListProviderModels(app)))
+			// Device-code sign-in for the chatgpt SDK. Two calls rather than
+			// one blocking handler: the browser owns the polling interval.
+			g.POST("/providers/{id}/chatgpt/device", bindAdmin(handleChatGPTDeviceStart(app, rt)))
+			g.POST("/providers/{id}/chatgpt/device/poll", bindAdmin(handleChatGPTDevicePoll(app, rt)))
+			g.DELETE("/providers/{id}/chatgpt", bindAdmin(handleChatGPTSignOut(app, rt)))
 			g.POST("/duplicates/scan", bindAdmin(handlePostDuplicatesScan(app, rt)))
 			g.POST("/taxonomy/prune", bindAdmin(handlePostTaxonomyPrune(app)))
 			g.POST("/import/ngx", bindAuth(handlePostImportNgx(app)))

--- a/backend/internal/appapi/chatgpt.go
+++ b/backend/internal/appapi/chatgpt.go
@@ -60,6 +60,13 @@ func lockLogin(providerID string) func() {
 	return mu.Unlock
 }
 
+// chatgptClient is the auth client the sign-in handlers use. It reads the
+// endpoints rather than closing over them, so the end-to-end suite's stub host
+// is picked up by a handler registered before it was installed.
+func chatgptClient() *chatgpt.Client {
+	return chatgpt.NewClient(nil).WithEndpoints(chatgpt.AuthEndpoints())
+}
+
 func chatgptProvider(app core.App, e *core.RequestEvent) (*core.Record, error) {
 	id := strings.TrimSpace(e.Request.PathValue("id"))
 	record, err := app.FindRecordById(aiprovider.CollectionName, id)
@@ -87,7 +94,7 @@ func handleChatGPTDeviceStart(app core.App, rt *config.Runtime) func(*core.Reque
 			return err
 		}
 
-		pending, startErr := chatgpt.NewClient(nil).StartDeviceLogin(e.Request.Context())
+		pending, startErr := chatgptClient().StartDeviceLogin(e.Request.Context())
 		if startErr != nil {
 			return writeChatGPTAuthError(e, app, startErr)
 		}
@@ -143,7 +150,7 @@ func handleChatGPTDevicePoll(app core.App, rt *config.Runtime) func(*core.Reques
 		}
 		pending := value.(*chatgpt.Pending)
 
-		tok, pollErr := chatgpt.NewClient(nil).PollDeviceLogin(e.Request.Context(), pending)
+		tok, pollErr := chatgptClient().PollDeviceLogin(e.Request.Context(), pending)
 		switch {
 		case errors.Is(pollErr, chatgpt.ErrAuthPending):
 			return writeJSON(e, http.StatusOK, map[string]any{"status": "pending"})

--- a/backend/internal/appapi/chatgpt.go
+++ b/backend/internal/appapi/chatgpt.go
@@ -1,0 +1,178 @@
+package appapi
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/chatgpt"
+	"lemmary/backend/internal/config"
+)
+
+// Shown when the chatgpt SDK is used on an instance that has not opted in.
+const chatgptDisabledMessage = "Signing in with a ChatGPT subscription is not enabled on this instance. Set AI_CHATGPT_LOGIN=1 to turn it on."
+
+// refuseWhenChatGPTDisabled guards every route that only makes sense for a
+// signed-in ChatGPT provider, and every write that would create one.
+//
+// The twin of refuseWhenManaged, and for the same reason: hiding the SDK in
+// Settings is a courtesy, and these endpoints stay reachable with any admin
+// session.
+func refuseWhenChatGPTDisabled(e *core.RequestEvent, rt *config.Runtime) (bool, error) {
+	if rt.ChatGPTLogin() {
+		return false, nil
+	}
+	return true, writeError(e, http.StatusForbidden, chatgptDisabledMessage)
+}
+
+// pendingLogins holds the device-code logins waiting on a browser.
+//
+// In memory, keyed by provider, and never sent to the client: the device auth
+// id is the half that completes a sign-in, so handing it out would let anyone
+// who saw one finish somebody else's login. The browser gets the user code and
+// the URL, which are useless without an approval.
+//
+// A restart drops them. That is correct rather than a limitation -- the code is
+// good for fifteen minutes and the operator is standing right there.
+var pendingLogins sync.Map // provider id -> *chatgpt.Pending
+
+func chatgptProvider(app core.App, e *core.RequestEvent) (*core.Record, error) {
+	id := strings.TrimSpace(e.Request.PathValue("id"))
+	record, err := app.FindRecordById(aiprovider.CollectionName, id)
+	if err != nil {
+		return nil, writeError(e, http.StatusNotFound, "Provider not found.")
+	}
+	if record.GetString("sdk") != aiprovider.SDKChatGPT {
+		return nil, writeError(e, http.StatusBadRequest, "This provider does not sign in with ChatGPT.")
+	}
+	return record, nil
+}
+
+// handleChatGPTDeviceStart asks OpenAI for a user code and hands the operator
+// the code and the URL to type it into.
+func handleChatGPTDeviceStart(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		if refused, err := refuseWhenManaged(e, rt); refused {
+			return err
+		}
+		if refused, err := refuseWhenChatGPTDisabled(e, rt); refused {
+			return err
+		}
+		record, err := chatgptProvider(app, e)
+		if record == nil {
+			return err
+		}
+
+		pending, startErr := chatgpt.NewClient(nil).StartDeviceLogin(e.Request.Context())
+		if startErr != nil {
+			return writeChatGPTAuthError(e, app, startErr)
+		}
+		pendingLogins.Store(record.Id, pending)
+
+		return writeJSON(e, http.StatusOK, map[string]any{
+			"user_code":        pending.UserCode,
+			"verification_url": pending.VerificationURL,
+			"interval_seconds": int(pending.Interval / time.Second),
+			"expires_in":       int(time.Until(pending.ExpiresAt) / time.Second),
+		})
+	}
+}
+
+// handleChatGPTDevicePoll checks once whether the operator has approved, and
+// stores the token if they have.
+//
+// One attempt per request so the browser owns the interval; a handler that
+// blocked for the full fifteen minutes would hold a connection open and give
+// the operator no way to cancel.
+func handleChatGPTDevicePoll(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		if refused, err := refuseWhenManaged(e, rt); refused {
+			return err
+		}
+		if refused, err := refuseWhenChatGPTDisabled(e, rt); refused {
+			return err
+		}
+		record, err := chatgptProvider(app, e)
+		if record == nil {
+			return err
+		}
+
+		value, ok := pendingLogins.Load(record.Id)
+		if !ok {
+			return writeJSON(e, http.StatusOK, map[string]any{"status": "expired"})
+		}
+		pending := value.(*chatgpt.Pending)
+
+		tok, pollErr := chatgpt.NewClient(nil).PollDeviceLogin(e.Request.Context(), pending)
+		switch {
+		case errors.Is(pollErr, chatgpt.ErrAuthPending):
+			return writeJSON(e, http.StatusOK, map[string]any{"status": "pending"})
+		case errors.Is(pollErr, chatgpt.ErrAuthExpired):
+			pendingLogins.Delete(record.Id)
+			return writeJSON(e, http.StatusOK, map[string]any{"status": "expired"})
+		case pollErr != nil:
+			pendingLogins.Delete(record.Id)
+			return writeChatGPTAuthError(e, app, pollErr)
+		}
+		pendingLogins.Delete(record.Id)
+
+		raw, err := tok.Marshal()
+		if err != nil {
+			return writeError(e, http.StatusInternalServerError, "Failed to store the ChatGPT sign-in.")
+		}
+		record.Set(aiprovider.OAuthField, raw)
+		if err := app.Save(record); err != nil {
+			return writeError(e, http.StatusInternalServerError, "Failed to store the ChatGPT sign-in.")
+		}
+		// Drop any source built from the previous token, so the next request
+		// picks the new one up rather than refreshing a credential this
+		// sign-in has just replaced.
+		chatgpt.Forget(record.Id)
+
+		return writeJSON(e, http.StatusOK, map[string]any{
+			"status":   "complete",
+			"provider": providerJSON(aiprovider.FromRecord(record)),
+		})
+	}
+}
+
+// handleChatGPTSignOut clears the stored token. The provider row stays: an
+// operator signing out usually means signing in as somebody else.
+//
+// Deliberately not behind refuseWhenChatGPTDisabled. Turning the flag off is
+// exactly when an operator most wants the stored token gone, and a sign-out
+// they cannot perform would leave it sitting in the row.
+func handleChatGPTSignOut(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		if refused, err := refuseWhenManaged(e, rt); refused {
+			return err
+		}
+		record, err := chatgptProvider(app, e)
+		if record == nil {
+			return err
+		}
+		pendingLogins.Delete(record.Id)
+		record.Set(aiprovider.OAuthField, "")
+		if err := app.Save(record); err != nil {
+			return writeError(e, http.StatusInternalServerError, "Failed to sign out.")
+		}
+		chatgpt.Forget(record.Id)
+		return writeJSON(e, http.StatusOK, providerJSON(aiprovider.FromRecord(record)))
+	}
+}
+
+// writeChatGPTAuthError passes OpenAI's refusal through in words an admin can
+// act on. The disabled-device-code case gets its own status because it is the
+// first thing most operators hit and the fix is a setting, not a retry.
+func writeChatGPTAuthError(e *core.RequestEvent, app core.App, err error) error {
+	if errors.Is(err, chatgpt.ErrDeviceAuthDisabled) {
+		return writeError(e, http.StatusConflict, chatgpt.ErrDeviceAuthDisabled.Error())
+	}
+	app.Logger().Warn("chatgpt device sign-in failed", "error", err)
+	return writeError(e, http.StatusBadGateway, "ChatGPT sign-in failed: "+err.Error())
+}

--- a/backend/internal/appapi/chatgpt.go
+++ b/backend/internal/appapi/chatgpt.go
@@ -41,6 +41,25 @@ func refuseWhenChatGPTDisabled(e *core.RequestEvent, rt *config.Runtime) (bool, 
 // good for fifteen minutes and the operator is standing right there.
 var pendingLogins sync.Map // provider id -> *chatgpt.Pending
 
+// loginLocks serializes the poll-exchange-save sequence per provider.
+//
+// The authorization code a poll returns is single-use. Two polls that overlap
+// -- the browser's interval is fixed and a slow round trip is all it takes --
+// would both read the same pending login, and the second exchange would be
+// refused for a login that had in fact just succeeded. One at a time, and the
+// one that arrives second finds the sign-in already stored.
+//
+// Never pruned: an entry is one mutex per chatgpt provider row this process has
+// polled, which is a handful.
+var loginLocks sync.Map // provider id -> *sync.Mutex
+
+func lockLogin(providerID string) func() {
+	value, _ := loginLocks.LoadOrStore(providerID, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
 func chatgptProvider(app core.App, e *core.RequestEvent) (*core.Record, error) {
 	id := strings.TrimSpace(e.Request.PathValue("id"))
 	record, err := app.FindRecordById(aiprovider.CollectionName, id)
@@ -102,8 +121,24 @@ func handleChatGPTDevicePoll(app core.App, rt *config.Runtime) func(*core.Reques
 			return err
 		}
 
+		unlock := lockLogin(record.Id)
+		defer unlock()
+
+		// Read after the lock, not before: a poll that queued behind another
+		// one is asking about a login that may already be finished.
 		value, ok := pendingLogins.Load(record.Id)
 		if !ok {
+			// A poll whose turn came after the login completed. The token is
+			// stored and the row is signed in, so this is that same success --
+			// reporting it as expired, or as the gateway error the consumed
+			// code would produce, would put an error on a row that is fine.
+			if fresh, findErr := app.FindRecordById(aiprovider.CollectionName, record.Id); findErr == nil &&
+				strings.TrimSpace(fresh.GetString(aiprovider.OAuthField)) != "" {
+				return writeJSON(e, http.StatusOK, map[string]any{
+					"status":   "complete",
+					"provider": providerJSON(aiprovider.FromRecord(fresh)),
+				})
+			}
 			return writeJSON(e, http.StatusOK, map[string]any{"status": "expired"})
 		}
 		pending := value.(*chatgpt.Pending)
@@ -125,14 +160,16 @@ func handleChatGPTDevicePoll(app core.App, rt *config.Runtime) func(*core.Reques
 		if err != nil {
 			return writeError(e, http.StatusInternalServerError, "Failed to store the ChatGPT sign-in.")
 		}
+		// Retired before the write, not after. Saving fires the provider hook,
+		// which rebuilds the AI clients and registers a source for the new
+		// token; forgetting afterwards would unregister the very source those
+		// clients hold, and the next reload would build a second one against
+		// the same rotating refresh token.
+		chatgpt.Forget(record.Id)
 		record.Set(aiprovider.OAuthField, raw)
 		if err := app.Save(record); err != nil {
 			return writeError(e, http.StatusInternalServerError, "Failed to store the ChatGPT sign-in.")
 		}
-		// Drop any source built from the previous token, so the next request
-		// picks the new one up rather than refreshing a credential this
-		// sign-in has just replaced.
-		chatgpt.Forget(record.Id)
 
 		return writeJSON(e, http.StatusOK, map[string]any{
 			"status":   "complete",
@@ -157,11 +194,16 @@ func handleChatGPTSignOut(app core.App, rt *config.Runtime) func(*core.RequestEv
 			return err
 		}
 		pendingLogins.Delete(record.Id)
+		// Before the write, so a refresh already on the wire cannot come back
+		// and store its rotated pair -- the update hook would read that as a
+		// sign-in and rebuild signed-in clients, undoing this. If the save then
+		// fails the row keeps its token but this process serves nothing from
+		// it, which is the safe direction for a sign-out.
+		chatgpt.Forget(record.Id)
 		record.Set(aiprovider.OAuthField, "")
 		if err := app.Save(record); err != nil {
 			return writeError(e, http.StatusInternalServerError, "Failed to sign out.")
 		}
-		chatgpt.Forget(record.Id)
 		return writeJSON(e, http.StatusOK, providerJSON(aiprovider.FromRecord(record)))
 	}
 }

--- a/backend/internal/appapi/chatgpt_test.go
+++ b/backend/internal/appapi/chatgpt_test.go
@@ -1,0 +1,55 @@
+package appapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/config"
+)
+
+func requestEvent(t *testing.T) (*core.RequestEvent, *httptest.ResponseRecorder) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	e := &core.RequestEvent{}
+	e.Response = rec
+	e.Request = httptest.NewRequest(http.MethodPost, "/api/app/providers/p1/chatgpt/device", nil)
+	return e, rec
+}
+
+// Hiding the SDK in Settings is a courtesy; these endpoints stay reachable with
+// any admin session, so the flag has to be enforced here or it is not enforced
+// at all. Same reasoning as refuseWhenManaged.
+func TestChatGPTEndpointsAreRefusedWhenTheFlagIsOff(t *testing.T) {
+	t.Parallel()
+	e, rec := requestEvent(t)
+	refused, err := refuseWhenChatGPTDisabled(e, config.NewRuntime(config.AIEnv{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !refused {
+		t.Fatal("a disabled instance served the ChatGPT sign-in")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	// The fix is a setting, not a retry, so the message has to name it.
+	if !strings.Contains(rec.Body.String(), "AI_CHATGPT_LOGIN") {
+		t.Errorf("the refusal does not say how to turn it on: %s", rec.Body.String())
+	}
+}
+
+func TestChatGPTEndpointsAreServedWhenTheFlagIsOn(t *testing.T) {
+	t.Parallel()
+	e, _ := requestEvent(t)
+	refused, err := refuseWhenChatGPTDisabled(e, config.NewRuntime(config.AIEnv{ChatGPTLogin: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refused {
+		t.Fatal("an instance that opted in still refused the sign-in")
+	}
+}

--- a/backend/internal/appapi/chatgpt_test.go
+++ b/backend/internal/appapi/chatgpt_test.go
@@ -4,7 +4,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pocketbase/pocketbase/core"
 
@@ -51,5 +54,57 @@ func TestChatGPTEndpointsAreServedWhenTheFlagIsOn(t *testing.T) {
 	}
 	if refused {
 		t.Fatal("an instance that opted in still refused the sign-in")
+	}
+}
+
+// The authorization code a poll returns is single-use, so the poll-exchange-
+// save sequence has to run one at a time per provider: two overlapping polls
+// would both read the same pending login, and the second exchange would be
+// refused for a sign-in that had just succeeded.
+//
+// The handler itself is not exercised here -- it wants a live PocketBase, which
+// nothing in this tree stands up -- so this covers the lock the handler holds.
+func TestLoginPollsAreSerializedPerProvider(t *testing.T) {
+	const id = "p-lock"
+	var inside, overlaps atomic.Int32
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := lockLogin(id)
+			defer unlock()
+			if inside.Add(1) > 1 {
+				overlaps.Add(1)
+			}
+			// Long enough that an unserialized run overlaps reliably.
+			time.Sleep(2 * time.Millisecond)
+			inside.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if n := overlaps.Load(); n != 0 {
+		t.Fatalf("%d polls ran concurrently for one provider", n)
+	}
+}
+
+// Per provider, not globally: one operator signing in must not stall another's.
+func TestLoginPollsOnDifferentProvidersDoNotBlockEachOther(t *testing.T) {
+	firstHeld := lockLogin("p-lock-a")
+	defer firstHeld()
+
+	done := make(chan struct{})
+	go func() {
+		unlock := lockLogin("p-lock-b")
+		unlock()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a poll on one provider blocked a poll on another")
 	}
 }

--- a/backend/internal/appapi/meta.go
+++ b/backend/internal/appapi/meta.go
@@ -73,6 +73,10 @@ func handleGetMeta(app core.App, rt *config.Runtime) func(*core.RequestEvent) er
 			// Public: the SPA needs both before anyone has signed in.
 			"passkeys":   passkeyLoginAvailable(app, e),
 			"ai_managed": rt.Managed(),
+			// Whether Settings offers the ChatGPT sign-in at all. Public for
+			// the same reason ai_managed is: the SPA reads meta before it can
+			// know whether the session is an admin's.
+			"chatgpt_login": rt.ChatGPTLogin(),
 		})
 	}
 }

--- a/backend/internal/appapi/providers.go
+++ b/backend/internal/appapi/providers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/chatgpt"
 	"lemmary/backend/internal/config"
 )
 
@@ -17,6 +18,14 @@ type providerResponse struct {
 	Alias     string `json:"alias"`
 	BaseURL   string `json:"base_url"`
 	APIKeySet bool   `json:"api_key_set"`
+
+	// SignedIn is api_key_set's counterpart for the SDKs that sign in. The
+	// token itself never leaves the server, exactly as the key never does;
+	// the account and plan are here so Settings can say whose subscription is
+	// about to be spent without decoding a JWT in the browser.
+	SignedIn bool   `json:"signed_in"`
+	Account  string `json:"account,omitempty"`
+	Plan     string `json:"plan,omitempty"`
 }
 
 type providerWriteRequest struct {
@@ -26,23 +35,60 @@ type providerWriteRequest struct {
 	APIKey  *string `json:"api_key"`
 }
 
-// invalidSDKMessage names every SDK the API accepts.
+// invalidSDKMessage names every SDK this instance accepts.
 //
 // Built from the list rather than written out: this sentence was a literal in
 // two handlers, and both still said "openai, openrouter, google_vision, or
 // mistral" long enough for a third and fourth SDK to be a real prospect.
-func invalidSDKMessage() string {
-	return "sdk must be one of " + strings.Join(aiprovider.ValidSDKs, ", ") + "."
+//
+// It takes the runtime because one SDK is conditional. Naming chatgpt on an
+// instance that will refuse it would send an admin looking for a typo in a
+// value that was never going to work.
+func invalidSDKMessage(rt *config.Runtime) string {
+	return "sdk must be one of " + strings.Join(availableSDKs(rt), ", ") + "."
+}
+
+func availableSDKs(rt *config.Runtime) []string {
+	out := make([]string, 0, len(aiprovider.ValidSDKs))
+	for _, sdk := range aiprovider.ValidSDKs {
+		if sdk == aiprovider.SDKChatGPT && !rt.ChatGPTLogin() {
+			continue
+		}
+		out = append(out, sdk)
+	}
+	return out
 }
 
 func providerJSON(p aiprovider.Provider) providerResponse {
-	return providerResponse{
+	out := providerResponse{
 		ID:        p.ID,
 		SDK:       p.SDK,
 		Alias:     p.Alias,
 		BaseURL:   p.BaseURL,
 		APIKeySet: p.APIKey != "",
+		SignedIn:  p.OAuth != "",
 	}
+	if out.SignedIn {
+		// A token that will not parse is a row nobody can use, so it reads as
+		// signed out rather than as a signed-in account with no name.
+		tok, err := chatgpt.ParseToken(p.OAuth)
+		if err != nil || !tok.Valid() {
+			out.SignedIn = false
+		} else {
+			out.Account = firstNonBlank(tok.Email, tok.AccountID)
+			out.Plan = tok.Plan
+		}
+	}
+	return out
+}
+
+func firstNonBlank(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func handleListProviders(app core.App) func(*core.RequestEvent) error {
@@ -76,7 +122,12 @@ func handleCreateProvider(app core.App, rt *config.Runtime) func(*core.RequestEv
 			sdk = strings.TrimSpace(*req.SDK)
 		}
 		if !aiprovider.ValidSDK(sdk) {
-			return writeError(e, http.StatusBadRequest, invalidSDKMessage())
+			return writeError(e, http.StatusBadRequest, invalidSDKMessage(rt))
+		}
+		if sdk == aiprovider.SDKChatGPT {
+			if refused, err := refuseWhenChatGPTDisabled(e, rt); refused {
+				return err
+			}
 		}
 		alias := ""
 		if req.Alias != nil {
@@ -180,7 +231,12 @@ func handlePatchProvider(app core.App, rt *config.Runtime) func(*core.RequestEve
 		if req.SDK != nil {
 			sdk = strings.TrimSpace(*req.SDK)
 			if !aiprovider.ValidSDK(sdk) {
-				return writeError(e, http.StatusBadRequest, invalidSDKMessage())
+				return writeError(e, http.StatusBadRequest, invalidSDKMessage(rt))
+			}
+			if sdk == aiprovider.SDKChatGPT {
+				if refused, err := refuseWhenChatGPTDisabled(e, rt); refused {
+					return err
+				}
 			}
 			if !aiprovider.IsLLM(sdk) || !aiprovider.CanEmbed(sdk) || !aiprovider.CanOCR(sdk) {
 				// A failed settings lookup must not skip these guards:

--- a/backend/internal/appapi/providers_test.go
+++ b/backend/internal/appapi/providers_test.go
@@ -125,8 +125,27 @@ func TestSearchHelperBindingGuardsTheSDKSwitch(t *testing.T) {
 // something notices when the list grows again.
 func TestInvalidSDKMessageNamesEverySDK(t *testing.T) {
 	t.Parallel()
-	message := invalidSDKMessage()
+	message := invalidSDKMessage(config.NewRuntime(config.AIEnv{ChatGPTLogin: true}))
 	for _, sdk := range aiprovider.ValidSDKs {
+		if !strings.Contains(message, sdk) {
+			t.Errorf("%q does not name %s", message, sdk)
+		}
+	}
+}
+
+// ...and it must not name the one SDK this instance would refuse. An admin sent
+// looking for a typo in a value that was never going to work is worse served
+// than one who never saw it offered.
+func TestInvalidSDKMessageOmitsChatGPTWhenDisabled(t *testing.T) {
+	t.Parallel()
+	message := invalidSDKMessage(config.NewRuntime(config.AIEnv{}))
+	if strings.Contains(message, aiprovider.SDKChatGPT) {
+		t.Errorf("%q names chatgpt on an instance that refuses it", message)
+	}
+	for _, sdk := range aiprovider.ValidSDKs {
+		if sdk == aiprovider.SDKChatGPT {
+			continue
+		}
 		if !strings.Contains(message, sdk) {
 			t.Errorf("%q does not name %s", message, sdk)
 		}

--- a/backend/internal/appapi/settings.go
+++ b/backend/internal/appapi/settings.go
@@ -343,21 +343,53 @@ func validateProviderID(app core.App, id string, need providerNeed) error {
 	if err != nil || p == nil {
 		return errInvalid("unknown provider")
 	}
+	return providerServes(*p, need)
+}
+
+// providerServes is the SDK half of the check above, split out so it can be
+// tested without a database -- the messages are the part that keeps going
+// stale.
+//
+// The three lists are derived, not written out. Spelled by hand they went stale
+// twice over: the OCR sentence still named four SDKs after docling shipped, and
+// would have gone on omitting chatgpt now that it reads documents -- so an
+// admin who believed either message would not have tried the provider that
+// works. Same reasoning as aiprovider.sdksWhere.
+func providerServes(p aiprovider.Provider, need providerNeed) error {
 	switch need {
 	case needLLM:
 		if !aiprovider.IsLLM(p.SDK) {
-			return errInvalid("extraction, chat, and search require an openai, openrouter, or mistral provider")
+			return errInvalid("extraction, chat, and search require " + oneOf(aiprovider.LLMSDKs()) + " provider")
 		}
 	case needEmbedding:
 		if !aiprovider.CanEmbed(p.SDK) {
-			return errInvalid("embeddings require an openai, openrouter, mistral, or local provider")
+			return errInvalid("embeddings require " + oneOf(aiprovider.EmbeddingSDKs()) + " provider")
 		}
 	case needOCR:
 		if !aiprovider.CanOCR(p.SDK) {
-			return errInvalid("OCR requires an openai, openrouter, mistral, or google_vision provider")
+			return errInvalid("OCR requires " + oneOf(aiprovider.OCRSDKs()) + " provider")
 		}
 	}
 	return nil
+}
+
+// oneOf renders a list of SDK names as "an openai, openrouter, or mistral",
+// which is how these sentences have always read.
+func oneOf(sdks []string) string {
+	article := "a"
+	if len(sdks) > 0 && strings.ContainsRune("aeiou", rune(sdks[0][0])) {
+		article = "an"
+	}
+	switch len(sdks) {
+	case 0:
+		return "a configured"
+	case 1:
+		return article + " " + sdks[0]
+	case 2:
+		return article + " " + sdks[0] + " or " + sdks[1]
+	default:
+		return article + " " + strings.Join(sdks[:len(sdks)-1], ", ") + ", or " + sdks[len(sdks)-1]
+	}
 }
 
 type settingsError string

--- a/backend/internal/appapi/settings_test.go
+++ b/backend/internal/appapi/settings_test.go
@@ -1,10 +1,12 @@
 package appapi
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
 
+	"lemmary/backend/internal/aiprovider"
 	"lemmary/backend/internal/config"
 )
 
@@ -130,5 +132,84 @@ func TestSettingsResponseExposesTheEmbeddingBinding(t *testing.T) {
 	}
 	if got.EmbeddingDims != 1536 {
 		t.Fatalf("embedding_dims = %d, want 1536", got.EmbeddingDims)
+	}
+}
+
+// The three binding messages are derived from the capability predicates, so a
+// new SDK cannot leave a sentence naming an old list. The OCR one had already
+// gone stale once -- it named four SDKs after docling shipped -- which is what
+// these pin.
+func TestBindingRefusalsNameEverySDKThatCouldServe(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		need    providerNeed
+		refused string
+		serves  []string
+		mustSay []string
+	}{
+		// refused is a real SDK this binding turns down, which is how the
+		// message is reached. CanOCR answers true for anything it does not know,
+		// so an invented name would not do -- and would not be reachable anyway,
+		// since ValidSDK gates what a row may hold.
+		{"llm", needLLM, aiprovider.SDKGoogleVision, aiprovider.LLMSDKs(),
+			[]string{aiprovider.SDKChatGPT}},
+		{"embedding", needEmbedding, aiprovider.SDKGoogleVision, aiprovider.EmbeddingSDKs(),
+			[]string{aiprovider.SDKLocalEmbeddings}},
+		{"ocr", needOCR, aiprovider.SDKLocalEmbeddings, aiprovider.OCRSDKs(),
+			[]string{aiprovider.SDKDocling, aiprovider.SDKChatGPT}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := providerServes(aiprovider.Provider{SDK: tc.refused}, tc.need)
+			if err == nil {
+				t.Fatalf("%s was accepted for this binding", tc.refused)
+			}
+			for _, sdk := range tc.serves {
+				if !strings.Contains(err.Error(), sdk) {
+					t.Errorf("message omits %s, which can serve this binding: %v", sdk, err)
+				}
+			}
+			// Named explicitly too, so the derivation cannot quietly stop
+			// producing the SDKs these messages used to leave out.
+			for _, sdk := range tc.mustSay {
+				if !strings.Contains(err.Error(), sdk) {
+					t.Errorf("message omits %s: %v", sdk, err)
+				}
+			}
+		})
+	}
+
+	// And every SDK that can serve is actually accepted, so the lists and the
+	// predicates cannot disagree.
+	for _, sdk := range aiprovider.OCRSDKs() {
+		if err := providerServes(aiprovider.Provider{SDK: sdk}, needOCR); err != nil {
+			t.Errorf("OCR refused %s, which OCRSDKs names: %v", sdk, err)
+		}
+	}
+	if err := providerServes(aiprovider.Provider{SDK: aiprovider.SDKLocalEmbeddings}, needOCR); err == nil {
+		t.Error("OCR accepted the embeddings-only SDK")
+	}
+	if err := providerServes(aiprovider.Provider{SDK: aiprovider.SDKChatGPT}, needEmbedding); err == nil {
+		t.Error("embeddings accepted chatgpt, whose endpoint has none")
+	}
+}
+
+func TestOneOfReadsAsASentence(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		sdks []string
+		want string
+	}{
+		{nil, "a configured"},
+		{[]string{"openai"}, "an openai"},
+		{[]string{"openai", "mistral"}, "an openai or mistral"},
+		{[]string{"openai", "mistral", "local"}, "an openai, mistral, or local"},
+		{[]string{"docling"}, "a docling"},
+	}
+	for _, tc := range cases {
+		if got := oneOf(tc.sdks); got != tc.want {
+			t.Errorf("oneOf(%v) = %q, want %q", tc.sdks, got, tc.want)
+		}
 	}
 }

--- a/backend/internal/chatgpt/deviceauth.go
+++ b/backend/internal/chatgpt/deviceauth.go
@@ -1,0 +1,414 @@
+package chatgpt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ClientID is the Codex client OpenAI's own CLI and IDE extensions present.
+//
+// There is no second option. The device-code endpoints below only issue tokens
+// for OpenAI's registered clients, and the Codex backend only answers requests
+// whose originator header names one -- see codexOriginator in transport.go.
+// Using them means presenting ourselves as that client, which is the whole
+// reason this SDK ships behind a flag and never runs on a managed instance.
+const ClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+// Endpoints are OpenAI's device-code and token URLs.
+//
+// A struct rather than constants so tests can point the whole flow at an
+// httptest server. Production callers take DefaultEndpoints and never touch it.
+type Endpoints struct {
+	UserCode        string
+	DeviceToken     string
+	OAuthToken      string
+	VerificationURL string
+
+	// RedirectURI is the value the authorization code was issued against. The
+	// device flow never redirects anywhere, but the exchange still checks the
+	// parameter, so it has to be the issuer's own device callback -- not the
+	// loopback address the browser flow registers.
+	RedirectURI string
+}
+
+func DefaultEndpoints() Endpoints {
+	return Endpoints{
+		UserCode:        "https://auth.openai.com/api/accounts/deviceauth/usercode",
+		DeviceToken:     "https://auth.openai.com/api/accounts/deviceauth/token",
+		OAuthToken:      "https://auth.openai.com/oauth/token",
+		VerificationURL: "https://auth.openai.com/codex/device",
+		RedirectURI:     "https://auth.openai.com/deviceauth/callback",
+	}
+}
+
+var (
+	// ErrAuthPending is the operator not having finished in the browser yet.
+	// Expected, and the reason polling exists; never surfaced as a failure.
+	ErrAuthPending = errors.New("chatgpt: authorization pending")
+
+	// ErrAuthExpired is the user code timing out, roughly fifteen minutes after
+	// it was issued. The only cure is a fresh code.
+	ErrAuthExpired = errors.New("chatgpt: device code expired")
+
+	// ErrDeviceAuthDisabled is the account not permitting device-code sign-in.
+	// It is off by default for everyone, so this is the first thing most
+	// operators will hit; the message names the setting.
+	ErrDeviceAuthDisabled = errors.New("chatgpt: device code sign-in is not enabled for this account -- turn it on under ChatGPT Settings -> Security, or ask a workspace admin to grant it")
+
+	// ErrNotSignedIn is a provider row with no token in it.
+	ErrNotSignedIn = errors.New("chatgpt: provider is not signed in")
+)
+
+const (
+	deviceCodeTTL     = 15 * time.Minute
+	defaultPollPeriod = 5 * time.Second
+	authTimeout       = 30 * time.Second
+)
+
+// Client talks to OpenAI's auth host. Zero value is not usable; use NewClient.
+type Client struct {
+	http      *http.Client
+	endpoints Endpoints
+}
+
+func NewClient(hc *http.Client) *Client {
+	if hc == nil {
+		hc = &http.Client{Timeout: authTimeout}
+	}
+	return &Client{http: hc, endpoints: DefaultEndpoints()}
+}
+
+// WithEndpoints returns a copy pointed at other URLs. Tests only.
+func (c *Client) WithEndpoints(e Endpoints) *Client {
+	return &Client{http: c.http, endpoints: e}
+}
+
+// Pending is a device-code login waiting on the operator's browser.
+//
+// It never leaves the server: DeviceAuthID is the half that would let anyone
+// holding it complete the sign-in, so the API hands the browser only the user
+// code and the URL and keeps this in memory. See the pending registry in
+// appapi.
+type Pending struct {
+	DeviceAuthID    string
+	UserCode        string
+	VerificationURL string
+	Interval        time.Duration
+	ExpiresAt       time.Time
+}
+
+func (p *Pending) Expired() bool { return time.Now().After(p.ExpiresAt) }
+
+// flexInt is a whole number that the issuer sometimes quotes as a string.
+//
+// Both spellings show up in the device-code responses -- "interval": 5 and
+// "interval": "5" -- and a plain int rejects the second, which failed the
+// whole sign-in over a field we only use as a hint.
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	text := strings.TrimSpace(string(b))
+	if text == "null" || text == "" {
+		return nil
+	}
+	if unquoted, err := strconv.Unquote(text); err == nil {
+		text = strings.TrimSpace(unquoted)
+		if text == "" {
+			return nil
+		}
+	}
+	n, err := strconv.ParseFloat(text, 64)
+	if err != nil {
+		return fmt.Errorf("chatgpt: %q is not a number", text)
+	}
+	*f = flexInt(n)
+	return nil
+}
+
+// StartDeviceLogin asks for a user code.
+func (c *Client) StartDeviceLogin(ctx context.Context) (*Pending, error) {
+	var out struct {
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+		// Older responses spell it without the underscore. Cheaper to accept
+		// both than to discover which one a given deployment sends.
+		UserCodeAlt string  `json:"usercode"`
+		Interval    flexInt `json:"interval"`
+	}
+	body := map[string]string{"client_id": ClientID}
+	if err := c.postJSON(ctx, c.endpoints.UserCode, body, &out); err != nil {
+		// Asking for a code at all is what the account setting gates, so a
+		// refusal here is that setting rather than anything about this request.
+		if status := statusOf(err); status == http.StatusForbidden || status == http.StatusNotFound {
+			return nil, ErrDeviceAuthDisabled
+		}
+		return nil, err
+	}
+
+	code := strings.TrimSpace(out.UserCode)
+	if code == "" {
+		code = strings.TrimSpace(out.UserCodeAlt)
+	}
+	if strings.TrimSpace(out.DeviceAuthID) == "" || code == "" {
+		return nil, fmt.Errorf("chatgpt: device authorization response is missing a code")
+	}
+
+	interval := time.Duration(out.Interval) * time.Second
+	if interval <= 0 {
+		interval = defaultPollPeriod
+	}
+	return &Pending{
+		DeviceAuthID:    out.DeviceAuthID,
+		UserCode:        code,
+		VerificationURL: c.endpoints.VerificationURL,
+		Interval:        interval,
+		ExpiresAt:       time.Now().Add(deviceCodeTTL),
+	}, nil
+}
+
+// PollDeviceLogin checks once whether the operator has approved the code, and
+// exchanges the authorization code for a token pair if they have.
+//
+// One attempt per call, with ErrAuthPending for "not yet": the caller owns the
+// interval, which lets the browser drive it through the API instead of tying up
+// a request for the full fifteen minutes.
+func (c *Client) PollDeviceLogin(ctx context.Context, p *Pending) (Token, error) {
+	if p == nil {
+		return Token{}, ErrAuthExpired
+	}
+	if p.Expired() {
+		return Token{}, ErrAuthExpired
+	}
+
+	var out struct {
+		AuthorizationCode string `json:"authorization_code"`
+		CodeVerifier      string `json:"code_verifier"`
+	}
+	body := map[string]string{
+		"device_auth_id": p.DeviceAuthID,
+		"user_code":      p.UserCode,
+	}
+	if err := c.postJSON(ctx, c.endpoints.DeviceToken, body, &out); err != nil {
+		// The endpoint answers 403 or 404 for the whole fifteen minutes the
+		// operator is still in the browser. Reading either as a failure would
+		// end every sign-in on its first poll.
+		status := statusOf(err)
+		waiting := status == http.StatusForbidden || status == http.StatusNotFound
+		if waiting && !errors.Is(err, ErrAuthExpired) && !errors.Is(err, ErrDeviceAuthDisabled) {
+			return Token{}, ErrAuthPending
+		}
+		return Token{}, err
+	}
+	// The endpoint answers 200 with an empty body while the operator is still
+	// in the browser, so absence of a code is the pending signal rather than a
+	// status field.
+	if strings.TrimSpace(out.AuthorizationCode) == "" {
+		return Token{}, ErrAuthPending
+	}
+
+	return c.exchangeCode(ctx, out.AuthorizationCode, out.CodeVerifier)
+}
+
+// RefreshToken trades a refresh token for a fresh pair. The refresh token
+// rotates, so the result must be persisted before the next call.
+func (c *Client) RefreshToken(ctx context.Context, refresh string) (Token, error) {
+	refresh = strings.TrimSpace(refresh)
+	if refresh == "" {
+		return Token{}, ErrNotSignedIn
+	}
+	var out tokenResponse
+	if err := c.postJSON(ctx, c.endpoints.OAuthToken, map[string]string{
+		"grant_type":    "refresh_token",
+		"client_id":     ClientID,
+		"refresh_token": refresh,
+	}, &out); err != nil {
+		return Token{}, err
+	}
+	return newToken(out, refresh)
+}
+
+// exchangeCode trades the authorization code the poll returned for a token
+// pair. Form-encoded, unlike every other call here: the OAuth endpoint takes
+// JSON for a refresh but the code grant only in the RFC 6749 spelling.
+func (c *Client) exchangeCode(ctx context.Context, code, verifier string) (Token, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {ClientID},
+		"code":          {code},
+		"code_verifier": {verifier},
+		"redirect_uri":  {c.endpoints.RedirectURI},
+	}
+	var out tokenResponse
+	if err := c.postForm(ctx, c.endpoints.OAuthToken, form, &out); err != nil {
+		return Token{}, err
+	}
+	return newToken(out, "")
+}
+
+// tokenResponse is the shape both grants answer with. Every field is optional:
+// a refresh that rotates nothing sends back only an access token.
+type tokenResponse struct {
+	AccessToken  string  `json:"access_token"`
+	RefreshToken string  `json:"refresh_token"`
+	IDToken      string  `json:"id_token"`
+	ExpiresIn    flexInt `json:"expires_in"`
+}
+
+// newToken turns a token response into what we store. keepRefresh is the
+// refresh token we sent, kept when the issuer rotates nothing -- dropping it
+// would sign the account out at the next restart.
+func newToken(out tokenResponse, keepRefresh string) (Token, error) {
+	if strings.TrimSpace(out.AccessToken) == "" {
+		return Token{}, fmt.Errorf("chatgpt: token response carried no access token")
+	}
+	tok := Token{
+		Access:    out.AccessToken,
+		Refresh:   strings.TrimSpace(out.RefreshToken),
+		IDToken:   out.IDToken,
+		ExpiresAt: expiryOf(out.AccessToken, time.Duration(out.ExpiresIn)*time.Second),
+	}
+	if tok.Refresh == "" {
+		tok.Refresh = strings.TrimSpace(keepRefresh)
+	}
+	tok.AccountID, tok.Plan, tok.Email = identityFromIDToken(tok.IDToken)
+	return tok, nil
+}
+
+// expiryOf reads the access token's own exp claim, and falls back to expires_in
+// for issuers that send one. The refresh grant returns neither an expires_in
+// nor anything else about lifetime, so the claim is the only honest answer
+// there; an hour is the last resort, because a zero ExpiresAt reads as "never
+// refresh" and would strand the account on a dead token.
+func expiryOf(accessToken string, expiresIn time.Duration) time.Time {
+	if exp, ok := jwtExpiry(accessToken); ok {
+		return exp
+	}
+	if expiresIn <= 0 {
+		expiresIn = time.Hour
+	}
+	return time.Now().Add(expiresIn)
+}
+
+func (c *Client) postJSON(ctx context.Context, endpoint string, in any, out any) error {
+	payload, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("encode request: %w", err)
+	}
+	return c.post(ctx, endpoint, "application/json", payload, out)
+}
+
+func (c *Client) postForm(ctx context.Context, endpoint string, form url.Values, out any) error {
+	return c.post(ctx, endpoint, "application/x-www-form-urlencoded", []byte(form.Encode()), out)
+}
+
+func (c *Client) post(ctx context.Context, endpoint, contentType string, payload []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+	// The auth host is as originator-sensitive as the inference host.
+	req.Header.Set("originator", codexOriginator)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("chatgpt auth request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read chatgpt auth response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return authError(resp.StatusCode, raw)
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		// Not an error: the poll endpoint answers empty while it waits, and
+		// the caller reads that as ErrAuthPending from the zero value.
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode chatgpt auth response: %w", err)
+	}
+	return nil
+}
+
+// authError turns an auth-host failure into something an admin can act on.
+//
+// The two that matter are told apart by the body rather than the status: OpenAI
+// returns 400 for both "still waiting" and "your account may not do this", and
+// showing the second as a generic 400 would leave the operator staring at a
+// code that will never work.
+func authError(status int, body []byte) error {
+	return &httpError{status: status, err: authReason(status, body)}
+}
+
+// httpError carries the status alongside the reason, because the same status
+// means different things at different legs of the flow: 403 is "still waiting"
+// while polling and "your account may not do this" when asking for a code.
+type httpError struct {
+	status int
+	err    error
+}
+
+func (e *httpError) Error() string { return e.err.Error() }
+func (e *httpError) Unwrap() error { return e.err }
+
+// statusOf is the HTTP status behind err, or 0 if it did not come from one.
+func statusOf(err error) int {
+	var he *httpError
+	if errors.As(err, &he) {
+		return he.status
+	}
+	return 0
+}
+
+func authReason(status int, body []byte) error {
+	var parsed struct {
+		Error       string `json:"error"`
+		Detail      string `json:"detail"`
+		Description string `json:"error_description"`
+		Message     string `json:"message"`
+	}
+	_ = json.Unmarshal(body, &parsed)
+
+	text := strings.ToLower(strings.Join([]string{
+		parsed.Error, parsed.Detail, parsed.Description, parsed.Message, string(body),
+	}, " "))
+
+	switch {
+	case strings.Contains(text, "authorization_pending"), strings.Contains(text, "slow_down"):
+		return ErrAuthPending
+	case strings.Contains(text, "expired_token"), strings.Contains(text, "expired"):
+		return ErrAuthExpired
+	case strings.Contains(text, "device") && (strings.Contains(text, "disabled") ||
+		strings.Contains(text, "not allowed") || strings.Contains(text, "not enabled")):
+		return ErrDeviceAuthDisabled
+	}
+
+	msg := strings.TrimSpace(firstNonEmpty(parsed.Description, parsed.Detail, parsed.Message, parsed.Error, string(body)))
+	if len(msg) > 300 {
+		msg = msg[:300]
+	}
+	return fmt.Errorf("chatgpt auth: HTTP %d: %s", status, msg)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/backend/internal/chatgpt/deviceauth.go
+++ b/backend/internal/chatgpt/deviceauth.go
@@ -50,6 +50,30 @@ func DefaultEndpoints() Endpoints {
 	}
 }
 
+// authEndpoints is what the sign-in handlers reach. DefaultEndpoints in every
+// deployment; the end-to-end suite points it at a stub auth host, which is the
+// only way to drive the device flow without OpenAI's own and a human in a
+// second browser tab.
+//
+// A package variable, and deliberately not an environment variable or a
+// parameter threaded through Register. An env variable would be a shippable
+// setting that redirects an OAuth flow to an arbitrary host, which is a
+// configuration mistake worth making impossible; a parameter would carry a
+// test seam through appwire and main for the sake of one suite. This is
+// reachable only from Go code linked into the same binary.
+var authEndpoints = DefaultEndpoints()
+
+// AuthEndpoints returns the endpoints the sign-in handlers use.
+func AuthEndpoints() Endpoints { return authEndpoints }
+
+// SetAuthEndpointsForTesting repoints the sign-in flow and returns a function
+// that puts it back. Never called outside a test binary.
+func SetAuthEndpointsForTesting(e Endpoints) func() {
+	previous := authEndpoints
+	authEndpoints = e
+	return func() { authEndpoints = previous }
+}
+
 var (
 	// ErrAuthPending is the operator not having finished in the browser yet.
 	// Expected, and the reason polling exists; never surfaced as a failure.

--- a/backend/internal/chatgpt/deviceauth_test.go
+++ b/backend/internal/chatgpt/deviceauth_test.go
@@ -1,0 +1,345 @@
+package chatgpt
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// authServer stands in for auth.openai.com. Each handler is a field so a test
+// can change one leg of the flow without restating the other three.
+type authServer struct {
+	usercode    http.HandlerFunc
+	deviceToken http.HandlerFunc
+	oauthToken  http.HandlerFunc
+}
+
+func (a authServer) start(t *testing.T) *Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/accounts/deviceauth/usercode", a.usercode)
+	mux.HandleFunc("/api/accounts/deviceauth/token", a.deviceToken)
+	mux.HandleFunc("/oauth/token", a.oauthToken)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return NewClient(srv.Client()).WithEndpoints(Endpoints{
+		UserCode:        srv.URL + "/api/accounts/deviceauth/usercode",
+		DeviceToken:     srv.URL + "/api/accounts/deviceauth/token",
+		OAuthToken:      srv.URL + "/oauth/token",
+		VerificationURL: srv.URL + "/codex/device",
+		RedirectURI:     srv.URL + "/deviceauth/callback",
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// idToken builds an unsigned JWT with the claim the account id lives in. Only
+// the payload segment is ever read, so the header and signature are filler.
+func idToken(t *testing.T, accountID, plan, email string) string {
+	t.Helper()
+	payload := map[string]any{
+		"email": email,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  plan,
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "header." + base64.RawURLEncoding.EncodeToString(raw) + ".signature"
+}
+
+// The whole point of the device flow: no redirect listener, so a headless
+// server can complete a sign-in the operator approves from their own browser.
+func TestDeviceLoginCompletesWithoutARedirect(t *testing.T) {
+	t.Parallel()
+	approved := false
+	client := authServer{
+		usercode: func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["client_id"] != ClientID {
+				t.Errorf("client_id = %q, want the Codex client", body["client_id"])
+			}
+			writeJSON(w, 200, map[string]any{
+				"device_auth_id": "dev-1", "user_code": "ABCD-1234", "interval": 2,
+			})
+		},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {
+			if !approved {
+				// The endpoint answers 200 with nothing while it waits.
+				writeJSON(w, 200, map[string]any{})
+				return
+			}
+			writeJSON(w, 200, map[string]any{
+				"authorization_code": "auth-code", "code_verifier": "verifier",
+			})
+		},
+		oauthToken: func(w http.ResponseWriter, r *http.Request) {
+			// The code grant goes out form-encoded, against the issuer's own
+			// device callback -- the value the code was issued for.
+			if err := r.ParseForm(); err != nil {
+				t.Error(err)
+			}
+			if r.PostForm.Get("grant_type") != "authorization_code" || r.PostForm.Get("code_verifier") != "verifier" {
+				t.Errorf("exchange body = %v", r.PostForm)
+			}
+			if !strings.HasSuffix(r.PostForm.Get("redirect_uri"), "/deviceauth/callback") {
+				t.Errorf("redirect_uri = %q", r.PostForm.Get("redirect_uri"))
+			}
+			writeJSON(w, 200, map[string]any{
+				"access_token":  "access-1",
+				"refresh_token": "refresh-1",
+				"id_token":      idToken(t, "acct-9", "pro", "someone@example.com"),
+				"expires_in":    3600,
+			})
+		},
+	}.start(t)
+
+	ctx := context.Background()
+	pending, err := client.StartDeviceLogin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending.UserCode != "ABCD-1234" || pending.Interval != 2*time.Second {
+		t.Fatalf("pending = %+v", pending)
+	}
+
+	if _, err := client.PollDeviceLogin(ctx, pending); !errors.Is(err, ErrAuthPending) {
+		t.Fatalf("before approval: err = %v, want ErrAuthPending", err)
+	}
+
+	approved = true
+	tok, err := client.PollDeviceLogin(ctx, pending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Access != "access-1" || tok.Refresh != "refresh-1" {
+		t.Fatalf("token = %+v", tok)
+	}
+	// The account id is what the inference request's chatgpt-account-id header
+	// carries; losing it here would fail every later request with a 4xx.
+	if tok.AccountID != "acct-9" || tok.Plan != "pro" || tok.Email != "someone@example.com" {
+		t.Fatalf("identity = %+v", tok)
+	}
+	if !tok.Valid() || tok.Expired(0) {
+		t.Fatalf("fresh token reads as unusable: %+v", tok)
+	}
+}
+
+// Device-code sign-in is off by default on every account, so this is the first
+// thing most operators hit. It has to arrive as advice, not as a bare 4xx.
+func TestDisabledDeviceAuthIsNamed(t *testing.T) {
+	t.Parallel()
+	client := authServer{
+		usercode: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 403, map[string]any{"error": "device_code_disabled"})
+		},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {},
+		oauthToken:  func(w http.ResponseWriter, r *http.Request) {},
+	}.start(t)
+
+	_, err := client.StartDeviceLogin(context.Background())
+	if !errors.Is(err, ErrDeviceAuthDisabled) {
+		t.Fatalf("err = %v, want ErrDeviceAuthDisabled", err)
+	}
+	if !strings.Contains(err.Error(), "Security") {
+		t.Errorf("the message does not say where to turn it on: %v", err)
+	}
+}
+
+func TestExpiredCodeIsNotRetried(t *testing.T) {
+	t.Parallel()
+	client := authServer{
+		usercode: func(w http.ResponseWriter, r *http.Request) {},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 400, map[string]any{"error": "expired_token"})
+		},
+		oauthToken: func(w http.ResponseWriter, r *http.Request) {},
+	}.start(t)
+
+	pending := &Pending{DeviceAuthID: "dev-1", UserCode: "ABCD", ExpiresAt: time.Now().Add(time.Minute)}
+	if _, err := client.PollDeviceLogin(context.Background(), pending); !errors.Is(err, ErrAuthExpired) {
+		t.Fatalf("err = %v, want ErrAuthExpired", err)
+	}
+
+	// A code whose fifteen minutes ran out locally never reaches the network.
+	stale := &Pending{DeviceAuthID: "dev-1", UserCode: "ABCD", ExpiresAt: time.Now().Add(-time.Second)}
+	if _, err := client.PollDeviceLogin(context.Background(), stale); !errors.Is(err, ErrAuthExpired) {
+		t.Fatalf("stale: err = %v, want ErrAuthExpired", err)
+	}
+}
+
+// The refresh token rotates on use, but the issuer does not always send a new
+// one. Dropping it in that case would sign the account out at the next restart.
+func TestRefreshKeepsTheOldRefreshTokenWhenNoneIsReturned(t *testing.T) {
+	t.Parallel()
+	client := authServer{
+		usercode:    func(w http.ResponseWriter, r *http.Request) {},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {},
+		oauthToken: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{"access_token": "access-2", "expires_in": 3600})
+		},
+	}.start(t)
+
+	tok, err := client.RefreshToken(context.Background(), "refresh-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Refresh != "refresh-1" {
+		t.Fatalf("refresh token = %q, want the one we sent", tok.Refresh)
+	}
+}
+
+func TestTokenRoundTripsThroughTheColumn(t *testing.T) {
+	t.Parallel()
+	// An empty column is a row nobody has signed in to, not a broken one.
+	if tok, err := ParseToken("  "); err != nil || tok.Valid() {
+		t.Fatalf("empty column: %+v, %v", tok, err)
+	}
+	if _, err := ParseToken("not json"); err == nil {
+		t.Fatal("unreadable column parsed without complaint")
+	}
+
+	in := Token{Access: "a", Refresh: "r", ExpiresAt: time.Now().Add(time.Hour).Round(time.Second), AccountID: "acct"}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := ParseToken(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Access != in.Access || out.Refresh != in.Refresh || !out.ExpiresAt.Equal(in.ExpiresAt) {
+		t.Fatalf("round trip lost something: %+v -> %+v", in, out)
+	}
+}
+
+// The issuer quotes interval and expires_in as strings on some responses, and
+// a sign-in that dies on the poll hint is a sign-in lost to nothing.
+func TestDeviceLoginAcceptsQuotedNumbers(t *testing.T) {
+	t.Parallel()
+	client := authServer{
+		usercode: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{
+				"device_auth_id": "dev-1", "user_code": "ABCD-1234", "interval": "5",
+			})
+		},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{
+				"authorization_code": "auth-code", "code_verifier": "verifier",
+			})
+		},
+		oauthToken: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{
+				"access_token": "access-1", "refresh_token": "refresh-1",
+				"id_token":   idToken(t, "acct-9", "pro", "someone@example.com"),
+				"expires_in": "900",
+			})
+		},
+	}.start(t)
+
+	ctx := context.Background()
+	pending, err := client.StartDeviceLogin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending.Interval != 5*time.Second {
+		t.Fatalf("interval = %v, want 5s", pending.Interval)
+	}
+	tok, err := client.PollDeviceLogin(ctx, pending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := time.Until(tok.ExpiresAt).Round(time.Minute); got != 15*time.Minute {
+		t.Fatalf("expires in %v, want 15m", got)
+	}
+}
+
+// The poll endpoint answers 403 or 404 for the whole time the operator is in
+// the browser. Reading either as a failure ends every sign-in on its first try.
+func TestPollReadsARefusalAsWaiting(t *testing.T) {
+	t.Parallel()
+	replies := []int{http.StatusForbidden, http.StatusNotFound}
+	attempt := 0
+	client := authServer{
+		usercode: func(w http.ResponseWriter, r *http.Request) {},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {
+			if attempt < len(replies) {
+				writeJSON(w, replies[attempt], map[string]any{"detail": "not found"})
+				attempt++
+				return
+			}
+			writeJSON(w, 200, map[string]any{
+				"authorization_code": "auth-code", "code_verifier": "verifier",
+			})
+		},
+		oauthToken: func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{"access_token": "access-1", "refresh_token": "refresh-1"})
+		},
+	}.start(t)
+
+	ctx := context.Background()
+	pending := &Pending{DeviceAuthID: "dev-1", UserCode: "ABCD", ExpiresAt: time.Now().Add(time.Minute)}
+	for range replies {
+		if _, err := client.PollDeviceLogin(ctx, pending); !errors.Is(err, ErrAuthPending) {
+			t.Fatalf("err = %v, want ErrAuthPending", err)
+		}
+	}
+	if _, err := client.PollDeviceLogin(ctx, pending); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The refresh grant answers with no expires_in, so the access token's own exp
+// claim is the only honest answer. Guessing an hour against a shorter lifetime
+// is a stack of 401s nobody refreshes out of.
+func TestRefreshTakesExpiryFromTheAccessToken(t *testing.T) {
+	t.Parallel()
+	exp := time.Now().Add(20 * time.Minute).Truncate(time.Second)
+	client := authServer{
+		usercode:    func(w http.ResponseWriter, r *http.Request) {},
+		deviceToken: func(w http.ResponseWriter, r *http.Request) {},
+		oauthToken: func(w http.ResponseWriter, r *http.Request) {
+			// A refresh goes out as JSON, unlike the code grant.
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if body["grant_type"] != "refresh_token" || body["refresh_token"] != "refresh-1" {
+				t.Errorf("refresh body = %v", body)
+			}
+			writeJSON(w, 200, map[string]any{"access_token": jwtWithExp(t, exp)})
+		},
+	}.start(t)
+
+	tok, err := client.RefreshToken(context.Background(), "refresh-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tok.ExpiresAt.Equal(exp) {
+		t.Fatalf("expires at %v, want the exp claim %v", tok.ExpiresAt, exp)
+	}
+}
+
+// jwtWithExp builds an unsigned access token carrying only an exp claim.
+func jwtWithExp(t *testing.T, exp time.Time) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"exp": exp.Unix()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "header." + base64.RawURLEncoding.EncodeToString(raw) + ".signature"
+}

--- a/backend/internal/chatgpt/sdk_test.go
+++ b/backend/internal/chatgpt/sdk_test.go
@@ -1,0 +1,92 @@
+package chatgpt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// codexServer answers like the Codex backend: an SSE stream with no
+// Content-Type header. It records the path and headers it was reached with.
+func codexServer(t *testing.T, seen *http.Request, path *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*seen = *r
+		*path = r.URL.Path
+		_, _ = w.Write([]byte(
+			"event: x\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n" +
+				"event: x\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":2,\"output_tokens\":1}}}\n\n",
+		))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The end-to-end case: the middleware sits under a real openai-go client, so
+// the path it rewrites is the one the SDK actually built from the base URL.
+//
+// It is worth asserting through the SDK rather than by hand because
+// option.WithBaseURL appends a trailing slash and resolves the endpoint as a
+// relative reference. A base URL of ".../backend-api/codex" that lost its last
+// segment on the way would post to /backend-api/responses and 404, and no unit
+// test over a hand-built request would notice.
+func TestTheMiddlewareRewritesThePathTheSDKBuilds(t *testing.T) {
+	var seen http.Request
+	var path string
+	srv := codexServer(t, &seen, &path)
+
+	client := openai.NewClient(
+		option.WithAPIKey(PlaceholderKey),
+		option.WithBaseURL("http://chatgpt.com"+chatgptBasePath),
+		option.WithMiddleware(Middleware(signedInSource(t, "sdk1"), nil)),
+		// Runs after ours, so the connection lands on httptest rather than the
+		// internet. The same trick the session middleware's SDK test uses.
+		option.WithMiddleware(aiprovider.RewriteHostMiddleware(srv.Listener.Addr().String())),
+	)
+
+	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("gpt-5.6-luna"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("completion through the SDK: %v", err)
+	}
+
+	if path != chatgptBasePath+"/responses" {
+		t.Fatalf("path = %q, want %s/responses", path, chatgptBasePath)
+	}
+	if got := seen.Header.Get("originator"); got != codexOriginator {
+		t.Errorf("originator = %q, want %q", got, codexOriginator)
+	}
+	if got := seen.Header.Get("Authorization"); got != "Bearer access-1" {
+		t.Errorf("Authorization = %q, want the live token rather than the placeholder", got)
+	}
+
+	// And the SDK decoded the reassembled answer, which is the whole point:
+	// ai.CompleteChat and everything above it see an ordinary completion.
+	if len(resp.Choices) != 1 || resp.Choices[0].Message.Content != "ok" {
+		t.Fatalf("choices = %+v", resp.Choices)
+	}
+	if resp.Usage.PromptTokens != 2 || resp.Usage.CompletionTokens != 1 {
+		t.Fatalf("usage = %+v", resp.Usage)
+	}
+}
+
+// chatgptBasePath is the path half of DefaultBaseURL(SDKChatGPT), so the test
+// above cannot drift from the URL the SDK is actually configured with.
+var chatgptBasePath = "/backend-api/codex"
+
+func TestTheDefaultBaseURLCarriesThatPath(t *testing.T) {
+	t.Parallel()
+	want := "https://chatgpt.com" + chatgptBasePath
+	if got := aiprovider.DefaultBaseURL(aiprovider.SDKChatGPT); got != want {
+		t.Fatalf("DefaultBaseURL = %q, want %q", got, want)
+	}
+}

--- a/backend/internal/chatgpt/source.go
+++ b/backend/internal/chatgpt/source.go
@@ -1,0 +1,181 @@
+package chatgpt
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// refreshLeeway is how early a token is treated as spent. Generous on purpose:
+// an extraction run can sit in a queue for a while between the moment the
+// middleware reads the token and the moment the request reaches OpenAI.
+const refreshLeeway = 5 * time.Minute
+
+// Persist writes a rotated token back to the ai_providers row.
+//
+// A function rather than a core.App here so the refresh path owns nothing of
+// PocketBase: the appapi and config packages already hold the app, and this one
+// stays testable without a database.
+type Persist func(providerID, oauth string) error
+
+// TokenSource hands out a live access token for one provider row, refreshing it
+// when it is close to expiring.
+//
+// One per provider id, kept in the package registry below rather than in the
+// runtime snapshot. That is deliberate: config.Runtime rebuilds every client on
+// any ai_providers write, and a source rebuilt with it would lose track of a
+// refresh already in flight -- and would re-read a row this very source is
+// about to update.
+type TokenSource struct {
+	providerID string
+	persist    Persist
+	client     *Client
+	logger     *slog.Logger
+
+	// Held across the refresh, which makes concurrent callers wait for one
+	// round trip instead of racing to spend the same rotating refresh token.
+	mu  sync.Mutex
+	tok Token
+}
+
+var (
+	sourcesMu sync.Mutex
+	sources   = map[string]*TokenSource{}
+)
+
+// SourceFor returns the source for a provider row, creating it on first use and
+// adopting a newer token when one has been written elsewhere -- a fresh
+// sign-in, or another process's refresh.
+//
+// An older token is ignored rather than adopted: the record we were handed may
+// have been read before our own refresh landed, and taking it would spend a
+// refresh token that has already rotated.
+func SourceFor(providerID, oauth string, persist Persist, logger *slog.Logger) *TokenSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	incoming, err := ParseToken(oauth)
+	if err != nil {
+		logger.Warn("stored ChatGPT token is unreadable; sign in again",
+			"provider_id", providerID, slog.Any("error", err))
+	}
+
+	sourcesMu.Lock()
+	defer sourcesMu.Unlock()
+
+	src, ok := sources[providerID]
+	if !ok {
+		src = &TokenSource{
+			providerID: providerID,
+			persist:    persist,
+			client:     NewClient(nil),
+			logger:     logger,
+		}
+		src.tok = incoming
+		sources[providerID] = src
+		return src
+	}
+
+	src.mu.Lock()
+	if !src.tok.Valid() || incoming.ExpiresAt.After(src.tok.ExpiresAt) {
+		src.tok = incoming
+	}
+	src.mu.Unlock()
+	src.persist = persist
+	return src
+}
+
+// Forget drops a provider's source, for sign-out and deletion. Without it a
+// row that signed out would keep serving from the token still in memory.
+func Forget(providerID string) {
+	sourcesMu.Lock()
+	delete(sources, providerID)
+	sourcesMu.Unlock()
+}
+
+// withEndpoints repoints the source's auth client. Tests only.
+func (s *TokenSource) withEndpoints(e Endpoints) *TokenSource {
+	s.client = s.client.WithEndpoints(e)
+	return s
+}
+
+// Identity is what Settings shows about the signed-in account. Never the token.
+func (s *TokenSource) Identity() (accountID, plan, email string, signedIn bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tok.AccountID, s.tok.Plan, s.tok.Email, s.tok.Valid()
+}
+
+// AccessToken returns a token good for the next few minutes, refreshing first
+// if the one in hand is not.
+func (s *TokenSource) AccessToken(ctx context.Context) (Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.tok.Valid() {
+		return Token{}, ErrNotSignedIn
+	}
+	if !s.tok.Expired(refreshLeeway) {
+		return s.tok, nil
+	}
+
+	refreshed, err := s.client.RefreshToken(ctx, s.tok.Refresh)
+	if err != nil {
+		// Keep the old token rather than clearing it: a network blip must not
+		// look like a sign-out, and the access token may still have minutes
+		// left inside the leeway.
+		s.logger.Warn("refreshing the ChatGPT token failed",
+			"provider_id", s.providerID, slog.Any("error", err))
+		if s.tok.Expired(0) {
+			return Token{}, err
+		}
+		return s.tok, nil
+	}
+
+	// Carry the identity forward: a refresh response need not repeat the
+	// id_token, and losing the account id would break the request header that
+	// says which ChatGPT account is being billed.
+	if refreshed.AccountID == "" {
+		refreshed.AccountID = s.tok.AccountID
+		refreshed.Plan = s.tok.Plan
+		refreshed.Email = s.tok.Email
+	}
+	s.tok = refreshed
+	s.save(refreshed)
+	return refreshed, nil
+}
+
+// Set replaces the token after a completed sign-in and stores it.
+func (s *TokenSource) Set(tok Token) error {
+	s.mu.Lock()
+	s.tok = tok
+	s.mu.Unlock()
+
+	raw, err := tok.Marshal()
+	if err != nil {
+		return err
+	}
+	if s.persist == nil {
+		return nil
+	}
+	return s.persist(s.providerID, raw)
+}
+
+// save persists a rotation. Failures are logged, not returned: the caller is
+// mid-request with a working token, and refusing to answer because the write
+// failed would turn a recoverable database hiccup into a failed extraction.
+// The cost of the miss is one extra refresh after the next restart.
+func (s *TokenSource) save(tok Token) {
+	if s.persist == nil {
+		return
+	}
+	raw, err := tok.Marshal()
+	if err == nil {
+		err = s.persist(s.providerID, raw)
+	}
+	if err != nil {
+		s.logger.Warn("storing the refreshed ChatGPT token failed",
+			"provider_id", s.providerID, slog.Any("error", err))
+	}
+}

--- a/backend/internal/chatgpt/source.go
+++ b/backend/internal/chatgpt/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -37,6 +38,12 @@ type TokenSource struct {
 	// round trip instead of racing to spend the same rotating refresh token.
 	mu  sync.Mutex
 	tok Token
+
+	// forgotten is set by Forget and never cleared: a source is retired, not
+	// paused. Atomic rather than guarded by mu on purpose -- mu is held across
+	// the refresh round trip, and a sign-out that had to wait for that would be
+	// a sign-out an operator watches spin.
+	forgotten atomic.Bool
 }
 
 var (
@@ -86,12 +93,22 @@ func SourceFor(providerID, oauth string, persist Persist, logger *slog.Logger) *
 	return src
 }
 
-// Forget drops a provider's source, for sign-out and deletion. Without it a
-// row that signed out would keep serving from the token still in memory.
+// Forget retires a provider's source, for sign-out and deletion.
+//
+// Dropping the registry entry is not enough on its own. A client built before
+// the sign-out still holds the source, and a refresh already in flight inside
+// AccessToken would come back and write the rotated pair to the row -- which
+// the update hook reads as a sign-in, rebuilding signed-in clients and undoing
+// the sign-out with no error anywhere. So the source is marked as well: from
+// here on it serves no tokens and persists nothing, whatever is mid-flight.
 func Forget(providerID string) {
 	sourcesMu.Lock()
+	src := sources[providerID]
 	delete(sources, providerID)
 	sourcesMu.Unlock()
+	if src != nil {
+		src.forgotten.Store(true)
+	}
 }
 
 // withEndpoints repoints the source's auth client. Tests only.
@@ -110,6 +127,10 @@ func (s *TokenSource) Identity() (accountID, plan, email string, signedIn bool) 
 // AccessToken returns a token good for the next few minutes, refreshing first
 // if the one in hand is not.
 func (s *TokenSource) AccessToken(ctx context.Context) (Token, error) {
+	if s.forgotten.Load() {
+		return Token{}, ErrNotSignedIn
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -141,6 +162,12 @@ func (s *TokenSource) AccessToken(ctx context.Context) (Token, error) {
 		refreshed.Plan = s.tok.Plan
 		refreshed.Email = s.tok.Email
 	}
+	// Checked again on the way out: the sign-out may have landed while this
+	// refresh was on the wire, and the whole point is that its token is
+	// neither served nor stored.
+	if s.forgotten.Load() {
+		return Token{}, ErrNotSignedIn
+	}
 	s.tok = refreshed
 	s.save(refreshed)
 	return refreshed, nil
@@ -148,6 +175,9 @@ func (s *TokenSource) AccessToken(ctx context.Context) (Token, error) {
 
 // Set replaces the token after a completed sign-in and stores it.
 func (s *TokenSource) Set(tok Token) error {
+	if s.forgotten.Load() {
+		return ErrNotSignedIn
+	}
 	s.mu.Lock()
 	s.tok = tok
 	s.mu.Unlock()
@@ -167,7 +197,7 @@ func (s *TokenSource) Set(tok Token) error {
 // failed would turn a recoverable database hiccup into a failed extraction.
 // The cost of the miss is one extra refresh after the next restart.
 func (s *TokenSource) save(tok Token) {
-	if s.persist == nil {
+	if s.persist == nil || s.forgotten.Load() {
 		return
 	}
 	raw, err := tok.Marshal()

--- a/backend/internal/chatgpt/source_test.go
+++ b/backend/internal/chatgpt/source_test.go
@@ -3,6 +3,7 @@ package chatgpt
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -179,5 +180,141 @@ func TestSourceForIgnoresAnOlderToken(t *testing.T) {
 	}
 	if tok.Access != "new" {
 		t.Fatalf("access token = %q, want the newer one", tok.Access)
+	}
+}
+
+// A sign-out is two writes: the row's token is cleared, and the source is
+// retired. Only the second reaches a refresh that is already on the wire -- and
+// without it that refresh comes back, stores its rotated pair, and the provider
+// update hook reads the write as a fresh sign-in and rebuilds signed-in
+// clients. The sign-out undoes itself, with no error anywhere to say so.
+func TestARefreshInFlightAcrossForgetStoresNothing(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-new",
+			"refresh_token": "rotated",
+			"expires_in":    3600,
+		})
+	}))
+	defer srv.Close()
+
+	var stores atomic.Int32
+	persist := func(_, _ string) error {
+		stores.Add(1)
+		return nil
+	}
+
+	const id = "p-signout"
+	Forget(id)
+	t.Cleanup(func() { Forget(id) })
+	// Inside the leeway, so the very next AccessToken refreshes.
+	raw, err := Token{Access: "old", Refresh: "refresh-1", ExpiresAt: time.Now().Add(time.Minute)}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := SourceFor(id, raw, persist, nil)
+	src.withEndpoints(Endpoints{OAuthToken: srv.URL})
+
+	type result struct {
+		tok Token
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		tok, err := src.AccessToken(context.Background())
+		done <- result{tok, err}
+	}()
+
+	<-started
+	// The sign-out lands while the refresh is still in the air. It must not
+	// block on it either: mu is held across that round trip, which is why the
+	// flag is atomic rather than guarded by the mutex.
+	Forget(id)
+	close(release)
+
+	got := <-done
+	if !errors.Is(got.err, ErrNotSignedIn) {
+		t.Fatalf("err = %v, want ErrNotSignedIn: a retired source must serve nothing", got.err)
+	}
+	if got.tok.Access != "" {
+		t.Errorf("handed out %q after sign-out", got.tok.Access)
+	}
+	if n := stores.Load(); n != 0 {
+		t.Fatalf("persisted %d times after sign-out; the sign-out would be undone", n)
+	}
+}
+
+func TestAForgottenSourceHandsOutNoToken(t *testing.T) {
+	const id = "p-retired"
+	Forget(id)
+	t.Cleanup(func() { Forget(id) })
+	raw, err := Token{Access: "live", Refresh: "r", ExpiresAt: time.Now().Add(time.Hour)}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := SourceFor(id, raw, nil, nil)
+
+	// Good for an hour, so nothing here needs the network.
+	if _, err := src.AccessToken(context.Background()); err != nil {
+		t.Fatalf("before sign-out: %v", err)
+	}
+	Forget(id)
+	if _, err := src.AccessToken(context.Background()); !errors.Is(err, ErrNotSignedIn) {
+		t.Fatalf("after sign-out: err = %v, want ErrNotSignedIn", err)
+	}
+}
+
+// Set is the sign-in write. A source retired first must refuse it rather than
+// store a token against a row that is being signed out or deleted.
+func TestSetOnAForgottenSourceStoresNothing(t *testing.T) {
+	const id = "p-set"
+	Forget(id)
+	t.Cleanup(func() { Forget(id) })
+
+	var stores atomic.Int32
+	src := SourceFor(id, "", func(_, _ string) error {
+		stores.Add(1)
+		return nil
+	}, nil)
+
+	Forget(id)
+	err := src.Set(Token{Access: "a", Refresh: "r", ExpiresAt: time.Now().Add(time.Hour)})
+	if !errors.Is(err, ErrNotSignedIn) {
+		t.Fatalf("err = %v, want ErrNotSignedIn", err)
+	}
+	if n := stores.Load(); n != 0 {
+		t.Fatalf("persisted %d times", n)
+	}
+}
+
+// Forget drops the registry entry as well as retiring the source, so the next
+// SourceFor builds a working one rather than handing back the retired object.
+func TestSourceForAfterForgetBuildsALiveSource(t *testing.T) {
+	const id = "p-resign"
+	Forget(id)
+	t.Cleanup(func() { Forget(id) })
+
+	first := SourceFor(id, "", nil, nil)
+	Forget(id)
+
+	raw, err := Token{Access: "fresh", Refresh: "r2", ExpiresAt: time.Now().Add(time.Hour)}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := SourceFor(id, raw, nil, nil)
+	if second == first {
+		t.Fatal("SourceFor handed back the retired source")
+	}
+	tok, err := second.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("the new source refuses to serve: %v", err)
+	}
+	if tok.Access != "fresh" {
+		t.Errorf("access = %q", tok.Access)
 	}
 }

--- a/backend/internal/chatgpt/source_test.go
+++ b/backend/internal/chatgpt/source_test.go
@@ -1,0 +1,183 @@
+package chatgpt
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// refreshingSource builds a source wired to a stub /oauth/token, and reports
+// how many times that endpoint was called.
+func refreshingSource(t *testing.T, tok Token, persist Persist) (*TokenSource, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-" + body["refresh_token"],
+			"refresh_token": "rotated",
+			"expires_in":    3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	Forget("p1")
+	t.Cleanup(func() { Forget("p1") })
+
+	raw, err := tok.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := SourceFor("p1", raw, persist, nil)
+	src.withEndpoints(Endpoints{OAuthToken: srv.URL})
+	return src, &calls
+}
+
+func TestAccessTokenRefreshesBeforeExpiryAndPersistsTheRotation(t *testing.T) {
+	var mu sync.Mutex
+	var stored string
+	persist := func(_, oauth string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		stored = oauth
+		return nil
+	}
+
+	// Inside the leeway: still technically valid, but too close to spend on a
+	// request that may sit in a queue first.
+	src, calls := refreshingSource(t, Token{
+		Access: "old", Refresh: "refresh-1", ExpiresAt: time.Now().Add(time.Minute),
+	}, persist)
+
+	tok, err := src.AccessToken(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Access != "access-refresh-1" {
+		t.Fatalf("access token = %q, want the refreshed one", tok.Access)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("refresh calls = %d, want 1", calls.Load())
+	}
+
+	mu.Lock()
+	saved := stored
+	mu.Unlock()
+	if saved == "" {
+		t.Fatal("the rotated refresh token was not written back")
+	}
+	parsed, err := ParseToken(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The refresh token rotates on use: storing the old one would mean the next
+	// refresh spends a credential the issuer has already retired.
+	if parsed.Refresh != "rotated" {
+		t.Fatalf("stored refresh token = %q, want the rotated one", parsed.Refresh)
+	}
+
+	// A token with an hour left is handed out as-is.
+	if _, err := src.AccessToken(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("refresh calls = %d after a second read, want 1", calls.Load())
+	}
+}
+
+// Concurrent requests must not each spend the rotating refresh token.
+func TestConcurrentCallersRefreshOnce(t *testing.T) {
+	src, calls := refreshingSource(t, Token{
+		Access: "old", Refresh: "refresh-1", ExpiresAt: time.Now().Add(time.Minute),
+	}, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := src.AccessToken(context.Background()); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if calls.Load() != 1 {
+		t.Fatalf("refresh calls = %d, want 1", calls.Load())
+	}
+}
+
+// A network blip is not a sign-out: the access token may still have minutes
+// left inside the leeway, and clearing it would break a working install.
+func TestAFailedRefreshKeepsAStillValidToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	Forget("p2")
+	defer Forget("p2")
+	raw, err := Token{Access: "old", Refresh: "r", ExpiresAt: time.Now().Add(time.Minute)}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := SourceFor("p2", raw, nil, nil)
+	src.withEndpoints(Endpoints{OAuthToken: srv.URL})
+
+	tok, err := src.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v, want the old token back", err)
+	}
+	if tok.Access != "old" {
+		t.Fatalf("access token = %q, want the one we still had", tok.Access)
+	}
+}
+
+func TestAnUnsignedProviderSaysSo(t *testing.T) {
+	Forget("p3")
+	defer Forget("p3")
+	src := SourceFor("p3", "", nil, nil)
+	if _, err := src.AccessToken(context.Background()); err != ErrNotSignedIn {
+		t.Fatalf("err = %v, want ErrNotSignedIn", err)
+	}
+}
+
+// The registry is what survives a runtime rebuild. A row re-read from the
+// database mid-refresh must not roll the source back to the token it held
+// before -- that credential has already been spent.
+func TestSourceForIgnoresAnOlderToken(t *testing.T) {
+	Forget("p4")
+	defer Forget("p4")
+
+	newer := Token{Access: "new", Refresh: "r2", ExpiresAt: time.Now().Add(time.Hour)}
+	raw, err := newer.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := SourceFor("p4", raw, nil, nil)
+
+	older, err := Token{Access: "old", Refresh: "r1", ExpiresAt: time.Now().Add(time.Minute)}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again := SourceFor("p4", older, nil, nil)
+	if again != src {
+		t.Fatal("SourceFor built a second source for one provider")
+	}
+	tok, err := src.AccessToken(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Access != "new" {
+		t.Fatalf("access token = %q, want the newer one", tok.Access)
+	}
+}

--- a/backend/internal/chatgpt/token.go
+++ b/backend/internal/chatgpt/token.go
@@ -1,0 +1,137 @@
+// Package chatgpt signs Lemmary in to OpenAI's Codex backend with a ChatGPT
+// subscription, and makes that backend answer the Chat Completions requests the
+// rest of the codebase already sends.
+//
+// Three pieces, in the order they run:
+//
+//   - deviceauth.go mints a token pair from a code the operator types into a
+//     browser. There is no redirect listener, so it works on a headless server.
+//   - source.go keeps that pair fresh and writes rotations back to the
+//     ai_providers row.
+//   - transport.go rewrites POST /chat/completions into POST /responses on the
+//     way out and the SSE answer back into a chat completion on the way in, as
+//     an openai-go middleware. Nothing above it -- not ai.CompleteChat, not the
+//     extractor, chatter, splitter, helper or search agent -- knows any of this
+//     happened.
+//
+// Every endpoint here is OpenAI's own, undocumented, and meant for OpenAI's
+// clients. That is why the feature is off unless AI_CHATGPT_LOGIN=1 and refused
+// outright on a managed instance: pointing an account at them is a decision the
+// operator makes for themselves. See docs/chatgpt_login.md.
+package chatgpt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Token is one signed-in ChatGPT account, as stored in ai_providers.oauth.
+//
+// Refresh is the durable half: access tokens last about an hour, and the
+// refresh token is what survives a restart. It rotates on every use, so a
+// refresh that succeeds must be persisted or the next one fails.
+type Token struct {
+	Access    string    `json:"access_token"`
+	Refresh   string    `json:"refresh_token"`
+	IDToken   string    `json:"id_token,omitempty"`
+	ExpiresAt time.Time `json:"expires_at"`
+
+	// Identity read out of IDToken at sign-in, so Settings can name the account
+	// without decoding a JWT on every render and without the token itself ever
+	// reaching the browser.
+	AccountID string `json:"account_id,omitempty"`
+	Plan      string `json:"plan,omitempty"`
+	Email     string `json:"email,omitempty"`
+}
+
+func (t Token) Valid() bool { return strings.TrimSpace(t.Access) != "" }
+
+// Expired reports whether the access token is spent, counting leeway as spent.
+// The leeway is what keeps a request that starts just under the wire from
+// arriving just over it.
+func (t Token) Expired(leeway time.Duration) bool {
+	if t.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().Add(leeway).After(t.ExpiresAt)
+}
+
+// Marshal serializes for the oauth column. Encoding here rather than at the
+// call sites keeps the column's shape the token's own business.
+func (t Token) Marshal() (string, error) {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return "", fmt.Errorf("encode chatgpt token: %w", err)
+	}
+	return string(b), nil
+}
+
+// ParseToken reads the oauth column. An empty column is not an error: it is a
+// provider row nobody has signed in to yet.
+func ParseToken(raw string) (Token, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Token{}, nil
+	}
+	var t Token
+	if err := json.Unmarshal([]byte(raw), &t); err != nil {
+		return Token{}, fmt.Errorf("decode chatgpt token: %w", err)
+	}
+	return t, nil
+}
+
+// identityFromIDToken pulls the account id, plan and email out of the id_token.
+//
+// The signature is not checked, deliberately: we just received this token over
+// TLS from the issuer in answer to our own request, so there is no second party
+// whose claims we would be trusting. Verifying it would mean fetching and
+// pinning a JWKS to learn something we already know.
+func identityFromIDToken(idToken string) (accountID, plan, email string) {
+	parts := strings.Split(strings.TrimSpace(idToken), ".")
+	if len(parts) < 2 {
+		return "", "", ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", ""
+	}
+	var claims struct {
+		Email string `json:"email"`
+		Auth  struct {
+			ChatGPTAccountID string `json:"chatgpt_account_id"`
+			ChatGPTPlanType  string `json:"chatgpt_plan_type"`
+		} `json:"https://api.openai.com/auth"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", "", ""
+	}
+	return claims.Auth.ChatGPTAccountID, claims.Auth.ChatGPTPlanType, claims.Email
+}
+
+// jwtExpiry reads the exp claim out of a token. Unsigned and unverified, for
+// the same reason identityFromIDToken does not verify: this is our own token,
+// and the claim only decides when we refresh it.
+//
+// The refresh grant answers with no expires_in at all, so without this every
+// refreshed token would carry a guessed hour -- fine when the real lifetime is
+// an hour, a stack of 401s when it is shorter.
+func jwtExpiry(token string) (time.Time, bool) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) < 2 {
+		return time.Time{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp <= 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(claims.Exp, 0), true
+}

--- a/backend/internal/chatgpt/transport.go
+++ b/backend/internal/chatgpt/transport.go
@@ -1,0 +1,570 @@
+package chatgpt
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openai/openai-go/option"
+	"lemmary/backend/internal/aiprovider"
+)
+
+const (
+	// codexOriginator names us to the Codex backend, which serves only its own
+	// clients: the header is checked against a whitelist and anything else is
+	// refused with a 403. It is also sent to the auth host, which is equally
+	// particular.
+	codexOriginator = "codex_cli_rs"
+
+	// codexBeta is the opt-in the Responses endpoint requires.
+	codexBeta = "responses=experimental"
+
+	// codexInstructions is the preamble the backend expects to lead the
+	// instructions field.
+	//
+	// It is short on purpose. The backend wants to see a Codex-shaped system
+	// prompt, and the real caller's system message follows immediately after,
+	// so this only has to satisfy the shape without steering the model away
+	// from the job it was actually given. If a future backend change starts
+	// rejecting requests, this is the first knob to turn.
+	codexInstructions = "You are a coding agent running in a terminal."
+)
+
+// PlaceholderKey stands in for the API key openai-go insists on having.
+//
+// A chatgpt client has no such key: Middleware sets a live bearer token on
+// every request instead. The value still has to be non-empty, both for the SDK
+// and for the `apiKey == ""` guards the chatter, splitter, helper and search
+// agent open with -- and it is never sent, because applyCodexHeaders overwrites
+// the Authorization header the SDK built from it.
+const PlaceholderKey = "chatgpt-oauth"
+
+// chatCompletionsSuffix is the path openai-go builds from any base URL. Matching
+// on it rather than on the whole URL is what lets the middleware sit under a
+// client whose base URL a test has repointed at httptest.
+const chatCompletionsSuffix = "/chat/completions"
+
+// Middleware makes the Codex backend answer Chat Completions requests.
+//
+// It is installed in place of an API key: the SDK is built with a placeholder
+// credential and this overwrites the Authorization header with a live token on
+// every attempt. Requests to any other path pass through untouched, which is
+// what keeps a misbound provider from silently rewriting somebody else's call.
+func Middleware(src *TokenSource, logger *slog.Logger) option.Middleware {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		if req == nil || req.URL == nil || !strings.HasSuffix(req.URL.Path, chatCompletionsSuffix) {
+			return next(req)
+		}
+
+		in, err := readChatRequest(req)
+		if err != nil {
+			return nil, err
+		}
+		tok, err := src.AccessToken(req.Context())
+		if err != nil {
+			return nil, err
+		}
+
+		payload, err := json.Marshal(toResponsesRequest(in))
+		if err != nil {
+			return nil, fmt.Errorf("chatgpt: encode responses request: %w", err)
+		}
+		req.URL.Path = strings.TrimSuffix(req.URL.Path, chatCompletionsSuffix) + "/responses"
+		req.Body = io.NopCloser(bytes.NewReader(payload))
+		req.ContentLength = int64(len(payload))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(payload)), nil
+		}
+		applyCodexHeaders(req, tok)
+
+		resp, err := next(req)
+		if err != nil || resp == nil {
+			return resp, err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			// Left exactly as it arrived: the SDK's own error decoding turns it
+			// into an APIError, and ai.CompleteChat's degradation paths read
+			// that body to decide whether to retry without JSON mode.
+			return resp, nil
+		}
+		if in.Stream {
+			return streamingResponse(resp, in.Model), nil
+		}
+		return bufferedResponse(resp, in.Model, logger)
+	}
+}
+
+func applyCodexHeaders(req *http.Request, tok Token) {
+	req.Header.Set("Authorization", "Bearer "+tok.Access)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("OpenAI-Beta", codexBeta)
+	req.Header.Set("originator", codexOriginator)
+	if tok.AccountID != "" {
+		req.Header.Set("chatgpt-account-id", tok.AccountID)
+	}
+	// The same per-purpose id the OpenCode header carries elsewhere: stable for
+	// the life of the process, so requests sharing a system prompt stay
+	// grouped. Falls back rather than sending nothing, which the backend
+	// dislikes.
+	session := aiprovider.SessionFrom(req.Context())
+	if session == "" {
+		session = aiprovider.SessionFor("chatgpt")
+	}
+	req.Header.Set("session_id", session)
+}
+
+// --- request translation ---
+
+type chatRequest struct {
+	Model               string          `json:"model"`
+	Messages            []chatMessage   `json:"messages"`
+	Stream              bool            `json:"stream"`
+	MaxTokens           *int64          `json:"max_tokens"`
+	MaxCompletionTokens *int64          `json:"max_completion_tokens"`
+	ResponseFormat      *responseFormat `json:"response_format"`
+}
+
+type responseFormat struct {
+	Type string `json:"type"`
+}
+
+type chatMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type responsesRequest struct {
+	Model           string          `json:"model"`
+	Instructions    string          `json:"instructions,omitempty"`
+	Input           []responsesItem `json:"input"`
+	Stream          bool            `json:"stream"`
+	Store           bool            `json:"store"`
+	MaxOutputTokens *int64          `json:"max_output_tokens,omitempty"`
+	Text            *responsesText  `json:"text,omitempty"`
+}
+
+type responsesItem struct {
+	Type    string             `json:"type"`
+	Role    string             `json:"role"`
+	Content []responsesContent `json:"content"`
+}
+
+type responsesContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type responsesText struct {
+	Format responseFormat `json:"format"`
+}
+
+func readChatRequest(req *http.Request) (chatRequest, error) {
+	var in chatRequest
+	if req.Body == nil {
+		return in, fmt.Errorf("chatgpt: chat completion request has no body")
+	}
+	raw, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return in, fmt.Errorf("chatgpt: read chat completion request: %w", err)
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return in, fmt.Errorf("chatgpt: decode chat completion request: %w", err)
+	}
+	return in, nil
+}
+
+// toResponsesRequest maps a chat completion onto the Responses shape.
+//
+// Two things are forced rather than carried over. stream is always true because
+// the Codex endpoint answers no other way -- a non-streaming caller gets the
+// stream reassembled below. store is always false: this is somebody's document
+// archive, and leaving copies of it in a ChatGPT history is not something an
+// operator asked for by signing in.
+//
+// temperature is dropped by having nowhere to go: the Responses shape here
+// carries no such field, so whatever ai.CompletionTemperature decided upstream
+// never reaches the backend. The Codex models refuse a custom value anyway.
+func toResponsesRequest(in chatRequest) responsesRequest {
+	out := responsesRequest{
+		Model:  in.Model,
+		Stream: true,
+		Store:  false,
+		Input:  make([]responsesItem, 0, len(in.Messages)),
+	}
+
+	instructions := []string{codexInstructions}
+	for _, msg := range in.Messages {
+		text := messageText(msg.Content)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
+		case "system", "developer":
+			// The Responses API has no system message: the role's content is
+			// the instructions field, which is also where the backend looks
+			// for the preamble above.
+			instructions = append(instructions, text)
+		case "assistant":
+			out.Input = append(out.Input, responsesItem{
+				Type: "message", Role: "assistant",
+				Content: []responsesContent{{Type: "output_text", Text: text}},
+			})
+		default:
+			out.Input = append(out.Input, responsesItem{
+				Type: "message", Role: "user",
+				Content: []responsesContent{{Type: "input_text", Text: text}},
+			})
+		}
+	}
+	out.Instructions = strings.Join(instructions, "\n\n")
+
+	switch {
+	case in.MaxCompletionTokens != nil:
+		out.MaxOutputTokens = in.MaxCompletionTokens
+	case in.MaxTokens != nil:
+		out.MaxOutputTokens = in.MaxTokens
+	}
+
+	if in.ResponseFormat != nil && strings.TrimSpace(in.ResponseFormat.Type) != "" {
+		out.Text = &responsesText{Format: responseFormat{Type: in.ResponseFormat.Type}}
+	}
+	return out
+}
+
+// messageText flattens a chat message's content.
+//
+// Content is either a plain string or an array of typed parts. Only the text
+// parts are kept: the one caller that sends images is OCR, and CanOCR already
+// refuses this SDK, so an image here means a misconfiguration rather than a
+// case to support.
+func messageText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		if part.Text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(part.Text)
+	}
+	return b.String()
+}
+
+// --- response translation ---
+
+type chatUsage struct {
+	PromptTokens        int            `json:"prompt_tokens"`
+	CompletionTokens    int            `json:"completion_tokens"`
+	TotalTokens         int            `json:"total_tokens"`
+	PromptTokensDetails *promptDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+type promptDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
+type chatCompletion struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []chatChoice `json:"choices"`
+	Usage   chatUsage    `json:"usage"`
+}
+
+type chatChoice struct {
+	Index        int            `json:"index"`
+	Message      chatOutMessage `json:"message"`
+	FinishReason string         `json:"finish_reason"`
+}
+
+type chatOutMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatChunk struct {
+	ID      string        `json:"id"`
+	Object  string        `json:"object"`
+	Created int64         `json:"created"`
+	Model   string        `json:"model"`
+	Choices []chunkChoice `json:"choices"`
+	Usage   *chatUsage    `json:"usage,omitempty"`
+}
+
+type chunkChoice struct {
+	Index        int        `json:"index"`
+	Delta        chunkDelta `json:"delta"`
+	FinishReason *string    `json:"finish_reason"`
+}
+
+type chunkDelta struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// responsesEvent is the subset of the Codex SSE stream that carries an answer.
+type responsesEvent struct {
+	Type     string `json:"type"`
+	Delta    string `json:"delta"`
+	Response *struct {
+		Status string `json:"status"`
+		Usage  *struct {
+			InputTokens        int `json:"input_tokens"`
+			OutputTokens       int `json:"output_tokens"`
+			TotalTokens        int `json:"total_tokens"`
+			InputTokensDetails *struct {
+				CachedTokens int `json:"cached_tokens"`
+			} `json:"input_tokens_details"`
+		} `json:"usage"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	} `json:"response"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func (e responsesEvent) usage() chatUsage {
+	var out chatUsage
+	if e.Response == nil || e.Response.Usage == nil {
+		return out
+	}
+	u := e.Response.Usage
+	out.PromptTokens = u.InputTokens
+	out.CompletionTokens = u.OutputTokens
+	out.TotalTokens = u.TotalTokens
+	if out.TotalTokens == 0 {
+		out.TotalTokens = u.InputTokens + u.OutputTokens
+	}
+	if u.InputTokensDetails != nil {
+		out.PromptTokensDetails = &promptDetails{CachedTokens: u.InputTokensDetails.CachedTokens}
+	}
+	return out
+}
+
+func (e responsesEvent) failure() error {
+	if e.Error != nil && strings.TrimSpace(e.Error.Message) != "" {
+		return fmt.Errorf("chatgpt: %s", e.Error.Message)
+	}
+	if e.Response != nil && e.Response.Error != nil && strings.TrimSpace(e.Response.Error.Message) != "" {
+		return fmt.Errorf("chatgpt: %s", e.Response.Error.Message)
+	}
+	return fmt.Errorf("chatgpt: the model did not finish its answer")
+}
+
+// bufferedResponse reassembles the whole stream into one chat completion, for
+// the callers that asked for a plain response.
+func bufferedResponse(resp *http.Response, model string, logger *slog.Logger) (*http.Response, error) {
+	defer resp.Body.Close()
+
+	var text strings.Builder
+	var usage chatUsage
+	var failure error
+	err := scanSSE(resp.Body, func(event responsesEvent) error {
+		switch event.Type {
+		case "response.output_text.delta":
+			text.WriteString(event.Delta)
+		case "response.completed":
+			usage = event.usage()
+		case "response.failed", "response.incomplete", "error":
+			failure = event.failure()
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if failure != nil {
+		// A partial answer is worth more than none to every caller here -- the
+		// extractor parses leniently and the chatter shows what it got -- but a
+		// stream that produced nothing at all is a failure, not an empty reply.
+		if text.Len() == 0 {
+			return nil, failure
+		}
+		logger.Warn("the ChatGPT response ended early; keeping the partial answer",
+			"model", model, slog.Any("error", failure))
+	}
+
+	body, err := json.Marshal(chatCompletion{
+		ID:      completionID(),
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   model,
+		Choices: []chatChoice{{
+			Index:        0,
+			Message:      chatOutMessage{Role: "assistant", Content: text.String()},
+			FinishReason: "stop",
+		}},
+		Usage: usage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("chatgpt: encode chat completion: %w", err)
+	}
+
+	out := cloneResponseHead(resp)
+	out.Header.Set("Content-Type", "application/json")
+	out.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	out.Body = io.NopCloser(bytes.NewReader(body))
+	out.ContentLength = int64(len(body))
+	return out, nil
+}
+
+// streamingResponse re-emits the Codex stream as chat completion chunks, so the
+// SDK's own stream decoder -- and ai.completeStreaming above it -- see the
+// shape they expect.
+func streamingResponse(resp *http.Response, model string) *http.Response {
+	pr, pw := io.Pipe()
+
+	// Cloned before the goroutine starts, so nothing reads the upstream
+	// response's fields while the goroutine is draining its body.
+	out := cloneResponseHead(resp)
+	out.Header.Set("Content-Type", "text/event-stream")
+	out.Header.Del("Content-Length")
+	out.Body = pr
+	out.ContentLength = -1
+
+	go func() {
+		defer resp.Body.Close()
+
+		id := completionID()
+		created := time.Now().Unix()
+		writeChunk := func(chunk chatChunk) error {
+			payload, err := json.Marshal(chunk)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(pw, "data: %s\n\n", payload)
+			return err
+		}
+
+		var usage chatUsage
+		var failure error
+		err := scanSSE(resp.Body, func(event responsesEvent) error {
+			switch event.Type {
+			case "response.output_text.delta":
+				if event.Delta == "" {
+					return nil
+				}
+				return writeChunk(chatChunk{
+					ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+					Choices: []chunkChoice{{Delta: chunkDelta{Content: event.Delta}}},
+				})
+			case "response.completed":
+				usage = event.usage()
+			case "response.failed", "response.incomplete", "error":
+				failure = event.failure()
+			}
+			return nil
+		})
+		if err == nil && failure != nil {
+			err = failure
+		}
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+
+		stop := "stop"
+		final := chatChunk{
+			ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+			Choices: []chunkChoice{{Delta: chunkDelta{}, FinishReason: &stop}},
+		}
+		// Usage rides the final chunk, which is where stream_options puts it and
+		// where ai.completeStreaming looks.
+		if usage.PromptTokens > 0 || usage.CompletionTokens > 0 {
+			final.Usage = &usage
+		}
+		if err := writeChunk(final); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.WriteString(pw, "data: [DONE]\n\n"); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close()
+	}()
+
+	return out
+}
+
+// cloneResponseHead copies everything but the body, so the SDK still sees the
+// upstream status and request id.
+func cloneResponseHead(resp *http.Response) *http.Response {
+	out := *resp
+	out.Header = resp.Header.Clone()
+	if out.Header == nil {
+		out.Header = http.Header{}
+	}
+	return &out
+}
+
+// scanSSE reads an event stream.
+//
+// Content-Type is never consulted: the Codex backend sends the stream without
+// one, and a reader that branched on it would decide the body was JSON and fail
+// on the first `data:`.
+func scanSSE(r io.Reader, onEvent func(responsesEvent) error) error {
+	scanner := bufio.NewScanner(r)
+	// Deltas are small, but a single completed event carries the whole response
+	// object. 1 MiB is well past anything observed and still bounded.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			// event: lines and blank separators. The type is inside the JSON
+			// too, so nothing is lost by ignoring the event: field.
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var event responsesEvent
+		if err := json.Unmarshal([]byte(payload), &event); err != nil {
+			// One unreadable frame is not worth abandoning a good answer for.
+			continue
+		}
+		if err := onEvent(event); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("chatgpt: read response stream: %w", err)
+	}
+	return nil
+}
+
+func completionID() string {
+	return "chatcmpl-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+}

--- a/backend/internal/chatgpt/transport.go
+++ b/backend/internal/chatgpt/transport.go
@@ -133,15 +133,50 @@ type chatRequest struct {
 	MaxTokens           *int64          `json:"max_tokens"`
 	MaxCompletionTokens *int64          `json:"max_completion_tokens"`
 	ResponseFormat      *responseFormat `json:"response_format"`
+	Tools               []chatTool      `json:"tools"`
+	// ToolChoice is carried through as it arrived. Both shapes the SDK can
+	// send -- the "auto"/"none"/"required" strings the archive uses, and the
+	// {"type":"function",...} object it does not -- are also what the
+	// Responses endpoint accepts, so there is nothing to translate.
+	ToolChoice json.RawMessage `json:"tool_choice"`
 }
 
 type responseFormat struct {
 	Type string `json:"type"`
 }
 
+// chatTool is one function tool as Chat Completions declares it: the name and
+// schema nested under a "function" object.
+type chatTool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+		Strict      *bool           `json:"strict"`
+	} `json:"function"`
+}
+
 type chatMessage struct {
 	Role    string          `json:"role"`
 	Content json.RawMessage `json:"content"`
+	// ToolCalls is what an assistant message carries instead of content when
+	// the model asked for a tool. Content is null on those, which is why the
+	// empty-text skip below cannot come first.
+	ToolCalls []chatToolCall `json:"tool_calls"`
+	// ToolCallID ties a tool-role message back to the call it answers.
+	ToolCallID string `json:"tool_call_id"`
+}
+
+type chatToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function chatToolCallFunc `json:"function"`
+}
+
+type chatToolCallFunc struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
 }
 
 type responsesRequest struct {
@@ -152,12 +187,32 @@ type responsesRequest struct {
 	Store           bool            `json:"store"`
 	MaxOutputTokens *int64          `json:"max_output_tokens,omitempty"`
 	Text            *responsesText  `json:"text,omitempty"`
+	Tools           []responsesTool `json:"tools,omitempty"`
+	ToolChoice      json.RawMessage `json:"tool_choice,omitempty"`
 }
 
+// responsesTool is the same function tool, flattened: the Responses shape puts
+// the name and schema on the tool itself rather than under a "function" key.
+type responsesTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Strict      bool            `json:"strict"`
+}
+
+// responsesItem is one input item. Three shapes share it, because the Responses
+// input list is a union: a message carries Role and Content, a function_call
+// carries CallID/Name/Arguments, and a function_call_output carries CallID and
+// Output. Everything not belonging to the shape in hand is omitted.
 type responsesItem struct {
-	Type    string             `json:"type"`
-	Role    string             `json:"role"`
-	Content []responsesContent `json:"content"`
+	Type      string             `json:"type"`
+	Role      string             `json:"role,omitempty"`
+	Content   []responsesContent `json:"content,omitempty"`
+	CallID    string             `json:"call_id,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Arguments string             `json:"arguments,omitempty"`
+	Output    string             `json:"output,omitempty"`
 }
 
 type responsesContent struct {
@@ -206,11 +261,44 @@ func toResponsesRequest(in chatRequest) responsesRequest {
 
 	instructions := []string{codexInstructions}
 	for _, msg := range in.Messages {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
 		text := messageText(msg.Content)
+
+		// The two shapes that are not a message have to be handled before the
+		// empty-text skip below: a tool result is an item of its own, and an
+		// assistant message that only asked for a tool has no content at all.
+		if role == "tool" {
+			if id := strings.TrimSpace(msg.ToolCallID); id != "" {
+				out.Input = append(out.Input, responsesItem{
+					Type: "function_call_output", CallID: id, Output: text,
+				})
+			}
+			continue
+		}
+		if role == "assistant" && len(msg.ToolCalls) > 0 {
+			// Some models say something before calling a tool. Keep it: it is
+			// part of the conversation the next round replays.
+			if strings.TrimSpace(text) != "" {
+				out.Input = append(out.Input, responsesItem{
+					Type: "message", Role: "assistant",
+					Content: []responsesContent{{Type: "output_text", Text: text}},
+				})
+			}
+			for _, call := range msg.ToolCalls {
+				out.Input = append(out.Input, responsesItem{
+					Type:      "function_call",
+					CallID:    call.ID,
+					Name:      call.Function.Name,
+					Arguments: call.Function.Arguments,
+				})
+			}
+			continue
+		}
+
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
+		switch role {
 		case "system", "developer":
 			// The Responses API has no system message: the role's content is
 			// the instructions field, which is also where the backend looks
@@ -229,6 +317,26 @@ func toResponsesRequest(in chatRequest) responsesRequest {
 		}
 	}
 	out.Instructions = strings.Join(instructions, "\n\n")
+
+	for _, tool := range in.Tools {
+		name := strings.TrimSpace(tool.Function.Name)
+		if name == "" {
+			continue
+		}
+		out.Tools = append(out.Tools, responsesTool{
+			Type:        "function",
+			Name:        name,
+			Description: tool.Function.Description,
+			Parameters:  tool.Function.Parameters,
+			// Matching ai.responsesParamsFrom: the archive's schemas are
+			// hand-written guidance rather than contracts, and strict mode
+			// rejects several of them outright.
+			Strict: false,
+		})
+	}
+	if len(out.Tools) > 0 {
+		out.ToolChoice = in.ToolChoice
+	}
 
 	switch {
 	case in.MaxCompletionTokens != nil:
@@ -306,8 +414,9 @@ type chatChoice struct {
 }
 
 type chatOutMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role      string         `json:"role"`
+	Content   string         `json:"content"`
+	ToolCalls []chatToolCall `json:"tool_calls,omitempty"`
 }
 
 type chatChunk struct {
@@ -326,16 +435,32 @@ type chunkChoice struct {
 }
 
 type chunkDelta struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
+	Role      string          `json:"role,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	ToolCalls []chunkToolCall `json:"tool_calls,omitempty"`
+}
+
+// chunkToolCall is a tool call inside a stream, where the index is what ties
+// fragments of one call together. Whole calls are emitted here rather than
+// fragments, but the index is still required for a decoder to place them.
+type chunkToolCall struct {
+	Index    int              `json:"index"`
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function chatToolCallFunc `json:"function"`
 }
 
 // responsesEvent is the subset of the Codex SSE stream that carries an answer.
 type responsesEvent struct {
-	Type     string `json:"type"`
-	Delta    string `json:"delta"`
+	Type  string `json:"type"`
+	Delta string `json:"delta"`
+	// Item carries a completed output item on response.output_item.done --
+	// which is where a function call arrives whole, arguments included, so
+	// nothing here has to accumulate argument fragments.
+	Item     *responsesOutputItem `json:"item"`
 	Response *struct {
-		Status string `json:"status"`
+		Status string                `json:"status"`
+		Output []responsesOutputItem `json:"output"`
 		Usage  *struct {
 			InputTokens        int `json:"input_tokens"`
 			OutputTokens       int `json:"output_tokens"`
@@ -351,6 +476,35 @@ type responsesEvent struct {
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error"`
+}
+
+// responsesOutputItem is one item the model produced. Only function calls are
+// read from it: the text arrives as deltas, which are cheaper to append than to
+// pick back out of the completed response.
+type responsesOutputItem struct {
+	Type      string `json:"type"`
+	CallID    string `json:"call_id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// toolCall turns a function_call output item into the Chat Completions shape,
+// and reports whether the item was one at all.
+func (i responsesOutputItem) toolCall() (chatToolCall, bool) {
+	if i.Type != "function_call" || strings.TrimSpace(i.Name) == "" {
+		return chatToolCall{}, false
+	}
+	args := i.Arguments
+	if strings.TrimSpace(args) == "" {
+		// A call with no arguments comes back with the field empty rather than
+		// as "{}", and every caller here feeds it straight to json.Unmarshal.
+		args = "{}"
+	}
+	return chatToolCall{
+		ID:       i.CallID,
+		Type:     "function",
+		Function: chatToolCallFunc{Name: i.Name, Arguments: args},
+	}, true
 }
 
 func (e responsesEvent) usage() chatUsage {
@@ -388,13 +542,25 @@ func bufferedResponse(resp *http.Response, model string, logger *slog.Logger) (*
 
 	var text strings.Builder
 	var usage chatUsage
+	var toolCalls []chatToolCall
+	var completed []responsesOutputItem
 	var failure error
 	err := scanSSE(resp.Body, func(event responsesEvent) error {
 		switch event.Type {
 		case "response.output_text.delta":
 			text.WriteString(event.Delta)
+		case "response.output_item.done":
+			if event.Item == nil {
+				return nil
+			}
+			if call, ok := event.Item.toolCall(); ok {
+				toolCalls = append(toolCalls, call)
+			}
 		case "response.completed":
 			usage = event.usage()
+			if event.Response != nil {
+				completed = event.Response.Output
+			}
 		case "response.failed", "response.incomplete", "error":
 			failure = event.failure()
 		}
@@ -403,26 +569,46 @@ func bufferedResponse(resp *http.Response, model string, logger *slog.Logger) (*
 	if err != nil {
 		return nil, err
 	}
+	// The per-item events are the primary source; the completed response is
+	// read only when none arrived, so a backend that reports its output one way
+	// or the other is served either way and neither is counted twice.
+	if len(toolCalls) == 0 {
+		for _, item := range completed {
+			if call, ok := item.toolCall(); ok {
+				toolCalls = append(toolCalls, call)
+			}
+		}
+	}
 	if failure != nil {
 		// A partial answer is worth more than none to every caller here -- the
 		// extractor parses leniently and the chatter shows what it got -- but a
 		// stream that produced nothing at all is a failure, not an empty reply.
-		if text.Len() == 0 {
+		if text.Len() == 0 && len(toolCalls) == 0 {
 			return nil, failure
 		}
 		logger.Warn("the ChatGPT response ended early; keeping the partial answer",
 			"model", model, slog.Any("error", failure))
 	}
 
+	// A model that asked for a tool has not finished answering, and the search
+	// and research loops read the reason as well as the calls.
+	finish := "stop"
+	if len(toolCalls) > 0 {
+		finish = "tool_calls"
+	}
 	body, err := json.Marshal(chatCompletion{
 		ID:      completionID(),
 		Object:  "chat.completion",
 		Created: time.Now().Unix(),
 		Model:   model,
 		Choices: []chatChoice{{
-			Index:        0,
-			Message:      chatOutMessage{Role: "assistant", Content: text.String()},
-			FinishReason: "stop",
+			Index: 0,
+			Message: chatOutMessage{
+				Role:      "assistant",
+				Content:   text.String(),
+				ToolCalls: toolCalls,
+			},
+			FinishReason: finish,
 		}},
 		Usage: usage,
 	})
@@ -468,6 +654,12 @@ func streamingResponse(resp *http.Response, model string) *http.Response {
 
 		var usage chatUsage
 		var failure error
+		// Tool calls are emitted whole, one chunk each, as they complete. No
+		// caller streams a tool-bearing request today -- research streams only
+		// its final answer turn, which declares none -- but a middleware that
+		// dropped them here would be lossy in exactly the way the buffered path
+		// was, and silently.
+		toolIndex := 0
 		err := scanSSE(resp.Body, func(event responsesEvent) error {
 			switch event.Type {
 			case "response.output_text.delta":
@@ -477,6 +669,25 @@ func streamingResponse(resp *http.Response, model string) *http.Response {
 				return writeChunk(chatChunk{
 					ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
 					Choices: []chunkChoice{{Delta: chunkDelta{Content: event.Delta}}},
+				})
+			case "response.output_item.done":
+				if event.Item == nil {
+					return nil
+				}
+				call, ok := event.Item.toolCall()
+				if !ok {
+					return nil
+				}
+				index := toolIndex
+				toolIndex++
+				return writeChunk(chatChunk{
+					ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+					Choices: []chunkChoice{{Delta: chunkDelta{ToolCalls: []chunkToolCall{{
+						Index:    index,
+						ID:       call.ID,
+						Type:     call.Type,
+						Function: call.Function,
+					}}}}},
 				})
 			case "response.completed":
 				usage = event.usage()
@@ -494,6 +705,9 @@ func streamingResponse(resp *http.Response, model string) *http.Response {
 		}
 
 		stop := "stop"
+		if toolIndex > 0 {
+			stop = "tool_calls"
+		}
 		final := chatChunk{
 			ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
 			Choices: []chunkChoice{{Delta: chunkDelta{}, FinishReason: &stop}},

--- a/backend/internal/chatgpt/transport.go
+++ b/backend/internal/chatgpt/transport.go
@@ -215,9 +215,17 @@ type responsesItem struct {
 	Output    string             `json:"output,omitempty"`
 }
 
+// responsesContent is one part of a message's content. Text uses Text; an image
+// uses ImageURL, which carries a data URI for a file this app read off disk;
+// and a PDF uses Filename with FileData, the same data URI. The Responses shape
+// puts the image's URL directly on the part, where the Chat Completions shape
+// nests it under an "image_url" object.
 type responsesContent struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data,omitempty"`
 }
 
 type responsesText struct {
@@ -262,15 +270,14 @@ func toResponsesRequest(in chatRequest) responsesRequest {
 	instructions := []string{codexInstructions}
 	for _, msg := range in.Messages {
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
-		text := messageText(msg.Content)
 
 		// The two shapes that are not a message have to be handled before the
-		// empty-text skip below: a tool result is an item of its own, and an
+		// empty-content skip below: a tool result is an item of its own, and an
 		// assistant message that only asked for a tool has no content at all.
 		if role == "tool" {
 			if id := strings.TrimSpace(msg.ToolCallID); id != "" {
 				out.Input = append(out.Input, responsesItem{
-					Type: "function_call_output", CallID: id, Output: text,
+					Type: "function_call_output", CallID: id, Output: messageText(msg.Content),
 				})
 			}
 			continue
@@ -278,10 +285,9 @@ func toResponsesRequest(in chatRequest) responsesRequest {
 		if role == "assistant" && len(msg.ToolCalls) > 0 {
 			// Some models say something before calling a tool. Keep it: it is
 			// part of the conversation the next round replays.
-			if strings.TrimSpace(text) != "" {
+			if content := messageContent(msg.Content, "assistant"); len(content) > 0 {
 				out.Input = append(out.Input, responsesItem{
-					Type: "message", Role: "assistant",
-					Content: []responsesContent{{Type: "output_text", Text: text}},
+					Type: "message", Role: "assistant", Content: content,
 				})
 			}
 			for _, call := range msg.ToolCalls {
@@ -295,26 +301,27 @@ func toResponsesRequest(in chatRequest) responsesRequest {
 			continue
 		}
 
-		if strings.TrimSpace(text) == "" {
+		// The Responses API has no system message: the role's content is the
+		// instructions field, which is also where the backend looks for the
+		// preamble above.
+		if role == "system" || role == "developer" {
+			if text := messageText(msg.Content); strings.TrimSpace(text) != "" {
+				instructions = append(instructions, text)
+			}
 			continue
 		}
-		switch role {
-		case "system", "developer":
-			// The Responses API has no system message: the role's content is
-			// the instructions field, which is also where the backend looks
-			// for the preamble above.
-			instructions = append(instructions, text)
-		case "assistant":
-			out.Input = append(out.Input, responsesItem{
-				Type: "message", Role: "assistant",
-				Content: []responsesContent{{Type: "output_text", Text: text}},
-			})
-		default:
-			out.Input = append(out.Input, responsesItem{
-				Type: "message", Role: "user",
-				Content: []responsesContent{{Type: "input_text", Text: text}},
-			})
+
+		itemRole := "user"
+		if role == "assistant" {
+			itemRole = "assistant"
 		}
+		content := messageContent(msg.Content, itemRole)
+		if len(content) == 0 {
+			continue
+		}
+		out.Input = append(out.Input, responsesItem{
+			Type: "message", Role: itemRole, Content: content,
+		})
 	}
 	out.Instructions = strings.Join(instructions, "\n\n")
 
@@ -351,29 +358,84 @@ func toResponsesRequest(in chatRequest) responsesRequest {
 	return out
 }
 
-// messageText flattens a chat message's content.
+// chatContentPart is one part of a multi-part chat message. OCR is the caller
+// that sends these: a text prompt plus the document, as an image_url part for a
+// scan or a file part for a PDF, both carrying a base64 data URI rather than a
+// URL the backend would have to fetch.
+type chatContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	ImageURL *struct {
+		URL string `json:"url"`
+	} `json:"image_url"`
+	File *struct {
+		Filename string `json:"filename"`
+		FileData string `json:"file_data"`
+	} `json:"file"`
+}
+
+// messageContent translates a chat message's content into Responses parts.
 //
-// Content is either a plain string or an array of typed parts. Only the text
-// parts are kept: the one caller that sends images is OCR, and CanOCR already
-// refuses this SDK, so an image here means a misconfiguration rather than a
-// case to support.
-func messageText(raw json.RawMessage) string {
+// Content is either a plain string or an array of typed parts. Both shapes
+// reach here: the extractor and the chatter send strings, OCR sends parts.
+// A part of a kind not named below is dropped rather than guessed at -- sending
+// an unknown shape to the backend earns an opaque 400 rather than a clear
+// failure.
+//
+// textOnly is what the instructions field needs, since a system message is not
+// an item and can only be a string.
+func messageContent(raw json.RawMessage, kind string) []responsesContent {
 	if len(raw) == 0 {
-		return ""
+		return nil
 	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err == nil {
-		return s
+	textType := "input_text"
+	if kind == "assistant" {
+		textType = "output_text"
 	}
-	var parts []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
+
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		if strings.TrimSpace(plain) == "" {
+			return nil
+		}
+		return []responsesContent{{Type: textType, Text: plain}}
 	}
+
+	var parts []chatContentPart
 	if err := json.Unmarshal(raw, &parts); err != nil {
-		return ""
+		return nil
 	}
-	var b strings.Builder
+	out := make([]responsesContent, 0, len(parts))
 	for _, part := range parts {
+		switch {
+		case part.Text != "":
+			out = append(out, responsesContent{Type: textType, Text: part.Text})
+		case part.ImageURL != nil && part.ImageURL.URL != "":
+			// input_image carries the URL on the part itself, not nested.
+			out = append(out, responsesContent{Type: "input_image", ImageURL: part.ImageURL.URL})
+		case part.File != nil && part.File.FileData != "":
+			name := part.File.Filename
+			if name == "" {
+				name = "document"
+			}
+			out = append(out, responsesContent{
+				Type: "input_file", Filename: name, FileData: part.File.FileData,
+			})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// messageText flattens a chat message's content to its text, for the system
+// role -- which the Responses API has no item for, only the instructions
+// string. Any attachment is left behind, which is correct: nobody sends a
+// document as a system message.
+func messageText(raw json.RawMessage) string {
+	var b strings.Builder
+	for _, part := range messageContent(raw, "user") {
 		if part.Text == "" {
 			continue
 		}

--- a/backend/internal/chatgpt/transport_test.go
+++ b/backend/internal/chatgpt/transport_test.go
@@ -1,0 +1,353 @@
+package chatgpt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// signedInSource is a source that hands out a token without touching a network.
+func signedInSource(t *testing.T, id string) *TokenSource {
+	t.Helper()
+	Forget(id)
+	t.Cleanup(func() { Forget(id) })
+	raw, err := Token{
+		Access: "access-1", Refresh: "r", AccountID: "acct-9",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return SourceFor(id, raw, nil, nil)
+}
+
+// sseBody is a Codex event stream. It is served without a Content-Type header
+// on purpose: the real backend sends none, and a reader that branched on it
+// would decide the body was JSON and fail on the first frame.
+func sseResponse(events ...string) *http.Response {
+	var b strings.Builder
+	for _, e := range events {
+		b.WriteString("event: x\ndata: " + e + "\n\n")
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(b.String())),
+	}
+}
+
+func chatBody(t *testing.T, stream bool) io.ReadCloser {
+	t.Helper()
+	body := map[string]any{
+		"model":  "gpt-5.6-luna",
+		"stream": stream,
+		"messages": []map[string]any{
+			{"role": "system", "content": "Return JSON."},
+			{"role": "user", "content": "Who signed this?"},
+		},
+		"max_tokens":      int64(256),
+		"response_format": map[string]any{"type": "json_object"},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return io.NopCloser(bytes.NewReader(raw))
+}
+
+func chatRequestFor(t *testing.T, stream bool) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://chatgpt.com/backend-api/codex/chat/completions", chatBody(t, stream))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func TestChatCompletionBecomesACodexResponsesCall(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t1"), nil)
+
+	var sent responsesRequest
+	var sentReq *http.Request
+	_, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		sentReq = req
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(raw, &sent); err != nil {
+			t.Fatalf("the rewritten body is not a responses request: %v", err)
+		}
+		return sseResponse(
+			`{"type":"response.output_text.delta","delta":"Ada "}`,
+			`{"type":"response.output_text.delta","delta":"Lovelace"}`,
+			`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":11,"output_tokens":3,"input_tokens_details":{"cached_tokens":7}}}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sentReq.URL.Path; got != "/backend-api/codex/responses" {
+		t.Fatalf("path = %q, want the responses endpoint", got)
+	}
+	// Without these the backend answers 403 regardless of the token.
+	for header, want := range map[string]string{
+		"Authorization":      "Bearer access-1",
+		"chatgpt-account-id": "acct-9",
+		"OpenAI-Beta":        codexBeta,
+		"originator":         codexOriginator,
+	} {
+		if got := sentReq.Header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+	if sentReq.Header.Get("session_id") == "" {
+		t.Error("session_id is empty")
+	}
+
+	// The Responses API has no system role: it becomes instructions, behind
+	// the preamble the backend expects to lead them.
+	if !strings.HasPrefix(sent.Instructions, codexInstructions) {
+		t.Errorf("instructions = %q, want the Codex preamble first", sent.Instructions)
+	}
+	if !strings.Contains(sent.Instructions, "Return JSON.") {
+		t.Errorf("instructions dropped the caller's system message: %q", sent.Instructions)
+	}
+	if len(sent.Input) != 1 || sent.Input[0].Role != "user" || sent.Input[0].Content[0].Type != "input_text" {
+		t.Fatalf("input = %+v", sent.Input)
+	}
+	if !sent.Stream {
+		t.Error("stream must be forced on: the endpoint answers no other way")
+	}
+	// Nobody asked for their archive to be kept in a ChatGPT history.
+	if sent.Store {
+		t.Error("store must be off")
+	}
+	if sent.MaxOutputTokens == nil || *sent.MaxOutputTokens != 256 {
+		t.Errorf("max_output_tokens = %v, want the caller's max_tokens", sent.MaxOutputTokens)
+	}
+	if sent.Text == nil || sent.Text.Format.Type != "json_object" {
+		t.Errorf("text.format = %+v, want the caller's response_format", sent.Text)
+	}
+}
+
+func TestABufferedAnswerIsReassembledIntoAChatCompletion(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t2"), nil)
+
+	resp, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.output_text.delta","delta":"Ada "}`,
+			`{"type":"response.output_text.delta","delta":"Lovelace"}`,
+			`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":11,"output_tokens":3,"total_tokens":14,"input_tokens_details":{"cached_tokens":7}}}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+
+	var out chatCompletion
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Choices) != 1 || out.Choices[0].Message.Content != "Ada Lovelace" {
+		t.Fatalf("choices = %+v", out.Choices)
+	}
+	if out.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish_reason = %q", out.Choices[0].FinishReason)
+	}
+	// Usage is what the token accounting in ai.logUsage records; dropping it
+	// would leave every ChatGPT completion logged as a line of zeros.
+	if out.Usage.PromptTokens != 11 || out.Usage.CompletionTokens != 3 {
+		t.Fatalf("usage = %+v", out.Usage)
+	}
+	if out.Usage.PromptTokensDetails == nil || out.Usage.PromptTokensDetails.CachedTokens != 7 {
+		t.Errorf("cached tokens = %+v", out.Usage.PromptTokensDetails)
+	}
+}
+
+func TestAStreamedAnswerBecomesChatCompletionChunks(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t3"), nil)
+
+	resp, err := mw(chatRequestFor(t, true), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.output_text.delta","delta":"Ada "}`,
+			`{"type":"response.output_text.delta","delta":"Lovelace"}`,
+			`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":11,"output_tokens":3}}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q", got)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	if !strings.HasSuffix(strings.TrimSpace(body), "data: [DONE]") {
+		t.Errorf("stream does not end with the terminator: %q", body)
+	}
+
+	var text strings.Builder
+	var sawStop bool
+	var usage *chatUsage
+	for _, line := range strings.Split(body, "\n") {
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if !strings.HasPrefix(line, "data:") || payload == "[DONE]" {
+			continue
+		}
+		var chunk chatChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			t.Fatalf("chunk is not a chat.completion.chunk: %v", err)
+		}
+		if chunk.Object != "chat.completion.chunk" {
+			t.Errorf("object = %q", chunk.Object)
+		}
+		for _, choice := range chunk.Choices {
+			text.WriteString(choice.Delta.Content)
+			if choice.FinishReason != nil && *choice.FinishReason == "stop" {
+				sawStop = true
+			}
+		}
+		if chunk.Usage != nil {
+			usage = chunk.Usage
+		}
+	}
+	if text.String() != "Ada Lovelace" {
+		t.Fatalf("streamed text = %q", text.String())
+	}
+	if !sawStop {
+		t.Error("no chunk carried finish_reason=stop")
+	}
+	// ai.completeStreaming reads usage off the final chunk and nowhere else.
+	if usage == nil || usage.PromptTokens != 11 {
+		t.Fatalf("usage = %+v", usage)
+	}
+}
+
+// The SDK's error decoding and ai.CompleteChat's retry-without-JSON-mode path
+// both read the upstream body. Rewriting a failure would hide both.
+func TestAnErrorResponsePassesThroughUntouched(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t4"), nil)
+
+	resp, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 400,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"nope"}}`)),
+		}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), "nope") {
+		t.Fatalf("body was rewritten: %s", raw)
+	}
+}
+
+// Anything that is not a chat completion -- a models listing, an embeddings
+// call from a misbound provider -- must reach the network as it was.
+func TestOtherPathsAreNotRewritten(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t5"), nil)
+
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api/codex/models", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	if _, err := mw(req, func(got *http.Request) (*http.Response, error) {
+		called = true
+		if got.URL.Path != "/backend-api/codex/models" {
+			t.Errorf("path = %q, want it untouched", got.URL.Path)
+		}
+		if got.Header.Get("Authorization") != "" {
+			t.Error("a passed-through request was given a token")
+		}
+		return &http.Response{StatusCode: 200, Header: http.Header{}, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("the request never reached the transport")
+	}
+}
+
+// A stream that stops early still carries an answer worth keeping: the
+// extractor parses leniently and the chatter shows what arrived.
+func TestAPartialAnswerSurvivesAFailedStream(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t6"), nil)
+
+	resp, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.output_text.delta","delta":"half an "}`,
+			`{"type":"response.failed","response":{"error":{"message":"rate limit"}}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out chatCompletion
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Choices[0].Message.Content != "half an " {
+		t.Fatalf("content = %q", out.Choices[0].Message.Content)
+	}
+
+	// A stream that produced nothing at all is a failure, not an empty reply.
+	if _, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(`{"type":"response.failed","response":{"error":{"message":"rate limit"}}}`), nil
+	}); err == nil || !strings.Contains(err.Error(), "rate limit") {
+		t.Fatalf("err = %v, want the backend's reason", err)
+	}
+}
+
+// A provider row nobody signed in to must fail before it reaches the network,
+// with a message that says what is missing.
+func TestAnUnsignedProviderNeverReachesTheNetwork(t *testing.T) {
+	t.Parallel()
+	Forget("t7")
+	defer Forget("t7")
+	mw := Middleware(SourceFor("t7", "", nil, nil), nil)
+
+	if _, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		t.Fatal("an unsigned provider reached the transport")
+		return nil, nil
+	}); err != ErrNotSignedIn {
+		t.Fatalf("err = %v, want ErrNotSignedIn", err)
+	}
+}
+
+func TestArrayContentIsFlattened(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`[{"type":"text","text":"one"},{"type":"text","text":"two"}]`)
+	if got := messageText(raw); got != "one\ntwo" {
+		t.Fatalf("messageText = %q", got)
+	}
+	if got := messageText(json.RawMessage(`"plain"`)); got != "plain" {
+		t.Fatalf("messageText = %q", got)
+	}
+}

--- a/backend/internal/chatgpt/transport_test.go
+++ b/backend/internal/chatgpt/transport_test.go
@@ -341,6 +341,8 @@ func TestAnUnsignedProviderNeverReachesTheNetwork(t *testing.T) {
 	}
 }
 
+// messageText is the system role's path: instructions is a string, so an
+// attachment there has nowhere to go and text is all that is kept.
 func TestArrayContentIsFlattened(t *testing.T) {
 	t.Parallel()
 	raw := json.RawMessage(`[{"type":"text","text":"one"},{"type":"text","text":"two"}]`)
@@ -349,6 +351,10 @@ func TestArrayContentIsFlattened(t *testing.T) {
 	}
 	if got := messageText(json.RawMessage(`"plain"`)); got != "plain" {
 		t.Fatalf("messageText = %q", got)
+	}
+	withImage := json.RawMessage(`[{"type":"text","text":"read this"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AA"}}]`)
+	if got := messageText(withImage); got != "read this" {
+		t.Fatalf("messageText = %q, want the text alone", got)
 	}
 }
 
@@ -675,5 +681,162 @@ func TestAStreamedFunctionCallBecomesAToolCallChunk(t *testing.T) {
 	}
 	if !strings.Contains(text, `"finish_reason":"tool_calls"`) {
 		t.Errorf("final chunk did not finish on tool_calls:\n%s", text)
+	}
+}
+
+// ocrRequestFor is the request internal/ocr builds: a system message, then a
+// user message whose content is a prompt plus the document -- an image_url part
+// for a scan or a file part for a PDF, each carrying a base64 data URI rather
+// than a URL the backend would have to fetch. See ocr.LLMUserContentParts.
+func ocrRequestFor(t *testing.T, document map[string]any) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"model": "gpt-5.6-luna",
+		"messages": []map[string]any{
+			{"role": "system", "content": "You transcribe documents for an archive."},
+			{"role": "user", "content": []map[string]any{
+				{"type": "text", "text": "Extract all text from this document."},
+				document,
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://chatgpt.com/backend-api/codex/chat/completions", io.NopCloser(bytes.NewReader(raw)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func sentInputFor(t *testing.T, mw func(*http.Request, func(*http.Request) (*http.Response, error)) (*http.Response, error), req *http.Request) responsesRequest {
+	t.Helper()
+	var sent responsesRequest
+	if _, err := mw(req, func(r *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &sent); err != nil {
+			t.Fatal(err)
+		}
+		return sseResponse(`{"type":"response.output_text.delta","delta":"text"}`,
+			`{"type":"response.completed","response":{"status":"completed"}}`), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return sent
+}
+
+// OCR is the caller that sends something other than text. A middleware that
+// kept only the text parts would send the model a transcription prompt with no
+// document behind it -- and the model would answer, so the failure is an
+// invented or empty transcription rather than an error.
+func TestAScanReachesTheModelAsAnImage(t *testing.T) {
+	t.Parallel()
+	const dataURI = "data:image/png;base64,iVBORw0KGgo="
+	sent := sentInputFor(t, Middleware(signedInSource(t, "t20"), nil), ocrRequestFor(t, map[string]any{
+		"type":      "image_url",
+		"image_url": map[string]any{"url": dataURI},
+	}))
+
+	if len(sent.Input) != 1 {
+		t.Fatalf("input = %+v, want the one user message", sent.Input)
+	}
+	parts := sent.Input[0].Content
+	if len(parts) != 2 {
+		t.Fatalf("content = %+v, want the prompt and the image", parts)
+	}
+	if parts[0].Type != "input_text" || !strings.Contains(parts[0].Text, "Extract all text") {
+		t.Errorf("prompt part = %+v", parts[0])
+	}
+	// input_image carries the URL on the part itself; the chat shape nests it
+	// under an "image_url" object, and sending that nested shape earns an
+	// opaque 400.
+	if parts[1].Type != "input_image" || parts[1].ImageURL != dataURI {
+		t.Fatalf("image part = %+v", parts[1])
+	}
+}
+
+func TestAPDFReachesTheModelAsAFile(t *testing.T) {
+	t.Parallel()
+	const dataURI = "data:application/pdf;base64,JVBERi0="
+	sent := sentInputFor(t, Middleware(signedInSource(t, "t21"), nil), ocrRequestFor(t, map[string]any{
+		"type": "file",
+		"file": map[string]any{"filename": "rent.pdf", "file_data": dataURI},
+	}))
+
+	parts := sent.Input[0].Content
+	if len(parts) != 2 {
+		t.Fatalf("content = %+v, want the prompt and the file", parts)
+	}
+	if parts[1].Type != "input_file" || parts[1].FileData != dataURI {
+		t.Fatalf("file part = %+v", parts[1])
+	}
+	// The name is what tells the model it is looking at a PDF rather than an
+	// opaque blob, and openai-go sends one for every OCR call.
+	if parts[1].Filename != "rent.pdf" {
+		t.Errorf("filename = %q", parts[1].Filename)
+	}
+}
+
+// A file with no name still has to go: LLMUserContentParts defaults it, but a
+// caller reaching this middleware directly may not.
+func TestAnUnnamedFileStillGetsAName(t *testing.T) {
+	t.Parallel()
+	sent := sentInputFor(t, Middleware(signedInSource(t, "t22"), nil), ocrRequestFor(t, map[string]any{
+		"type": "file",
+		"file": map[string]any{"file_data": "data:application/pdf;base64,JVBERi0="},
+	}))
+	parts := sent.Input[0].Content
+	if len(parts) != 2 || parts[1].Filename == "" {
+		t.Fatalf("content = %+v, want a named file part", parts)
+	}
+}
+
+// A part of a kind nothing here knows is dropped rather than forwarded as an
+// unknown shape, which the backend answers with an opaque 400.
+func TestAnUnknownContentPartIsDropped(t *testing.T) {
+	t.Parallel()
+	sent := sentInputFor(t, Middleware(signedInSource(t, "t23"), nil), ocrRequestFor(t, map[string]any{
+		"type":        "input_audio",
+		"input_audio": map[string]any{"data": "AAA", "format": "wav"},
+	}))
+	parts := sent.Input[0].Content
+	if len(parts) != 1 || parts[0].Type != "input_text" {
+		t.Fatalf("content = %+v, want only the text part", parts)
+	}
+}
+
+// An assistant turn's text is output_text, not input_text: the Responses shape
+// distinguishes them, and a replayed conversation that got it wrong would be
+// refused.
+func TestAssistantTextIsOutputText(t *testing.T) {
+	t.Parallel()
+	raw, err := json.Marshal(map[string]any{
+		"model": "gpt-5.6-luna",
+		"messages": []map[string]any{
+			{"role": "user", "content": "hello"},
+			{"role": "assistant", "content": "hi"},
+			{"role": "user", "content": "again"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://chatgpt.com/backend-api/codex/chat/completions", io.NopCloser(bytes.NewReader(raw)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sent := sentInputFor(t, Middleware(signedInSource(t, "t24"), nil), req)
+
+	if len(sent.Input) != 3 {
+		t.Fatalf("input = %+v", sent.Input)
+	}
+	if sent.Input[0].Content[0].Type != "input_text" {
+		t.Errorf("user part = %+v", sent.Input[0].Content[0])
+	}
+	if sent.Input[1].Role != "assistant" || sent.Input[1].Content[0].Type != "output_text" {
+		t.Errorf("assistant part = %+v", sent.Input[1])
 	}
 }

--- a/backend/internal/chatgpt/transport_test.go
+++ b/backend/internal/chatgpt/transport_test.go
@@ -351,3 +351,329 @@ func TestArrayContentIsFlattened(t *testing.T) {
 		t.Fatalf("messageText = %q", got)
 	}
 }
+
+// searchToolBody is a tool-bearing completion in the shape openai-go marshals
+// one: the function's name and schema nested under "function", and tool_choice
+// as the bare string the search and research loops send.
+func searchToolBody(t *testing.T, choice string, messages []map[string]any) io.ReadCloser {
+	t.Helper()
+	if messages == nil {
+		messages = []map[string]any{
+			{"role": "system", "content": "You search an archive."},
+			{"role": "user", "content": "What did the landlord send in May?"},
+		}
+	}
+	raw, err := json.Marshal(map[string]any{
+		"model":    "gpt-5.6-luna",
+		"messages": messages,
+		"tools": []map[string]any{{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "search_documents",
+				"description": "Search the user's document archive.",
+				"parameters": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"query": map[string]any{"type": "string"}},
+					"required":   []string{"query"},
+				},
+			},
+		}},
+		"tool_choice": choice,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return io.NopCloser(bytes.NewReader(raw))
+}
+
+func toolRequestFor(t *testing.T, choice string, messages []map[string]any) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://chatgpt.com/backend-api/codex/chat/completions", searchToolBody(t, choice, messages))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+// Deep Search and Research declare function tools on every round. A middleware
+// that dropped them would leave the model unable to reach the archive at all,
+// and the search loop reads a round with no tool calls as a finished answer --
+// so the failure is a confident reply with no documents behind it, not an error.
+func TestFunctionToolsReachTheCodexEndpoint(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t10"), nil)
+
+	var sent responsesRequest
+	_, err := mw(toolRequestFor(t, "auto", nil), func(req *http.Request) (*http.Response, error) {
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(raw, &sent); err != nil {
+			t.Fatal(err)
+		}
+		return sseResponse(`{"type":"response.completed","response":{"status":"completed"}}`), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sent.Tools) != 1 {
+		t.Fatalf("tools = %+v, want the caller's one function", sent.Tools)
+	}
+	tool := sent.Tools[0]
+	// Flattened: the Responses shape puts the name on the tool itself rather
+	// than under a "function" key.
+	if tool.Type != "function" || tool.Name != "search_documents" {
+		t.Errorf("tool = %+v", tool)
+	}
+	if !strings.Contains(tool.Description, "document archive") {
+		t.Errorf("description = %q", tool.Description)
+	}
+	if !strings.Contains(string(tool.Parameters), `"query"`) {
+		t.Errorf("parameters = %s", tool.Parameters)
+	}
+	if tool.Strict {
+		t.Error("strict must stay off: the archive's schemas are guidance, and strict mode rejects several")
+	}
+	if got := strings.TrimSpace(string(sent.ToolChoice)); got != `"auto"` {
+		t.Errorf("tool_choice = %s, want the caller's", got)
+	}
+}
+
+// The final round declares its tools and forbids them, because an endpoint that
+// sees a bare tool_choice with no tools array answers 400.
+func TestToolChoiceNoneIsCarriedWithTheTools(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t11"), nil)
+
+	var sent responsesRequest
+	_, err := mw(toolRequestFor(t, "none", nil), func(req *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(req.Body)
+		if err := json.Unmarshal(raw, &sent); err != nil {
+			t.Fatal(err)
+		}
+		return sseResponse(`{"type":"response.completed","response":{"status":"completed"}}`), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sent.Tools) != 1 {
+		t.Fatalf("tools = %+v", sent.Tools)
+	}
+	if got := strings.TrimSpace(string(sent.ToolChoice)); got != `"none"` {
+		t.Errorf("tool_choice = %s", got)
+	}
+}
+
+// A plain completion must not grow a tool_choice: the field is meaningless
+// without tools and some endpoints refuse it.
+func TestAToollessCompletionSendsNoToolChoice(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t12"), nil)
+
+	var sent responsesRequest
+	_, err := mw(chatRequestFor(t, false), func(req *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(req.Body)
+		if err := json.Unmarshal(raw, &sent); err != nil {
+			t.Fatal(err)
+		}
+		return sseResponse(`{"type":"response.completed","response":{"status":"completed"}}`), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sent.Tools) != 0 || len(sent.ToolChoice) != 0 {
+		t.Errorf("tools = %+v, tool_choice = %s", sent.Tools, sent.ToolChoice)
+	}
+}
+
+// The round after a tool call replays the whole conversation, and the two
+// shapes disagree about how: chat carries the calls on the assistant message
+// and answers them with a tool-role message, while Responses makes each one a
+// free-standing item.
+func TestAToolRoundReplaysAsFreeStandingItems(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t13"), nil)
+
+	messages := []map[string]any{
+		{"role": "system", "content": "You search an archive."},
+		{"role": "user", "content": "What did the landlord send in May?"},
+		{
+			"role":    "assistant",
+			"content": nil,
+			"tool_calls": []map[string]any{{
+				"id":       "call_7",
+				"type":     "function",
+				"function": map[string]any{"name": "search_documents", "arguments": `{"query":"landlord"}`},
+			}},
+		},
+		{"role": "tool", "tool_call_id": "call_7", "content": "1 hit: rent increase notice"},
+	}
+
+	var sent responsesRequest
+	_, err := mw(toolRequestFor(t, "auto", messages), func(req *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(req.Body)
+		if err := json.Unmarshal(raw, &sent); err != nil {
+			t.Fatal(err)
+		}
+		return sseResponse(`{"type":"response.completed","response":{"status":"completed"}}`), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sent.Input) != 3 {
+		t.Fatalf("input = %+v, want the user turn, the call and its result", sent.Input)
+	}
+	// An assistant message with tool calls and no content must not be dropped
+	// by the empty-content skip -- the call is the whole point of the turn.
+	call := sent.Input[1]
+	if call.Type != "function_call" || call.CallID != "call_7" || call.Name != "search_documents" {
+		t.Fatalf("call item = %+v", call)
+	}
+	if call.Arguments != `{"query":"landlord"}` {
+		t.Errorf("arguments = %q", call.Arguments)
+	}
+	if len(call.Content) != 0 || call.Role != "" {
+		t.Errorf("a function_call must carry no role or content: %+v", call)
+	}
+	result := sent.Input[2]
+	if result.Type != "function_call_output" || result.CallID != "call_7" {
+		t.Fatalf("result item = %+v", result)
+	}
+	if result.Output != "1 hit: rent increase notice" {
+		t.Errorf("output = %q", result.Output)
+	}
+}
+
+// The answer side of the same gap: a function_call the model produced has to
+// come back as message.tool_calls, which is the only thing the search and
+// research loops look at.
+func TestAFunctionCallComesBackAsAToolCall(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t14"), nil)
+
+	resp, err := mw(toolRequestFor(t, "auto", nil), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_7","name":"search_documents","arguments":"{\"query\":\"landlord\"}"}}`,
+			`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":40,"output_tokens":9}}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out chatCompletion
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Choices) != 1 {
+		t.Fatalf("choices = %+v", out.Choices)
+	}
+	calls := out.Choices[0].Message.ToolCalls
+	if len(calls) != 1 {
+		t.Fatalf("tool_calls = %+v", calls)
+	}
+	if calls[0].ID != "call_7" || calls[0].Type != "function" || calls[0].Function.Name != "search_documents" {
+		t.Fatalf("call = %+v", calls[0])
+	}
+	if calls[0].Function.Arguments != `{"query":"landlord"}` {
+		t.Errorf("arguments = %q", calls[0].Function.Arguments)
+	}
+	// A model that asked for a tool has not finished answering.
+	if out.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q", out.Choices[0].FinishReason)
+	}
+}
+
+// Some backends report their output only on the completed response. Read there
+// too -- but only when no per-item event arrived, so neither is counted twice.
+func TestAFunctionCallOnTheCompletedResponseIsRead(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t15"), nil)
+
+	resp, err := mw(toolRequestFor(t, "auto", nil), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.completed","response":{"status":"completed","output":[{"type":"message"},{"type":"function_call","call_id":"call_9","name":"search_documents","arguments":""}]}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out chatCompletion
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	calls := out.Choices[0].Message.ToolCalls
+	if len(calls) != 1 || calls[0].ID != "call_9" {
+		t.Fatalf("tool_calls = %+v", calls)
+	}
+	// A call with no arguments arrives with the field empty, and every caller
+	// here feeds it straight to json.Unmarshal.
+	if calls[0].Function.Arguments != "{}" {
+		t.Errorf("arguments = %q, want an empty object", calls[0].Function.Arguments)
+	}
+}
+
+func TestAnItemEventAndACompletedResponseDoNotDoubleCount(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t16"), nil)
+
+	resp, err := mw(toolRequestFor(t, "auto", nil), func(req *http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_7","name":"search_documents","arguments":"{}"}}`,
+			`{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","call_id":"call_7","name":"search_documents","arguments":"{}"}]}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out chatCompletion
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if calls := out.Choices[0].Message.ToolCalls; len(calls) != 1 {
+		t.Fatalf("tool_calls = %+v, want one", calls)
+	}
+}
+
+// No caller streams a tool-bearing request today, but a stream that dropped a
+// tool call would be lossy in exactly the way the buffered path was.
+func TestAStreamedFunctionCallBecomesAToolCallChunk(t *testing.T) {
+	t.Parallel()
+	mw := Middleware(signedInSource(t, "t17"), nil)
+
+	req := toolRequestFor(t, "auto", nil)
+	// Rebuild the body with stream on: the caller's flag is what picks the path.
+	var body map[string]any
+	raw, _ := io.ReadAll(req.Body)
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatal(err)
+	}
+	body["stream"] = true
+	reraw, _ := json.Marshal(body)
+	req.Body = io.NopCloser(bytes.NewReader(reraw))
+
+	resp, err := mw(req, func(*http.Request) (*http.Response, error) {
+		return sseResponse(
+			`{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_7","name":"search_documents","arguments":"{\"query\":\"rent\"}"}}`,
+			`{"type":"response.completed","response":{"status":"completed"}}`,
+		), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(out)
+	if !strings.Contains(text, `"tool_calls"`) || !strings.Contains(text, "call_7") {
+		t.Fatalf("stream carried no tool call:\n%s", text)
+	}
+	if !strings.Contains(text, `"finish_reason":"tool_calls"`) {
+		t.Errorf("final chunk did not finish on tool_calls:\n%s", text)
+	}
+}

--- a/backend/internal/config/aienv.go
+++ b/backend/internal/config/aienv.go
@@ -21,6 +21,17 @@ type AIEnv struct {
 	Managed   bool
 	Providers aiprovider.Bootstrap
 
+	// ChatGPTLogin opens the chatgpt SDK, which bills an operator's ChatGPT
+	// subscription instead of a metered API key by talking to OpenAI's own
+	// Codex backend. Off unless asked for, because those endpoints are
+	// undocumented and reserved for OpenAI's clients: whether to point an
+	// account at them is the operator's decision, not a default.
+	//
+	// Refused together with Managed. The tenant of a managed instance is not
+	// the party whose account would be at risk, and the operator is already
+	// paying the AI bill they chose.
+	ChatGPTLogin bool
+
 	// Operator-owned in managed mode.
 	NearDuplicateEnabled   bool
 	NearDuplicateThreshold float64
@@ -69,6 +80,10 @@ const (
 	// Settings choice. Empty falls back to the search model.
 	EnvAISearchHelperModel = "AI_SEARCH_HELPER_MODEL"
 
+	// EnvChatGPTLogin opens the chatgpt SDK. See AIEnv.ChatGPTLogin and
+	// docs/chatgpt_login.md.
+	EnvChatGPTLogin = "AI_CHATGPT_LOGIN"
+
 	EnvOCRSDK     = "OCR_SDK"
 	EnvOCRAPIKey  = "OCR_API_KEY"
 	EnvOCRBaseURL = "OCR_BASE_URL"
@@ -84,9 +99,20 @@ func AIEnvFromEnv() (AIEnv, error) {
 	if err != nil {
 		return AIEnv{}, err
 	}
+	// Strict for the same reason AI_MANAGED is: a typo read as "off" would
+	// leave an operator staring at a Settings page with no sign-in button and
+	// nothing to explain why.
+	chatgptLogin, err := strictBool(EnvChatGPTLogin)
+	if err != nil {
+		return AIEnv{}, err
+	}
+	if managed && chatgptLogin {
+		return AIEnv{}, fmt.Errorf("%s and %s cannot both be set: a managed instance bills the operator's own provider", EnvManaged, EnvChatGPTLogin)
+	}
 
 	env := AIEnv{
 		Managed:                managed,
+		ChatGPTLogin:           chatgptLogin,
 		NearDuplicateEnabled:   getEnvBool("NEAR_DUPLICATE_DETECTION_ENABLED", false),
 		NearDuplicateThreshold: getEnvFloat("NEAR_DUPLICATE_THRESHOLD", DefaultNearDuplicateThreshold),
 		OCRTimeout:             time.Duration(envIntDefault("OCR_TIMEOUT_SEC", 40, 1)) * time.Second,
@@ -139,10 +165,13 @@ func strictBool(key string) (bool, error) {
 
 func parseLLM() (aiprovider.ProviderSpec, error) {
 	sdk := strings.TrimSpace(getEnv(EnvAISDK, aiprovider.SDKOpenAI))
-	if !aiprovider.IsLLM(sdk) {
+	// EnvLLMSDKs, not LLMSDKs: chatgpt chats, but its credential is minted by
+	// signing in rather than written down, so naming it here would seed a
+	// provider row that the file naming it can never complete.
+	if !aiprovider.IsLLM(sdk) || aiprovider.RequiresOAuth(sdk) {
 		return aiprovider.ProviderSpec{}, fmt.Errorf(
-			"%s=%q is not a language-model SDK (want one of %s, %s, %s)",
-			EnvAISDK, sdk, aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter, aiprovider.SDKMistral)
+			"%s=%q is not a language-model SDK that can be configured from the environment (want one of %s)",
+			EnvAISDK, sdk, strings.Join(aiprovider.EnvLLMSDKs(), ", "))
 	}
 
 	spec := aiprovider.ProviderSpec{
@@ -182,8 +211,8 @@ func parseOCR(llm aiprovider.ProviderSpec) (aiprovider.ProviderSpec, error) {
 		// Valid as an SDK, just not for this job. Caught here rather than on the
 		// first uploaded document.
 		return aiprovider.ProviderSpec{}, fmt.Errorf(
-			"%s=%q cannot read a document; it serves embeddings only",
-			EnvOCRSDK, sdk)
+			"%s=%q cannot read a document (want one of %s)",
+			EnvOCRSDK, sdk, strings.Join(aiprovider.OCRSDKs(), ", "))
 	}
 
 	// The same SDK is the same endpoint: reuse the language model's credential

--- a/backend/internal/config/aienv.go
+++ b/backend/internal/config/aienv.go
@@ -214,6 +214,15 @@ func parseOCR(llm aiprovider.ProviderSpec) (aiprovider.ProviderSpec, error) {
 			"%s=%q cannot read a document (want one of %s)",
 			EnvOCRSDK, sdk, strings.Join(aiprovider.OCRSDKs(), ", "))
 	}
+	// EnvOCRSDKs, not OCRSDKs: chatgpt reads documents perfectly well, but its
+	// credential is minted by signing in rather than written down, so naming it
+	// here would seed a row the file naming it can never complete. Bind OCR to
+	// it from Settings instead, once it is signed in.
+	if aiprovider.RequiresOAuth(sdk) {
+		return aiprovider.ProviderSpec{}, fmt.Errorf(
+			"%s=%q cannot be configured from the environment: it is signed in to from Settings, not given a key (want one of %s)",
+			EnvOCRSDK, sdk, strings.Join(aiprovider.EnvOCRSDKs(), ", "))
+	}
 
 	// The same SDK is the same endpoint: reuse the language model's credential
 	// and address rather than making an operator write them out twice.

--- a/backend/internal/config/aienv_test.go
+++ b/backend/internal/config/aienv_test.go
@@ -14,7 +14,7 @@ func clearAIEnv(t *testing.T) {
 	for _, key := range []string{
 		EnvManaged, EnvAISDK, EnvAIAPIKey, EnvAIBaseURL, EnvAIModel, EnvAIEmbeddingModel,
 		EnvAIEmbeddingSDK, EnvAIEmbeddingAPIKey, EnvAIEmbeddingBaseURL,
-		EnvOCRSDK, EnvOCRAPIKey, EnvOCRBaseURL, EnvOCRModel,
+		EnvOCRSDK, EnvOCRAPIKey, EnvOCRBaseURL, EnvOCRModel, EnvChatGPTLogin,
 		"NEAR_DUPLICATE_DETECTION_ENABLED",
 		"NEAR_DUPLICATE_THRESHOLD", "OCR_TIMEOUT_SEC", "AI_TIMEOUT_SEC",
 		"WORKER_TIMEOUT_SEC", "WORKER_MAX_RETRIES", "DEEP_SEARCH_LANGUAGES",
@@ -367,5 +367,50 @@ func TestManagedAcceptsACompleteEnvironment(t *testing.T) {
 	}
 	if !env.Managed {
 		t.Fatal("expected managed mode on")
+	}
+}
+
+// AI_CHATGPT_LOGIN opens an SDK that talks to OpenAI's first-party endpoints
+// with somebody's personal subscription. A typo read as "off" would leave an
+// operator staring at a Settings page with no sign-in button and nothing to
+// explain why, so it is strict like AI_MANAGED.
+func TestChatGPTLoginIsStrictAndOffByDefault(t *testing.T) {
+	clearAIEnv(t)
+	env, err := AIEnvFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.ChatGPTLogin {
+		t.Fatal("an unset AI_CHATGPT_LOGIN read as on")
+	}
+
+	clearAIEnv(t)
+	t.Setenv(EnvChatGPTLogin, "1")
+	env, err = AIEnvFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !env.ChatGPTLogin {
+		t.Fatal("AI_CHATGPT_LOGIN=1 read as off")
+	}
+
+	clearAIEnv(t)
+	t.Setenv(EnvChatGPTLogin, "maybe")
+	if _, err := AIEnvFromEnv(); err == nil {
+		t.Fatal("a misspelled AI_CHATGPT_LOGIN was accepted")
+	}
+}
+
+// The tenant of a managed instance is not the party whose ChatGPT account would
+// be at risk, and the operator already chose and pays for a provider. Refusing
+// the combination at parse time beats discovering it from Settings.
+func TestChatGPTLoginIsRefusedOnAManagedInstance(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvManaged, "1")
+	t.Setenv(EnvChatGPTLogin, "1")
+	t.Setenv(EnvAIAPIKey, "sk-test")
+	t.Setenv(EnvAIModel, "some-model")
+	if _, err := AIEnvFromEnv(); err == nil {
+		t.Fatal("AI_MANAGED and AI_CHATGPT_LOGIN were accepted together")
 	}
 }

--- a/backend/internal/config/chatgpt_env_test.go
+++ b/backend/internal/config/chatgpt_env_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// The environment can carry a key; it cannot carry a sign-in. AI_SDK=chatgpt
+// would otherwise pass the IsLLM check and seed a provider row that the file
+// naming it can never complete.
+func TestChatGPTIsNotAnAISDKValue(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAISDK, aiprovider.SDKChatGPT)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+
+	_, err := AIEnvFromEnv()
+	if err == nil {
+		t.Fatal("AI_SDK=chatgpt was accepted")
+	}
+	if !strings.Contains(err.Error(), EnvAISDK) {
+		t.Errorf("the error does not name the variable: %v", err)
+	}
+	// The message lists what is allowed, and must not list the value it just
+	// refused -- that is the whole failure mode it exists to avoid.
+	if strings.Contains(err.Error(), "want one of") && strings.Count(err.Error(), aiprovider.SDKChatGPT) > 1 {
+		t.Errorf("the error offers chatgpt as an alternative to itself: %v", err)
+	}
+}
+
+// OCR_SDK=chatgpt is valid as an SDK and useless for this job, the same
+// situation `local` is in. The message used to say "it serves embeddings only",
+// which was true of the only SDK that could reach it at the time.
+func TestChatGPTIsNotAnOCRSDKValue(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+	t.Setenv(EnvOCRSDK, aiprovider.SDKChatGPT)
+
+	_, err := AIEnvFromEnv()
+	if err == nil {
+		t.Fatal("OCR_SDK=chatgpt was accepted")
+	}
+	if !strings.Contains(err.Error(), EnvOCRSDK) {
+		t.Errorf("the error does not name the variable: %v", err)
+	}
+	if strings.Contains(err.Error(), "embeddings only") {
+		t.Errorf("the error still describes the wrong SDK: %v", err)
+	}
+}
+
+// providerRecord is a detached ai_providers row loaded the way PocketBase loads
+// one: PostScan is what fills Original(), which is the whole basis of the
+// rotation test below.
+func providerRecord(t *testing.T, oauth string) *core.Record {
+	t.Helper()
+	collection := core.NewBaseCollection(aiprovider.CollectionName)
+	collection.Fields.Add(
+		&core.TextField{Name: "sdk"},
+		&core.TextField{Name: "alias"},
+		&core.TextField{Name: "base_url"},
+		&core.TextField{Name: "api_key"},
+		&core.TextField{Name: aiprovider.OAuthField},
+	)
+	record := core.NewRecord(collection)
+	record.Id = "provider1"
+	record.Set("sdk", aiprovider.SDKChatGPT)
+	record.Set("alias", "ChatGPT")
+	record.Set(aiprovider.OAuthField, oauth)
+	if err := record.PostScan(); err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+// An hourly refresh must not rebuild every AI client, and a sign-in or sign-out
+// must. Both write the token and nothing else, so "oauth moved" cannot tell
+// them apart -- only whether the row was, and stays, able to serve.
+func TestOnlyATokenRotationSkipsTheReload(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		before  string
+		after   string
+		skipped bool
+	}{
+		{"refresh rotates a live token", `{"access":"old"}`, `{"access":"new"}`, true},
+		{"sign-in fills an empty column", "", `{"access":"new"}`, false},
+		{"sign-out empties it", `{"access":"old"}`, "", false},
+		{"a whitespace-only column is empty", "   ", `{"access":"new"}`, false},
+		{"an unchanged token is not a rotation", `{"access":"same"}`, `{"access":"same"}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			record := providerRecord(t, tc.before)
+			record.Set(aiprovider.OAuthField, tc.after)
+			if got := onlyTokenRotated(record); got != tc.skipped {
+				t.Fatalf("onlyTokenRotated = %v, want %v", got, tc.skipped)
+			}
+		})
+	}
+}
+
+// A write that moves the token and something else is a configuration change,
+// whatever else it does, so it reloads.
+func TestARotationAlongsideAnotherFieldStillReloads(t *testing.T) {
+	for _, field := range []string{"sdk", "alias", "base_url", "api_key"} {
+		t.Run(field, func(t *testing.T) {
+			record := providerRecord(t, `{"access":"old"}`)
+			record.Set(aiprovider.OAuthField, `{"access":"new"}`)
+			record.Set(field, "moved")
+			if onlyTokenRotated(record) {
+				t.Fatalf("a write that also changed %s skipped the reload", field)
+			}
+		})
+	}
+}

--- a/backend/internal/config/chatgpt_env_test.go
+++ b/backend/internal/config/chatgpt_env_test.go
@@ -31,9 +31,11 @@ func TestChatGPTIsNotAnAISDKValue(t *testing.T) {
 	}
 }
 
-// OCR_SDK=chatgpt is valid as an SDK and useless for this job, the same
-// situation `local` is in. The message used to say "it serves embeddings only",
-// which was true of the only SDK that could reach it at the time.
+// OCR_SDK=chatgpt is refused, but no longer for want of the capability: the SDK
+// reads documents now. The obstacle is the credential -- a sign-in cannot be
+// written into a file -- so the message has to say that rather than repeat the
+// old "cannot read a document", which would now be a lie an operator could
+// disprove from Settings.
 func TestChatGPTIsNotAnOCRSDKValue(t *testing.T) {
 	clearAIEnv(t)
 	t.Setenv(EnvAIAPIKey, "sk-test")
@@ -48,6 +50,17 @@ func TestChatGPTIsNotAnOCRSDKValue(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "embeddings only") {
 		t.Errorf("the error still describes the wrong SDK: %v", err)
+	}
+	if strings.Contains(err.Error(), "cannot read a document") {
+		t.Errorf("the error blames the capability, which chatgpt now has: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Settings") {
+		t.Errorf("the error does not say where the provider can be configured: %v", err)
+	}
+	// Same trap as the AI_SDK message above: the alternatives are derived, so
+	// chatgpt must not appear in its own "want one of" list.
+	if strings.Contains(err.Error(), "want one of") && strings.Count(err.Error(), aiprovider.SDKChatGPT) > 1 {
+		t.Errorf("the error offers chatgpt as an alternative to itself: %v", err)
 	}
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -402,12 +402,20 @@ func NormalizeLanguageList(raw string) string {
 	return strings.Join(out, ",")
 }
 
+// HasLLM reports whether anything can reason over a document yet. It is what
+// the setup wizard and the readiness check ask before declaring an install
+// finished.
+//
+// Configured rather than APIKey != "", for the same reason HasOCR and
+// HasEmbedding ask it: the chatgpt SDK holds a token instead of a key, and the
+// bare key test would have left a signed-in instance stuck on the setup wizard
+// with a working provider in front of it.
 func HasLLM(cfg Config) bool {
 	p := cfg.ExtractProvider
 	if p == nil {
 		p = cfg.ChatProvider
 	}
-	return p != nil && p.APIKey != "" && aiprovider.IsLLM(p.SDK)
+	return p != nil && p.Configured() && aiprovider.IsLLM(p.SDK)
 }
 
 // HasEmbedding reports whether dense retrieval can run. A provider missing the

--- a/backend/internal/config/runtime.go
+++ b/backend/internal/config/runtime.go
@@ -3,12 +3,15 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
+	"github.com/openai/openai-go/option"
 	"github.com/pocketbase/pocketbase/core"
 	"lemmary/backend/internal/ai"
 	"lemmary/backend/internal/aiprovider"
 	"lemmary/backend/internal/applog"
+	"lemmary/backend/internal/chatgpt"
 	"lemmary/backend/internal/ocr"
 )
 
@@ -72,6 +75,11 @@ func (r *Runtime) Env() AIEnv { return r.env }
 
 func (r *Runtime) Managed() bool { return r.env.Managed }
 
+// ChatGPTLogin reports whether the chatgpt SDK may be used at all. Read by the
+// provider endpoints, which refuse it when off, and by /meta, which is how the
+// SPA knows whether to offer the sign-in button.
+func (r *Runtime) ChatGPTLogin() bool { return r.env.ChatGPTLogin }
+
 func (r *Runtime) Snapshot() Snapshot {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -92,6 +100,51 @@ func (r *Runtime) Reload(app core.App) error {
 	return nil
 }
 
+// usableLLM reports whether a provider row can back a language-model binding.
+//
+// Configured rather than APIKey != "": the chatgpt SDK holds no key, and asking
+// the old question would have left every chatgpt binding silently unavailable
+// with nothing in the log but "ai: unavailable".
+func usableLLM(p *aiprovider.Provider) bool {
+	return p != nil && p.Configured() && aiprovider.IsLLM(p.SDK)
+}
+
+// llmCredential is what an LLM client is built with: the key to pass, and any
+// extra SDK options the provider needs.
+//
+// Every SDK but one hands over its API key and asks for nothing else. The
+// chatgpt SDK has no key to hand over -- its credential is a token that expires
+// hourly -- so it contributes a middleware that mints one per request instead,
+// plus a placeholder for the SDK's own insistence on a non-empty key.
+func llmCredential(app core.App, p *aiprovider.Provider, logger *slog.Logger) (string, []option.RequestOption) {
+	if p == nil {
+		return "", nil
+	}
+	if !aiprovider.RequiresOAuth(p.SDK) {
+		return p.APIKey, nil
+	}
+	src := chatgpt.SourceFor(p.ID, p.OAuth, persistOAuth(app), logger)
+	return chatgpt.PlaceholderKey, []option.RequestOption{
+		option.WithMiddleware(chatgpt.Middleware(src, logger)),
+	}
+}
+
+// persistOAuth stores a rotated token back on the provider row.
+//
+// Saved through the record so the value passes the same field validation as any
+// other write. It fires the ai_providers update hook, which is why that hook
+// skips the reload when oauth is the only field that moved: see reloadProviders.
+func persistOAuth(app core.App) chatgpt.Persist {
+	return func(providerID, oauth string) error {
+		record, err := app.FindRecordById(aiprovider.CollectionName, providerID)
+		if err != nil {
+			return err
+		}
+		record.Set(aiprovider.OAuthField, oauth)
+		return app.Save(record)
+	}
+}
+
 func (r *Runtime) apply(app core.App, cfg Config) {
 	logger := app.Logger()
 	ocrLogger := logger.With("component", "ocr")
@@ -107,41 +160,50 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 		}
 	}
 
+	// One credential for the extraction provider, shared by the two clients
+	// built on it: asking twice would put two middlewares over one token
+	// source, and the splitter is always the extractor's provider.
+	extractKey, extractOpts := llmCredential(app, cfg.ExtractProvider, aiLogger)
+
 	var extractor ai.Extractor
-	if cfg.ExtractProvider != nil && cfg.ExtractProvider.APIKey != "" && aiprovider.IsLLM(cfg.ExtractProvider.SDK) {
+	if usableLLM(cfg.ExtractProvider) {
 		extractor = ai.NewExtractor(
 			cfg.ExtractProvider.SDK,
-			cfg.ExtractProvider.APIKey,
+			extractKey,
 			cfg.ExtractModel,
 			cfg.ExtractProvider.BaseURL,
 			cfg.ExtractionPromptVer,
 			cfg.ProcessingResultLanguage,
 			cfg.OpenAITimeout,
 			aiLogger,
+			extractOpts...,
 		)
 	}
 
 	var chatter ai.Chatter
-	if cfg.ChatProvider != nil && cfg.ChatProvider.APIKey != "" && aiprovider.IsLLM(cfg.ChatProvider.SDK) {
+	if usableLLM(cfg.ChatProvider) {
+		key, opts := llmCredential(app, cfg.ChatProvider, aiLogger)
 		chatter = ai.NewChatter(
 			cfg.ChatProvider.SDK,
-			cfg.ChatProvider.APIKey,
+			key,
 			cfg.ChatModel,
 			cfg.ChatProvider.BaseURL,
 			cfg.OpenAITimeout,
 			aiLogger,
+			opts...,
 		)
 	}
 
 	var splitter ai.Splitter
-	if cfg.ExtractProvider != nil && cfg.ExtractProvider.APIKey != "" && aiprovider.IsLLM(cfg.ExtractProvider.SDK) {
+	if usableLLM(cfg.ExtractProvider) {
 		splitter = ai.NewSplitter(
 			cfg.ExtractProvider.SDK,
-			cfg.ExtractProvider.APIKey,
+			extractKey,
 			cfg.ExtractModel,
 			cfg.ExtractProvider.BaseURL,
 			cfg.OpenAITimeout,
 			aiLogger,
+			extractOpts...,
 		)
 	}
 
@@ -159,28 +221,32 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 	}
 
 	var searchAgent ai.SearchAgent
-	if cfg.SearchProvider != nil && cfg.SearchProvider.APIKey != "" && aiprovider.IsLLM(cfg.SearchProvider.SDK) {
+	if usableLLM(cfg.SearchProvider) {
+		key, opts := llmCredential(app, cfg.SearchProvider, aiLogger)
 		searchAgent = ai.NewSearchAgent(
 			cfg.SearchProvider.SDK,
-			cfg.SearchProvider.APIKey,
+			key,
 			cfg.SearchModel,
 			cfg.SearchProvider.BaseURL,
 			cfg.OpenAITimeout,
 			cfg.DeepSearchLanguages,
 			cfg.ProcessingResultLanguage,
 			aiLogger,
+			opts...,
 		)
 	}
 
 	var searchHelper ai.Helper
-	if cfg.SearchHelperProvider != nil && cfg.SearchHelperProvider.APIKey != "" && aiprovider.IsLLM(cfg.SearchHelperProvider.SDK) {
+	if usableLLM(cfg.SearchHelperProvider) {
+		key, opts := llmCredential(app, cfg.SearchHelperProvider, aiLogger)
 		searchHelper = ai.NewHelper(
 			cfg.SearchHelperProvider.SDK,
-			cfg.SearchHelperProvider.APIKey,
+			key,
 			cfg.SearchHelperModel,
 			cfg.SearchHelperProvider.BaseURL,
 			cfg.OpenAITimeout,
 			aiLogger,
+			opts...,
 		)
 	}
 
@@ -289,7 +355,52 @@ func RegisterHooks(app core.App, rt *Runtime) {
 		_ = rt.Reload(e.App)
 		return nil
 	}
+	updateProviders := func(e *core.RecordEvent) error {
+		if err := e.Next(); err != nil {
+			return err
+		}
+		if onlyTokenRotated(e.Record) {
+			return nil
+		}
+		_ = rt.Reload(e.App)
+		return nil
+	}
 	app.OnRecordAfterCreateSuccess(aiprovider.CollectionName).BindFunc(reloadProviders)
-	app.OnRecordAfterUpdateSuccess(aiprovider.CollectionName).BindFunc(reloadProviders)
+	app.OnRecordAfterUpdateSuccess(aiprovider.CollectionName).BindFunc(updateProviders)
 	app.OnRecordAfterDeleteSuccess(aiprovider.CollectionName).BindFunc(reloadProviders)
+}
+
+// onlyTokenRotated reports a write that did nothing but replace one live
+// ChatGPT token with another.
+//
+// The token refreshes about once an hour, and every refresh saves the provider
+// row. Reloading on those would rebuild every AI client on a timer -- swapping
+// the extractor out from under a running job, and re-reading a row the token
+// source itself has just written.
+//
+// A rotation, not merely "oauth moved". Signing in and signing out also touch
+// no other field, and both change what the row can serve: after a sign-in the
+// clients do not exist yet, because the last apply saw an unconfigured row, and
+// after a sign-out the built clients would keep answering from the token still
+// held by the middleware, which Forget cannot reach. Both must reload, so the
+// test is that the row was usable before and stays usable after.
+func onlyTokenRotated(record *core.Record) bool {
+	if record == nil {
+		return false
+	}
+	original := record.Original()
+	if original == nil {
+		return false
+	}
+	before := strings.TrimSpace(original.GetString(aiprovider.OAuthField))
+	after := strings.TrimSpace(record.GetString(aiprovider.OAuthField))
+	if before == after || before == "" || after == "" {
+		return false
+	}
+	for _, field := range []string{"sdk", "alias", "base_url", "api_key"} {
+		if record.GetString(field) != original.GetString(field) {
+			return false
+		}
+	}
+	return true
 }

--- a/backend/internal/config/runtime.go
+++ b/backend/internal/config/runtime.go
@@ -109,14 +109,15 @@ func usableLLM(p *aiprovider.Provider) bool {
 	return p != nil && p.Configured() && aiprovider.IsLLM(p.SDK)
 }
 
-// llmCredential is what an LLM client is built with: the key to pass, and any
-// extra SDK options the provider needs.
+// providerCredential is what a client on a provider row is built with: the key
+// to pass, and any extra SDK options the provider needs. Both the AI clients
+// and the OCR one go through it.
 //
 // Every SDK but one hands over its API key and asks for nothing else. The
 // chatgpt SDK has no key to hand over -- its credential is a token that expires
 // hourly -- so it contributes a middleware that mints one per request instead,
 // plus a placeholder for the SDK's own insistence on a non-empty key.
-func llmCredential(app core.App, p *aiprovider.Provider, logger *slog.Logger) (string, []option.RequestOption) {
+func providerCredential(app core.App, p *aiprovider.Provider, logger *slog.Logger) (string, []option.RequestOption) {
 	if p == nil {
 		return "", nil
 	}
@@ -152,7 +153,12 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 
 	var ocrProvider ocr.Provider
 	if cfg.OCRProvider != nil {
-		built, err := ocr.NewFromAIProvider(*cfg.OCRProvider, cfg.OCRModel, cfg.OCRTimeout, ocrLogger)
+		// The same credential treatment the AI clients get: a chatgpt row has
+		// a minted token rather than a key, and the row itself carries neither.
+		p := *cfg.OCRProvider
+		key, opts := providerCredential(app, cfg.OCRProvider, ocrLogger)
+		p.APIKey = key
+		built, err := ocr.NewFromAIProvider(p, cfg.OCRModel, cfg.OCRTimeout, ocrLogger, opts...)
 		if err != nil {
 			logger.Warn("OCR provider unavailable after settings reload", slog.Any("error", err))
 		} else {
@@ -163,7 +169,7 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 	// One credential for the extraction provider, shared by the two clients
 	// built on it: asking twice would put two middlewares over one token
 	// source, and the splitter is always the extractor's provider.
-	extractKey, extractOpts := llmCredential(app, cfg.ExtractProvider, aiLogger)
+	extractKey, extractOpts := providerCredential(app, cfg.ExtractProvider, aiLogger)
 
 	var extractor ai.Extractor
 	if usableLLM(cfg.ExtractProvider) {
@@ -182,7 +188,7 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 
 	var chatter ai.Chatter
 	if usableLLM(cfg.ChatProvider) {
-		key, opts := llmCredential(app, cfg.ChatProvider, aiLogger)
+		key, opts := providerCredential(app, cfg.ChatProvider, aiLogger)
 		chatter = ai.NewChatter(
 			cfg.ChatProvider.SDK,
 			key,
@@ -222,7 +228,7 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 
 	var searchAgent ai.SearchAgent
 	if usableLLM(cfg.SearchProvider) {
-		key, opts := llmCredential(app, cfg.SearchProvider, aiLogger)
+		key, opts := providerCredential(app, cfg.SearchProvider, aiLogger)
 		searchAgent = ai.NewSearchAgent(
 			cfg.SearchProvider.SDK,
 			key,
@@ -238,7 +244,7 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 
 	var searchHelper ai.Helper
 	if usableLLM(cfg.SearchHelperProvider) {
-		key, opts := llmCredential(app, cfg.SearchHelperProvider, aiLogger)
+		key, opts := providerCredential(app, cfg.SearchHelperProvider, aiLogger)
 		searchHelper = ai.NewHelper(
 			cfg.SearchHelperProvider.SDK,
 			key,

--- a/backend/internal/config/runtime.go
+++ b/backend/internal/config/runtime.go
@@ -365,9 +365,22 @@ func RegisterHooks(app core.App, rt *Runtime) {
 		_ = rt.Reload(e.App)
 		return nil
 	}
+	deleteProviders := func(e *core.RecordEvent) error {
+		if err := e.Next(); err != nil {
+			return err
+		}
+		// A deleted row's token source would otherwise sit in the package
+		// registry until restart, still holding a refresh token for a provider
+		// nobody can reach any more.
+		if e.Record != nil && aiprovider.RequiresOAuth(e.Record.GetString("sdk")) {
+			chatgpt.Forget(e.Record.Id)
+		}
+		_ = rt.Reload(e.App)
+		return nil
+	}
 	app.OnRecordAfterCreateSuccess(aiprovider.CollectionName).BindFunc(reloadProviders)
 	app.OnRecordAfterUpdateSuccess(aiprovider.CollectionName).BindFunc(updateProviders)
-	app.OnRecordAfterDeleteSuccess(aiprovider.CollectionName).BindFunc(reloadProviders)
+	app.OnRecordAfterDeleteSuccess(aiprovider.CollectionName).BindFunc(deleteProviders)
 }
 
 // onlyTokenRotated reports a write that did nothing but replace one live

--- a/backend/internal/ocr/provider.go
+++ b/backend/internal/ocr/provider.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openai/openai-go/option"
+
 	"lemmary/backend/internal/aiprovider"
 )
 
@@ -35,7 +37,13 @@ type ProviderInfo struct {
 	SDK  string `json:"sdk"`
 }
 
-func NewFromAIProvider(p aiprovider.Provider, model string, timeout time.Duration, logger *slog.Logger) (Provider, error) {
+// NewFromAIProvider builds the OCR provider a row describes.
+//
+// extra carries request options the caller had to build for it -- today only
+// the chatgpt middleware, which mints a bearer token per request because that
+// SDK's credential expires hourly and cannot be baked into a client. See
+// config.providerCredential.
+func NewFromAIProvider(p aiprovider.Provider, model string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) (Provider, error) {
 	// Asked first, so an SDK that can never read a document says so instead of
 	// complaining about a missing model or key it would have no use for.
 	if !aiprovider.CanOCR(p.SDK) {
@@ -64,9 +72,13 @@ func NewFromAIProvider(p aiprovider.Provider, model string, timeout time.Duratio
 	case aiprovider.SDKMistral:
 		logger.Info("using provider", "provider", p.Alias, "sdk", p.SDK, "model", model)
 		return NewMistralProvider(p.APIKey, model, p.BaseURL, timeout, logger), nil
-	case aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter:
+	case aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter, aiprovider.SDKChatGPT:
+		// chatgpt joins the metered LLM SDKs here rather than getting a branch
+		// of its own: the request is the same multimodal chat completion, and
+		// what differs -- a minted bearer token, and the Responses rewrite
+		// underneath -- is entirely inside the options in extra.
 		logger.Info("using provider", "provider", p.Alias, "sdk", p.SDK, "model", model)
-		return NewLLMProvider(p, model, timeout, logger), nil
+		return NewLLMProvider(p, model, timeout, logger, extra...), nil
 	case aiprovider.SDKDocling:
 		// model names docling's OCR engine here, not a model; empty leaves the
 		// choice to the server. p.APIKey is optional and usually empty.

--- a/backend/internal/ocr/provider.go
+++ b/backend/internal/ocr/provider.go
@@ -36,6 +36,11 @@ type ProviderInfo struct {
 }
 
 func NewFromAIProvider(p aiprovider.Provider, model string, timeout time.Duration, logger *slog.Logger) (Provider, error) {
+	// Asked first, so an SDK that can never read a document says so instead of
+	// complaining about a missing model or key it would have no use for.
+	if !aiprovider.CanOCR(p.SDK) {
+		return nil, fmt.Errorf("sdk %s cannot read a document; want one of %s", p.SDK, strings.Join(aiprovider.OCRSDKs(), ", "))
+	}
 	if aiprovider.RequiresAPIKey(p.SDK) && p.APIKey == "" {
 		return nil, fmt.Errorf("provider %q has no API key", p.Alias)
 	}

--- a/backend/internal/ocr/provider_test.go
+++ b/backend/internal/ocr/provider_test.go
@@ -46,6 +46,26 @@ func TestNewFromAIProviderRequirements(t *testing.T) {
 			wantErr:  "OCR model is required",
 		},
 		{
+			// The credential is a minted token, which config.providerCredential
+			// substitutes for the key. Demanding an api_key here would refuse
+			// a provider that is signed in and working.
+			name: "chatgpt needs no key, only a model",
+			provider: aiprovider.Provider{
+				SDK: aiprovider.SDKChatGPT, Alias: "ChatGPT subscription",
+				BaseURL: aiprovider.DefaultBaseURL(aiprovider.SDKChatGPT),
+			},
+			model:    "gpt-5.6-luna",
+			wantName: aiprovider.SDKChatGPT,
+		},
+		{
+			name: "chatgpt still needs a model",
+			provider: aiprovider.Provider{
+				SDK: aiprovider.SDKChatGPT, Alias: "ChatGPT subscription",
+				BaseURL: aiprovider.DefaultBaseURL(aiprovider.SDKChatGPT),
+			},
+			wantErr: "OCR model is required",
+		},
+		{
 			name:     "an unknown sdk is refused, not treated as keyless",
 			provider: aiprovider.Provider{SDK: "tesseract", Alias: "Tesseract", BaseURL: "http://x"},
 			wantErr:  "API key",

--- a/backend/migrations/1730000025_chatgpt_provider.go
+++ b/backend/migrations/1730000025_chatgpt_provider.go
@@ -1,0 +1,111 @@
+package migrations
+
+import (
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// Adds ai_providers.oauth and widens ai_providers.sdk to include chatgpt.
+//
+// Two changes, one migration, because neither is usable without the other: the
+// SDK cannot be selected until it is in the select field's values, and a row
+// with that SDK holds no credential until the column exists.
+//
+// EnsureCollection already builds both from the current code, but it returns an
+// existing collection untouched -- which is every install past its first boot.
+// Same reasoning as 1730000024, which widened the field for the sidecar SDKs.
+func init() {
+	m.Register(func(app core.App) error {
+		if err := addProviderOAuthField(app); err != nil {
+			return err
+		}
+		return setProviderSDKValues(app, aiprovider.ValidSDKs)
+	}, func(app core.App) error {
+		// Rows before values, as in 1730000024: a record whose sdk is no longer
+		// in Values fails validation on its next save. Best-effort throughout --
+		// a down-migration that halts halfway is worse than one that leaves a
+		// stale binding an admin can see and clear.
+		records, err := app.FindAllRecords(aiprovider.CollectionName, dbx.HashExp{"sdk": aiprovider.SDKChatGPT})
+		if err == nil {
+			for _, record := range records {
+				clearProviderBindings(app, record.Id)
+				clearLLMProviderBindings(app, record.Id)
+				_ = app.Delete(record)
+			}
+		}
+		if err := dropProviderOAuthField(app); err != nil {
+			return err
+		}
+		return setProviderSDKValues(app, sdksWithoutChatGPT())
+	})
+}
+
+func sdksWithoutChatGPT() []string {
+	out := make([]string, 0, len(aiprovider.ValidSDKs))
+	for _, sdk := range aiprovider.ValidSDKs {
+		if sdk != aiprovider.SDKChatGPT {
+			out = append(out, sdk)
+		}
+	}
+	return out
+}
+
+func addProviderOAuthField(app core.App) error {
+	collection, err := app.FindCollectionByNameOrId(aiprovider.CollectionName)
+	if err != nil {
+		// Nothing to add on an instance that has never held a provider:
+		// EnsureCollection builds the field itself. Migration order is not
+		// something this may depend on.
+		return nil
+	}
+	if collection.Fields.GetByName(aiprovider.OAuthField) != nil {
+		return nil
+	}
+	collection.Fields.Add(&core.TextField{Name: aiprovider.OAuthField, Max: 8000})
+	return app.Save(collection)
+}
+
+func dropProviderOAuthField(app core.App) error {
+	collection, err := app.FindCollectionByNameOrId(aiprovider.CollectionName)
+	if err != nil {
+		return nil
+	}
+	if collection.Fields.GetByName(aiprovider.OAuthField) == nil {
+		return nil
+	}
+	collection.Fields.RemoveByName(aiprovider.OAuthField)
+	return app.Save(collection)
+}
+
+// clearLLMProviderBindings unbinds the four language-model roles when any of
+// them points at the provider about to be deleted.
+//
+// Separate from clearProviderBindings, which covers OCR and embeddings: those
+// two were the only roles the sidecar SDKs could hold, and a chatgpt provider
+// can hold none of them and all four of these.
+func clearLLMProviderBindings(app core.App, providerID string) {
+	settings, err := app.FindRecordById("app_settings", "appsettings0001")
+	if err != nil || settings == nil {
+		return
+	}
+	changed := false
+	for _, pair := range [][2]string{
+		{"extract_provider_id", "extract_model"},
+		{"chat_provider_id", "chat_model"},
+		{"search_provider_id", "search_model"},
+		{"search_helper_provider_id", "search_helper_model"},
+	} {
+		if settings.GetString(pair[0]) != providerID {
+			continue
+		}
+		settings.Set(pair[0], "")
+		settings.Set(pair[1], "")
+		changed = true
+	}
+	if changed {
+		_ = app.Save(settings)
+	}
+}

--- a/backend/migrations/chatgpt_provider_test.go
+++ b/backend/migrations/chatgpt_provider_test.go
@@ -1,0 +1,76 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/chatgpt"
+)
+
+// A chatgpt provider needs two things that no earlier release's collection has:
+// its SDK in the sdk field's allowed values, and a column to keep the token in.
+// Either one missing fails the save, so both are asserted through a real save
+// rather than by reading the schema back.
+func TestAChatGPTProviderCanBeSavedAfterMigrating(t *testing.T) {
+	app := bootMigratedApp(t)
+
+	collection, err := app.FindCollectionByNameOrId(aiprovider.CollectionName)
+	if err != nil {
+		t.Fatalf("providers collection: %v", err)
+	}
+	if collection.Fields.GetByName(aiprovider.OAuthField) == nil {
+		t.Fatal("the oauth column is missing after migrating")
+	}
+
+	token, err := chatgpt.Token{Access: "a", Refresh: "r"}.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("sdk", aiprovider.SDKChatGPT)
+	record.Set("alias", aiprovider.DefaultAlias(aiprovider.SDKChatGPT))
+	record.Set("base_url", aiprovider.DefaultBaseURL(aiprovider.SDKChatGPT))
+	record.Set(aiprovider.OAuthField, token)
+	if err := app.Save(record); err != nil {
+		t.Fatalf("save a chatgpt provider: %v", err)
+	}
+
+	// And it reads back as signed in, which is what Configured asks and what
+	// the runtime builds a client on.
+	p := aiprovider.FromRecord(record)
+	if !p.Configured() {
+		t.Fatal("a saved chatgpt provider with a token reads as unconfigured")
+	}
+}
+
+// Managed instances re-run migrations on every boot, so both halves have to be
+// no-ops once they have been applied.
+func TestTheChatGPTMigrationIsIdempotent(t *testing.T) {
+	app := bootMigratedApp(t)
+
+	for i := 0; i < 2; i++ {
+		if err := addProviderOAuthField(app); err != nil {
+			t.Fatalf("add the oauth field (pass %d): %v", i, err)
+		}
+		if err := setProviderSDKValues(app, aiprovider.ValidSDKs); err != nil {
+			t.Fatalf("widen the sdk field (pass %d): %v", i, err)
+		}
+	}
+}
+
+// The down-migration narrows the field back to the list as it stood before
+// chatgpt existed. Derived rather than written out, so the next SDK needs no
+// edit here -- and it must not drop anything else on the way.
+func TestNarrowingBackRemovesOnlyChatGPT(t *testing.T) {
+	got := sdksWithoutChatGPT()
+	if len(got) != len(aiprovider.ValidSDKs)-1 {
+		t.Fatalf("prior SDKs = %v, want every SDK but chatgpt", got)
+	}
+	for _, sdk := range got {
+		if sdk == aiprovider.SDKChatGPT {
+			t.Fatal("the narrowed list still names chatgpt")
+		}
+	}
+}

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -16,6 +16,7 @@ to use.
 | `openai` | ✅ | ✅ models that accept files/images | ✅ |
 | `openrouter` | ✅ many vendors on one key | ✅ models advertising `file` input | ✅ |
 | `google_vision` | ❌ | ✅ | ❌ |
+| `chatgpt` | ✅ **on a ChatGPT subscription** | ❌ | ❌ |
 | `docling` | ❌ | ✅ **on your own host** | ❌ |
 | `local` | ❌ | ❌ | ✅ **a model on your own hardware** |
 
@@ -47,6 +48,13 @@ The alternatives are worth naming:
   Its default recognizer is PaddleOCR's PP-OCR models, so there is no separate
   PaddleOCR provider to choose. The price is real: a multi-gigabyte image, and
   seconds rather than milliseconds a page. See [Local OCR](/local_ocr).
+- **`chatgpt`** — chat only, billed against a ChatGPT Plus, Pro or Business
+  subscription instead of per token. There is no key to paste: you add the
+  provider, sign in with a device code, and bind chat, extraction or Deep Search
+  to it. Embeddings and OCR are refused, because the endpoint behind it serves
+  neither. Off unless `AI_CHATGPT_LOGIN=1`, and refused on a managed instance —
+  it reaches OpenAI's own Codex endpoints, so the account you sign in with is
+  the one carrying the risk. See [ChatGPT sign-in](/chatgpt_login).
 - **`local`** — embeddings only, on a model you run yourself. Like `docling` it
   takes no API key: the base URL is the whole configuration. It is the mirror
   image of `google_vision` — a single job, done off the network. See [Local
@@ -93,11 +101,12 @@ after that.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `AI_MANAGED` | `0` | Whether the operator owns AI configuration. See the table above. |
-| `AI_SDK` | `openai` | The language model's SDK: `openai`, `openrouter` or `mistral`. `google_vision`, `docling` and `local` are refused — none of them can serve extraction. |
+| `AI_CHATGPT_LOGIN` | `0` | Whether **Settings** offers the `chatgpt` SDK, which bills a ChatGPT subscription instead of a metered key. Off unless set, and refused together with `AI_MANAGED=1`. It is not an `AI_SDK` value: the provider is added and signed in to from Settings, because its credential is minted rather than typed. See [ChatGPT sign-in](/chatgpt_login). |
+| `AI_SDK` | `openai` | The language model's SDK: `openai`, `openrouter` or `mistral`. `google_vision`, `docling` and `local` are refused — none of them can serve extraction. `chatgpt` too: it has no key to seed from the environment. |
 | `AI_API_KEY` | empty | Its credential. **One key is usually the whole configuration**: with this and nothing else the app creates one provider and routes extraction, chat, Deep Search *and* OCR to it. |
 | `AI_MODEL` | `gpt-5.6-luna` | The model for extraction, chat and Deep Search. Be sure it supports the result language set in **Settings**. |
 | `AI_BASE_URL` | the SDK's own endpoint | An OpenAI-compatible base URL, for a gateway or a self-hosted endpoint. |
-| `OCR_SDK` | unset (OCR runs on the `AI_SDK` provider) | A separate provider for OCR: `openai`, `openrouter`, `mistral`, `google_vision` or `docling`. `local` is refused — it serves embeddings only. Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. |
+| `OCR_SDK` | unset (OCR runs on the `AI_SDK` provider) | A separate provider for OCR: `openai`, `openrouter`, `mistral`, `google_vision` or `docling`. `local` and `chatgpt` are refused — neither can read a document. Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. |
 | `OCR_API_KEY` | `AI_API_KEY` when the SDKs match | Its credential. Required for an OCR SDK that differs from `AI_SDK` — except `docling`, which has no account behind it. Optional there, and only if you started the sidecar with `DOCLING_SERVE_API_KEY`. |
 | `OCR_BASE_URL` | `AI_BASE_URL` when the SDKs match, else the SDK's own endpoint | Where that provider lives. For `docling` the default is the compose service name, `http://docling:5001`, so `OCR_SDK=docling` alone is a complete configuration under the overlay. |
 | `OCR_MODEL` | `AI_MODEL` when the SDKs match | Its model. Not required for `google_vision` or `docling`, which read a document without one; for `docling` it optionally names the OCR engine instead. See [Choosing an engine](/local_ocr#choosing-an-engine). |

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -16,7 +16,7 @@ to use.
 | `openai` | ✅ | ✅ models that accept files/images | ✅ |
 | `openrouter` | ✅ many vendors on one key | ✅ models advertising `file` input | ✅ |
 | `google_vision` | ❌ | ✅ | ❌ |
-| **ChatGPT subscription** — `chatgpt` | ✅ **on a ChatGPT subscription** | ❌ | ❌ |
+| **ChatGPT subscription** — `chatgpt` | ✅ **on a ChatGPT subscription** | ✅ **on the same seat** | ❌ |
 | **Local OCR (Docling)** — `docling` | ❌ | ✅ **on your own host** | ❌ |
 | **Local Embeddings (huggingface/text-embeddings-inference)** — `local` | ❌ | ❌ | ✅ **on your own hardware** |
 
@@ -42,14 +42,17 @@ The alternatives are worth naming:
 - **`google_vision`** — OCR only; it cannot serve extraction and is refused as
   `AI_SDK`. Worth pairing with an LLM when its free tier (1000 pages a month)
   matters. See [Google Vision API key](/google_vision).
-- **ChatGPT subscription** — chat only, billed against a ChatGPT Plus, Pro or
-  Business subscription instead of per token. There is no key to paste: you add
-  the provider, sign in with a device code, and bind chat, extraction or Deep
-  Search to it. Embeddings and OCR are refused, because the endpoint behind it
-  serves neither. Off unless `AI_CHATGPT_LOGIN=1`, and refused on a managed
-  instance — it reaches OpenAI's own Codex endpoints, so the account you sign in
-  with is the one carrying the risk. Its SDK value is `chatgpt`, though it is
-  not an `AI_SDK` value. See [ChatGPT sign-in](/chatgpt_login).
+- **ChatGPT subscription** — everything but embeddings, billed against a
+  ChatGPT Plus, Pro or Business subscription instead of per token. There is no
+  key to paste: you add the provider, sign in with a device code, and bind chat,
+  extraction, Deep Search or OCR to it. OCR works the way it does on `openai` —
+  the file goes to the model — so an instance whose only AI credential is a
+  ChatGPT seat is a complete install. Embeddings are refused: the endpoint has
+  no `/embeddings` at all. Off unless `AI_CHATGPT_LOGIN=1`, and refused on a
+  managed instance — it reaches OpenAI's own Codex endpoints, so the account you
+  sign in with is the one carrying the risk. Its SDK value is `chatgpt`, though
+  it is not an `AI_SDK` or `OCR_SDK` value: a sign-in cannot be written into
+  `.env`. See [ChatGPT sign-in](/chatgpt_login).
 - **Local OCR (Docling)** — OCR only, and the only provider that reads a
   document without sending it anywhere: a sidecar container beside the app,
   with no port published and **no API key at all** — the base URL is the whole
@@ -112,7 +115,7 @@ after that.
 | `AI_API_KEY` | empty | Its credential. **One key is usually the whole configuration**: with this and nothing else the app creates one provider and routes extraction, chat, Deep Search *and* OCR to it. |
 | `AI_MODEL` | `gpt-5.6-luna` | The model for extraction, chat and Deep Search. Be sure it supports the result language set in **Settings**. |
 | `AI_BASE_URL` | the SDK's own endpoint | An OpenAI-compatible base URL, for a gateway or a self-hosted endpoint. |
-| `OCR_SDK` | unset (OCR runs on the `AI_SDK` provider) | A separate provider for OCR: `openai`, `openrouter`, `mistral`, `google_vision` or `docling` (Local OCR). `local` (Local Embeddings) and `chatgpt` are refused — neither can read a document. Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. |
+| `OCR_SDK` | unset (OCR runs on the `AI_SDK` provider) | A separate provider for OCR: `openai`, `openrouter`, `mistral`, `google_vision` or `docling` (Local OCR). `local` (Local Embeddings) is refused — it serves embeddings only. `chatgpt` reads documents but is refused here too: it is signed in to from Settings rather than given a key, so the environment has nothing to seed it with. Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. |
 | `OCR_API_KEY` | `AI_API_KEY` when the SDKs match | Its credential. Required for an OCR SDK that differs from `AI_SDK` — except Local OCR (`docling`), which has no account behind it. Optional there, and only if you started the sidecar with `DOCLING_SERVE_API_KEY`. |
 | `OCR_BASE_URL` | `AI_BASE_URL` when the SDKs match, else the SDK's own endpoint | Where that provider lives. For Local OCR (`docling`) the default is the compose service name, `http://docling:5001`, so `OCR_SDK=docling` alone is a complete configuration under the overlay. |
 | `OCR_MODEL` | `AI_MODEL` when the SDKs match | Its model. Not required for `google_vision` or Local OCR (`docling`), which read a document without one; for Local OCR it optionally names the OCR engine instead. See [Choosing an engine](/local_ocr#choosing-an-engine). |

--- a/docs/chatgpt_login.md
+++ b/docs/chatgpt_login.md
@@ -2,8 +2,8 @@
 
 Lemmary can run its language-model work on a **ChatGPT Plus, Pro or Business
 subscription** instead of a metered API key. You sign in once with a device
-code, bind chat, extraction and Deep Search to it, and those calls come out of
-the seat you already pay for rather than out of API credits.
+code, bind chat, extraction, Deep Search and OCR to it, and those calls come out
+of the seat you already pay for rather than out of API credits.
 
 It is off unless you turn it on, and there are good reasons for that. Read the
 whole page before you do.
@@ -15,13 +15,25 @@ whole page before you do.
 | Document chat | ✅ |
 | Metadata extraction | ✅ |
 | Deep Search (and its per-document helper) | ✅ |
-| Embeddings | ❌ — keep a keyed provider bound |
-| OCR | ❌ — keep Mistral, Google Vision or the Docling sidecar |
+| OCR | ✅ — a PDF or an image, up to 10 MB, read by the bound model |
+| Embeddings | ❌ — keep a keyed provider or the sidecar bound |
 
-The endpoint behind this SDK serves one thing: a conversation. It has no
-`/embeddings` and accepts no attachments, so Settings refuses to bind a
-`chatgpt` provider to embeddings or OCR. A mixed install is the normal shape —
-chat on the subscription, embeddings and OCR on something else.
+OCR works the same way it does on OpenAI or OpenRouter: the file goes to the
+model as an attachment and the model transcribes it. So the whole pipeline can
+run on the subscription — which means an instance whose only AI credential is a
+ChatGPT seat is a complete install, with no API key anywhere.
+
+Embeddings are the exception, and not a matter of degree: the endpoint has no
+`/embeddings` at all, so Settings refuses that binding. Deep Search still works
+without them — it falls back to keyword matching — but its dense half needs a
+keyed provider or the [local embeddings sidecar](/local_embeddings).
+
+Two things worth knowing before you put OCR here. A subscription's quota is a
+window rather than a meter, and OCR is the heaviest thing Lemmary does per
+document, so a bulk import can spend a window quickly. And these are general
+models being asked to read a scan, not a document endpoint: Mistral's OCR is
+purpose-built for the job and the Docling sidecar does it without leaving your
+host. Either is the better OCR if you have it.
 
 ## What you are agreeing to
 
@@ -85,14 +97,26 @@ SDK.
 
 ### 4. Bind the models
 
-Under **Settings → Models**, point **Chat**, **Extraction**, **Deep Search** or
-the **Deep Search helper** at the new provider and pick a model. The picker is
-served locally — the endpoint publishes no catalogue — and the **Custom model
-id** box takes anything the list does not name. Which models the account may
-actually use depends on its plan; one it may not use fails on the first request
-with the backend's own message.
+Under **Settings → Models**, point **Chat**, **Extraction**, **Deep Search**,
+the **Deep Search helper** or **OCR** at the new provider and pick a model. The
+picker is served locally — the endpoint publishes no catalogue — and the
+**Custom model id** box takes anything the list does not name. Which models the
+account may actually use depends on its plan; one it may not use fails on the
+first request with the backend's own message.
 
-Leave **Embeddings** and **OCR** where they are.
+The same list is offered for OCR as for chat, because the Codex catalogue says
+nothing about which models read a file. Pick a full model rather than a `mini`
+one if the scans are poor.
+
+Leave **Embeddings** where it is.
+
+### Setting up a fresh instance this way
+
+The setup wizard offers **ChatGPT subscription** too, once `AI_CHATGPT_LOGIN=1`
+is set, so a first-boot instance can be configured with no API key at all.
+Choosing it saves the provider row and then holds the step open for the
+sign-in — the token needs a row to be stored against — and setup carries on to
+the model bindings once you have approved the code.
 
 ## Signing out, and signing in as somebody else
 
@@ -127,6 +151,15 @@ not covering the bound model. Try the default model, or a smaller one.
 **Requests start failing for everyone at once** — most likely the quota window,
 or a change on OpenAI's side. Rebind chat and Deep Search to a keyed provider
 while you work out which.
+
+**OCR returns empty or invented text** — the model was handed the file but
+could not read it, or was a `mini` model on a poor scan. Try a larger model
+first. `OCR_SDK=chatgpt` is refused in `.env`, by the way: the environment can
+carry a key but not a sign-in, so OCR is bound to this provider from Settings.
+
+**"LLM OCR does not support mime type ..."** — the attachment path takes PDFs
+and images only, the same as OpenAI and OpenRouter. Anything else needs Mistral,
+Google Vision or the Docling sidecar.
 
 **Extraction results got worse after switching** — extraction asks for JSON, and
 a backend that will not honour the request is answered in plain text and parsed

--- a/docs/chatgpt_login.md
+++ b/docs/chatgpt_login.md
@@ -1,0 +1,134 @@
+# ChatGPT sign-in
+
+Lemmary can run its language-model work on a **ChatGPT Plus, Pro or Business
+subscription** instead of a metered API key. You sign in once with a device
+code, bind chat, extraction and Deep Search to it, and those calls come out of
+the seat you already pay for rather than out of API credits.
+
+It is off unless you turn it on, and there are good reasons for that. Read the
+whole page before you do.
+
+## What it can and cannot do
+
+| | |
+| --- | --- |
+| Document chat | ✅ |
+| Metadata extraction | ✅ |
+| Deep Search (and its per-document helper) | ✅ |
+| Embeddings | ❌ — keep a keyed provider bound |
+| OCR | ❌ — keep Mistral, Google Vision or the Docling sidecar |
+
+The endpoint behind this SDK serves one thing: a conversation. It has no
+`/embeddings` and accepts no attachments, so Settings refuses to bind a
+`chatgpt` provider to embeddings or OCR. A mixed install is the normal shape —
+chat on the subscription, embeddings and OCR on something else.
+
+## What you are agreeing to
+
+This works by presenting Lemmary as one of OpenAI's own Codex clients: it uses
+the Codex client id to sign in and the Codex `originator` header to make
+requests. Those endpoints are undocumented and reserved for OpenAI's own
+clients.
+
+Three consequences worth being clear about:
+
+- **The account is yours to risk.** OpenAI can treat a third-party client using
+  subscription credentials as a terms violation. Nothing here hides what
+  Lemmary is doing, and nobody can promise how OpenAI will treat it.
+- **It can break without warning.** Any change on OpenAI's side can start
+  refusing these requests. The failure shows up as a provider error on the next
+  document, not as a silent fallback to a billed provider.
+- **Quota is a window, not a meter.** A subscription's allowance refills over
+  five-hour and weekly windows. Deep Search fans out across documents and can
+  spend a window quickly; if that becomes a problem, move the **Deep Search
+  helper** binding back to a keyed provider first — it does the bulk reading.
+
+This is why the SDK never appears on a managed instance: there, the tenant is
+not the party whose account would be at stake.
+
+## Turning it on
+
+### 1. Allow device-code sign-in on the ChatGPT account
+
+Device-code login is off by default for everybody. It is what lets you approve a
+sign-in from any browser, which is the only way this works on a server.
+
+- **Personal account** — ChatGPT → **Settings** → **Security** → enable device
+  code authorization.
+- **Team, Enterprise or Edu** — a workspace admin has to grant it in the
+  workspace permissions; the personal toggle is greyed out or absent.
+
+If you skip this, Lemmary's sign-in fails with a message naming the setting.
+
+### 2. Set the flag
+
+```bash
+AI_CHATGPT_LOGIN=1
+```
+
+Absent means off. A value it cannot read — `AI_CHATGPT_LOGIN=ture` — is an error
+rather than a silent off, the same as `AI_MANAGED`. Setting it together with
+`AI_MANAGED=1` refuses to start.
+
+Restart the app. **Settings → Providers** now offers a **ChatGPT subscription**
+SDK.
+
+### 3. Add the provider and sign in
+
+1. **Settings → Providers → Add provider**, SDK **ChatGPT subscription**. There
+   is no API key field. Save it.
+2. The saved row grows a **Sign in with ChatGPT** button. Press it and Lemmary
+   shows a short code and a link.
+3. Open the link in any browser signed in to the ChatGPT account, enter the
+   code, approve. The code is good for about fifteen minutes.
+4. The row reads **signed in**, with the account and plan beside it.
+
+### 4. Bind the models
+
+Under **Settings → Models**, point **Chat**, **Extraction**, **Deep Search** or
+the **Deep Search helper** at the new provider and pick a model. The picker is
+served locally — the endpoint publishes no catalogue — and the **Custom model
+id** box takes anything the list does not name. Which models the account may
+actually use depends on its plan; one it may not use fails on the first request
+with the backend's own message.
+
+Leave **Embeddings** and **OCR** where they are.
+
+## Signing out, and signing in as somebody else
+
+**Sign out** on the provider row clears the stored token and leaves the row.
+Signing in again is the same two clicks, so switching accounts needs no new
+provider.
+
+The bindings stay pointed at the row while it is signed out; those features
+report an unconfigured provider until somebody signs in again.
+
+## Where the token lives
+
+In the `oauth` column of the provider row, beside the API keys of every other
+provider. Like a key it is never returned by the API — Settings sees only
+whether a row is signed in, and the account name it was signed in with.
+
+The access token lasts about an hour and is refreshed in place, roughly once an
+hour, for as long as the instance runs. If you use [encryption at
+rest](/encryption), the token is covered by it exactly as an API key is.
+
+## Troubleshooting
+
+**"device code sign-in is not enabled for this account"** — step 1 above. On a
+Team, Enterprise or Edu workspace only an admin can grant it.
+
+**The code expired** — it is good for about fifteen minutes. Press **Sign in
+with ChatGPT** again for a new one.
+
+**403 on every request after a successful sign-in** — usually the account's plan
+not covering the bound model. Try the default model, or a smaller one.
+
+**Requests start failing for everyone at once** — most likely the quota window,
+or a change on OpenAI's side. Rebind chat and Deep Search to a keyed provider
+while you work out which.
+
+**Extraction results got worse after switching** — extraction asks for JSON, and
+a backend that will not honour the request is answered in plain text and parsed
+leniently. If the metadata is thinner than it was, put **Extraction** back on a
+keyed provider and leave chat and Deep Search on the subscription.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Setup and operation guides for Lemmary.
 - [Local OCR](/local_ocr) — run the OCR engine yourself, so scans never leave the host
 - [Local embeddings](/local_embeddings) — run the embedding model yourself, so Deep Search costs no tokens
 - [Google Vision API key](/google_vision) — obtain a Cloud Vision API key for OCR
+- [ChatGPT sign-in](/chatgpt_login) — run chat, extraction and Deep Search on a ChatGPT subscription instead of a metered key
 - [OAuth2 / SSO sign-in](/oauth) — enable provider sign-in on the app login screen
 - [Passkey sign-in](/passkeys) — sign in with a fingerprint, face, or device PIN instead of a password
 - [Encryption at rest](/encryption) — keep the volume ciphertext-only, and what that costs

--- a/frontend/.vitepress/config.ts
+++ b/frontend/.vitepress/config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
           { text: 'Local OCR', link: '/local_ocr' },
           { text: 'Local embeddings', link: '/local_embeddings' },
           { text: 'Google Vision', link: '/google_vision' },
+          { text: 'ChatGPT sign-in', link: '/chatgpt_login' },
           { text: 'OAuth2', link: '/oauth' },
           { text: 'Passkeys', link: '/passkeys' },
           { text: 'Encryption at rest', link: '/encryption' },

--- a/frontend/src/components/ChatGPTSignIn.tsx
+++ b/frontend/src/components/ChatGPTSignIn.tsx
@@ -49,7 +49,13 @@ export function ChatGPTSignIn({
     // The server's own interval, not one of our choosing: polling faster than
     // OpenAI asks for is what earns a slow_down.
     const period = Math.max(login.interval_seconds, 1) * 1000
+    // One poll at a time. A round trip slower than the interval would otherwise
+    // have two in the air asking about the same single-use authorization code,
+    // and whichever settled last would decide what the operator sees.
+    let inFlight = false
     const timer = setInterval(() => {
+      if (inFlight) return
+      inFlight = true
       void (async () => {
         try {
           const result = await pollChatGPTLogin(provider.id)
@@ -65,6 +71,8 @@ export function ChatGPTSignIn({
           if (cancelled) return
           setLogin(null)
           setError(err instanceof Error ? err.message : 'ChatGPT sign-in failed')
+        } finally {
+          inFlight = false
         }
       })()
     }, period)

--- a/frontend/src/components/ChatGPTSignIn.tsx
+++ b/frontend/src/components/ChatGPTSignIn.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  pollChatGPTLogin,
+  signOutChatGPT,
+  startChatGPTLogin,
+  type AIProvider,
+  type ChatGPTDeviceLogin,
+} from '../lib/api/providers'
+import { Button, fieldHintClassName } from './ui'
+
+/**
+ * The sign-in panel for a chatgpt provider, in place of the API key field every
+ * other SDK shows.
+ *
+ * It lives on the saved provider rather than in the add form because the flow
+ * needs a provider id to store the token against: an operator creates the row
+ * first, then signs in to it. That also makes signing in as a different account
+ * the same two clicks as signing in the first time.
+ *
+ * The device-code flow is what makes this work on a server: the code is typed
+ * into a browser on any machine, so nothing has to reach a loopback port on the
+ * host Lemmary runs on.
+ */
+export function ChatGPTSignIn({
+  provider,
+  onChange,
+}: {
+  provider: AIProvider
+  // Widened to Promise<unknown> so the page can pass its own provider reload,
+  // which resolves to the new list rather than to nothing.
+  onChange: () => void | Promise<unknown>
+}) {
+  const [login, setLogin] = useState<ChatGPTDeviceLogin | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  // Held in a ref so the polling effect does not list it as a dependency: the
+  // page passes a fresh closure on every render, and depending on it would tear
+  // the timer down and start a new interval several times a second.
+  const onChangeRef = useRef(onChange)
+  useEffect(() => {
+    onChangeRef.current = onChange
+  })
+
+  useEffect(() => {
+    if (!login) return
+    let cancelled = false
+
+    // The server's own interval, not one of our choosing: polling faster than
+    // OpenAI asks for is what earns a slow_down.
+    const period = Math.max(login.interval_seconds, 1) * 1000
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const result = await pollChatGPTLogin(provider.id)
+          if (cancelled) return
+          if (result.status === 'pending') return
+          setLogin(null)
+          if (result.status === 'expired') {
+            setError('That code expired. Start again to get a new one.')
+            return
+          }
+          await onChangeRef.current()
+        } catch (err) {
+          if (cancelled) return
+          setLogin(null)
+          setError(err instanceof Error ? err.message : 'ChatGPT sign-in failed')
+        }
+      })()
+    }, period)
+
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+    }
+  }, [login, provider.id])
+
+  async function onStart() {
+    setBusy(true)
+    setError('')
+    try {
+      setLogin(await startChatGPTLogin(provider.id))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start the ChatGPT sign-in')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function onSignOut() {
+    setBusy(true)
+    setError('')
+    try {
+      await signOutChatGPT(provider.id)
+      setLogin(null)
+      await onChange()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to sign out')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-2">
+      {provider.signed_in ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <p className={fieldHintClassName}>
+            Signed in{provider.account ? ` as ${provider.account}` : ''}
+            {provider.plan ? ` (${provider.plan})` : ''}.
+          </p>
+          <Button variant="secondary" size="xs" disabled={busy} onClick={() => void onSignOut()}>
+            Sign out
+          </Button>
+        </div>
+      ) : login ? (
+        <div className="flex flex-col gap-1">
+          <p className="text-sm text-ink">
+            Open{' '}
+            <a
+              className="underline"
+              href={login.verification_url}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {login.verification_url}
+            </a>{' '}
+            and enter this code:
+          </p>
+          <p className="font-mono text-lg tracking-widest text-ink">{login.user_code}</p>
+          <p className={fieldHintClassName}>
+            Waiting for you to approve it. The code is good for about fifteen minutes.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="secondary" size="xs" disabled={busy} onClick={() => void onStart()}>
+            {busy ? 'Starting…' : 'Sign in with ChatGPT'}
+          </Button>
+          <p className={fieldHintClassName}>
+            Needs device code sign-in enabled on the account, under ChatGPT Settings → Security.
+          </p>
+        </div>
+      )}
+      {error && <p className="text-xs text-madder">{error}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -7,7 +7,9 @@ import {
   createAIProvider,
   isLLMProvider,
   listAIProviders,
+  providerConfigured,
   requiresAPIKey,
+  requiresSignIn,
   sdkAliasDefault,
   keylessProviderDocs,
   keylessProviderHint,
@@ -17,7 +19,9 @@ import {
   type ProviderSDK,
 } from '../lib/api/providers'
 import { getAppSettings, updateAppSettings } from '../lib/api/settings'
+import { useAppMeta } from '../hooks/useAppMeta'
 import { AppFooter } from './AppFooter'
+import { ChatGPTSignIn } from './ChatGPTSignIn'
 import { ProviderModelFields } from './ProviderModelFields'
 import {
   AppLogo,
@@ -54,6 +58,9 @@ function nextConfigStep(status: SetupStatus): Step {
 }
 
 export function SetupWizard({ appName, accent, initialStatus, onComplete }: SetupWizardProps) {
+  // The meta endpoint is public, which is what lets the wizard read the flag
+  // before there is a session to read it with.
+  const { chatgptLogin } = useAppMeta()
   const [step, setStep] = useState<Step>(() => initialStep(initialStatus))
   const [status, setStatus] = useState(initialStatus)
   const [submitting, setSubmitting] = useState(false)
@@ -74,6 +81,10 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
   const [alias, setAlias] = useState('')
   const [baseURL, setBaseURL] = useState(SDK_DEFAULT_BASE.openai)
   const [apiKey, setApiKey] = useState('')
+  // The row a ChatGPT sign-in is waiting on. Signing in needs a provider id to
+  // store the token against, so the SDK cannot be finished in one step: the row
+  // is created first, then signed in to, and only then does the wizard move on.
+  const [signInProvider, setSignInProvider] = useState<AIProvider | null>(null)
 
   const [ocrProviderId, setOcrProviderId] = useState('')
   const [ocrModel, setOcrModel] = useState('')
@@ -161,7 +172,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
       if (requiresAPIKey(sdk) && !apiKey.trim()) {
         throw new Error('Enter an API key.')
       }
-      await createAIProvider({
+      const created = await createAIProvider({
         sdk,
         alias: alias.trim() || sdkAliasDefault(sdk),
         base_url: baseURL.trim(),
@@ -171,6 +182,12 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
       setProviders(nextProviders)
       setApiKey('')
       setAlias('')
+      // A row that signs in is not usable yet, and the models step would offer
+      // a provider that answers nothing. Hold here until the token is stored.
+      if (requiresSignIn(sdk)) {
+        setSignInProvider(nextProviders.find((item) => item.id === created.id) ?? created)
+        return
+      }
       const next = await refreshStatus()
       if (!next.needs_config) {
         setStep('done')
@@ -184,6 +201,25 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
     }
   }
 
+  // Called by the sign-in panel whenever it stores or clears a token. It is the
+  // provider list that says whether the sign-in took, not the panel: the token
+  // never reaches the browser, so `signed_in` on the reloaded row is the only
+  // evidence there is.
+  async function onSignedIn() {
+    const nextProviders = await listAIProviders()
+    setProviders(nextProviders)
+    const row = signInProvider && nextProviders.find((item) => item.id === signInProvider.id)
+    if (!row) {
+      setSignInProvider(null)
+      return
+    }
+    setSignInProvider(row)
+    if (!providerConfigured(row)) return
+    setSignInProvider(null)
+    const next = await refreshStatus()
+    setStep(next.needs_config ? 'models' : 'done')
+  }
+
   async function onSaveModels(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault()
     try {
@@ -193,7 +229,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
         throw new Error('Choose an OCR provider.')
       }
       if (!extractProviderId) {
-        throw new Error('Choose an extraction provider (OpenAI, OpenRouter, or Mistral).')
+        throw new Error('Choose an extraction provider.')
       }
       // First-launch setup only asks for one LLM binding: chat and search start
       // out pointing at the extraction provider/model and can be split later in
@@ -213,9 +249,7 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
         if (!next.has_ocr || !next.has_llm) {
           setStep(next.provider_count ? 'models' : 'providers')
         }
-        setError(
-          'Setup is still incomplete. Add an OCR provider and an LLM provider (OpenAI, OpenRouter, or Mistral).',
-        )
+        setError('Setup is still incomplete. Add an OCR provider and a language-model provider.')
         return
       }
       setStep('done')
@@ -336,7 +370,26 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
             </form>
           )}
 
-          {step === 'providers' && (
+          {step === 'providers' && signInProvider && (
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-ink-muted">
+                <strong className="font-medium text-ink">{signInProvider.alias}</strong> is saved
+                but not signed in yet. Open the link below, enter the code, and setup carries on by
+                itself once the token is stored.
+              </p>
+              <ChatGPTSignIn provider={signInProvider} onChange={onSignedIn} />
+              {error && <p className="text-sm text-madder">{error}</p>}
+              <button
+                type="button"
+                className="text-left text-xs font-medium text-ink-soft hover:text-ink"
+                onClick={() => setSignInProvider(null)}
+              >
+                Add a different provider instead
+              </button>
+            </div>
+          )}
+
+          {step === 'providers' && !signInProvider && (
             <form className="flex flex-col gap-4" onSubmit={onSaveProvider}>
               <p className="text-sm text-ink-muted">
                 Add a provider. OpenAI, OpenRouter, or Mistral can run extraction and chat;
@@ -344,6 +397,13 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
                 Local OCR runs Docling on your own host and Local Embeddings serves Deep
                 Search's dense half — neither needs an API key, but each needs its compose
                 overlay running first.
+                {chatgptLogin === true && (
+                  <>
+                    {' '}
+                    A ChatGPT subscription covers extraction, chat and OCR on the seat you already
+                    pay for, with no API key at all — you sign in with a code instead.
+                  </>
+                )}
               </p>
               {providers.length > 0 && (
                 <p className="text-xs text-ink-soft">
@@ -361,11 +421,14 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
                   }}
                   className={inputClassName}
                 >
-                  {/* chatgpt is not offered here whatever AI_CHATGPT_LOGIN
-                      says: signing in needs a saved provider row to store the
-                      token against, so it cannot be finished in one step of a
-                      wizard. Add it from Settings afterwards. */}
-                  {SDK_OPTIONS.filter((option) => option.value !== 'chatgpt').map((option) => (
+                  {/* chatgpt only where the instance opted in, the same
+                      condition Settings uses. Signing in needs a saved row to
+                      store the token against, so choosing it here creates the
+                      row and then holds the step open for the sign-in rather
+                      than finishing in one submit. */}
+                  {SDK_OPTIONS.filter(
+                    (option) => option.value !== 'chatgpt' || chatgptLogin === true,
+                  ).map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
@@ -427,7 +490,8 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
               </p>
               {llmProviders.length === 0 && (
                 <p className="text-sm text-amber-800">
-                  Add an OpenAI, OpenRouter, or Mistral provider to enable extraction and chat.
+                  Add an OpenAI, OpenRouter{chatgptLogin === true ? ', ChatGPT' : ''} or Mistral
+                  provider to enable extraction and chat.
                 </p>
               )}
               <ProviderModelFields

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -288,7 +288,9 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
           <h2 className="mb-4 font-display text-lg font-semibold text-ink">
             {step === 'admin' && 'Create your admin account'}
             {step === 'passkey' && 'Add a passkey'}
-            {step === 'providers' && 'Add a provider'}
+            {/* The sign-in stands on a row that is already added, so the
+                heading follows what the step is actually asking for. */}
+            {step === 'providers' && (signInProvider ? 'Sign in to ChatGPT' : 'Add a provider')}
             {step === 'models' && 'Choose models'}
             {step === 'done' && 'Setup complete'}
           </h2>

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -358,7 +358,11 @@ export function SetupWizard({ appName, accent, initialStatus, onComplete }: Setu
                   }}
                   className={inputClassName}
                 >
-                  {SDK_OPTIONS.map((option) => (
+                  {/* chatgpt is not offered here whatever AI_CHATGPT_LOGIN
+                      says: signing in needs a saved provider row to store the
+                      token against, so it cannot be finished in one step of a
+                      wizard. Add it from Settings afterwards. */}
+                  {SDK_OPTIONS.filter((option) => option.value !== 'chatgpt').map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>

--- a/frontend/src/lib/api/meta.ts
+++ b/frontend/src/lib/api/meta.ts
@@ -13,23 +13,33 @@ export type AppMeta = {
    * rejects, which fails the whole patch including tenant-owned timeouts.
    */
   aiManaged?: boolean
+  /**
+   * Whether this instance allows signing in with a ChatGPT subscription
+   * (AI_CHATGPT_LOGIN). Unknown reads as off, the opposite default to
+   * aiManaged and for the same reason: both err towards offering less. An SDK
+   * shown here that the server refuses is a dead end an admin cannot diagnose.
+   */
+  chatgptLogin?: boolean
 }
 
 export async function getAppMeta(): Promise<AppMeta> {
   try {
-    const data = await apiFetch<{ app_name?: string; accent?: string; ai_managed?: boolean }>(
-      '/api/app/meta',
-      {
-        public: true,
-        fallbackError: 'Failed to load app meta',
-      },
-    )
+    const data = await apiFetch<{
+      app_name?: string
+      accent?: string
+      ai_managed?: boolean
+      chatgpt_login?: boolean
+    }>('/api/app/meta', {
+      public: true,
+      fallbackError: 'Failed to load app meta',
+    })
     const appName = typeof data.app_name === 'string' ? data.app_name.trim() : ''
     const accent = typeof data.accent === 'string' ? data.accent.trim() : ''
     return {
       appName: appName || DEFAULT_APP_NAME,
       accent: accent || DEFAULT_ACCENT,
       aiManaged: data.ai_managed === true,
+      chatgptLogin: data.chatgpt_login === true,
     }
   } catch {
     // A name and accent have safe defaults; who owns AI configuration does not.

--- a/frontend/src/lib/api/providers.test.ts
+++ b/frontend/src/lib/api/providers.test.ts
@@ -153,16 +153,18 @@ describe('eligibleProviders', () => {
   })
 })
 
-// chatgpt is the mirror image of local: it chats and does nothing else, where
-// local embeds and does nothing else. Both exist to keep these predicates from
-// collapsing back into one "is it a hosted LLM" question.
+// chatgpt is what keeps these predicates from collapsing back into one "is it
+// a hosted LLM" question: it chats and reads documents but does not embed,
+// where local embeds and does nothing else.
 describe('the ChatGPT subscription SDK', () => {
-  it('chats but neither embeds nor reads a document', () => {
+  it('chats and reads documents but does not embed', () => {
     expect(isLLMProvider('chatgpt')).toBe(true)
     expect(canEmbedProvider('chatgpt')).toBe(false)
     expect(providerServesPurpose('chatgpt', 'llm')).toBe(true)
+    expect(providerServesPurpose('chatgpt', 'ocr')).toBe(true)
+    // The Codex backend serves no /embeddings at all, so this is the one
+    // binding it cannot take.
     expect(providerServesPurpose('chatgpt', 'embedding')).toBe(false)
-    expect(providerServesPurpose('chatgpt', 'ocr')).toBe(false)
   })
 
   it('signs in instead of taking a key', () => {

--- a/frontend/src/lib/api/providers.test.ts
+++ b/frontend/src/lib/api/providers.test.ts
@@ -4,8 +4,10 @@ import {
   canEmbedProvider,
   isLLMProvider,
   eligibleProviders,
+  providerConfigured,
   providerServesPurpose,
   requiresAPIKey,
+  requiresSignIn,
   SDK_DEFAULT_BASE,
   SDK_OPTIONS,
 } from './providers'
@@ -111,5 +113,37 @@ describe('eligibleProviders', () => {
 
   it('keeps an already-bound provider whatever its SDK, so it never renders blank', () => {
     expect(eligibleProviders(all, 'llm', 'p3').map((p) => p.id)).toEqual(['p1', 'p3'])
+  })
+})
+
+// chatgpt is the mirror image of local: it chats and does nothing else, where
+// local embeds and does nothing else. Both exist to keep these predicates from
+// collapsing back into one "is it a hosted LLM" question.
+describe('the ChatGPT subscription SDK', () => {
+  it('chats but neither embeds nor reads a document', () => {
+    expect(isLLMProvider('chatgpt')).toBe(true)
+    expect(canEmbedProvider('chatgpt')).toBe(false)
+    expect(providerServesPurpose('chatgpt', 'llm')).toBe(true)
+    expect(providerServesPurpose('chatgpt', 'embedding')).toBe(false)
+    expect(providerServesPurpose('chatgpt', 'ocr')).toBe(false)
+  })
+
+  it('signs in instead of taking a key', () => {
+    expect(requiresSignIn('chatgpt')).toBe(true)
+    expect(requiresAPIKey('chatgpt')).toBe(false)
+    for (const sdk of ['openai', 'openrouter', 'mistral', 'google_vision', 'local', 'docling']) {
+      expect(requiresSignIn(sdk)).toBe(false)
+    }
+  })
+
+  it('is configured by its token, not by a key or an address', () => {
+    const row = { sdk: 'chatgpt' as const, api_key_set: true, signed_in: false, base_url: 'x' }
+    expect(providerConfigured(row)).toBe(false)
+    expect(providerConfigured({ ...row, signed_in: true })).toBe(true)
+  })
+
+  it('is offered in the SDK picker with a default base URL', () => {
+    expect(SDK_OPTIONS.some((option) => option.value === 'chatgpt')).toBe(true)
+    expect(SDK_DEFAULT_BASE.chatgpt).toBe('https://chatgpt.com/backend-api/codex')
   })
 })

--- a/frontend/src/lib/api/providers.ts
+++ b/frontend/src/lib/api/providers.ts
@@ -5,6 +5,7 @@ export type ProviderSDK =
   | 'openrouter'
   | 'google_vision'
   | 'mistral'
+  | 'chatgpt'
   | 'local'
   | 'docling'
 
@@ -14,6 +15,11 @@ export type AIProvider = {
   alias: string
   base_url: string
   api_key_set: boolean
+  /** api_key_set's counterpart for the SDKs that sign in instead of taking a key. */
+  signed_in: boolean
+  /** Email or account id of the signed-in ChatGPT account. Never a token. */
+  account?: string
+  plan?: string
 }
 
 export type AIProviderWrite = {
@@ -42,6 +48,9 @@ export const SDK_DEFAULT_BASE: Record<ProviderSDK, string> = {
   openrouter: 'https://openrouter.ai/api/v1',
   mistral: 'https://api.mistral.ai/v1',
   google_vision: '',
+  // Not a /v1 root: the Codex backend serves one endpoint, and the middleware
+  // behind this SDK rewrites the SDK's /chat/completions into it.
+  chatgpt: 'https://chatgpt.com/backend-api/codex',
   // The service names in docker-compose.embeddings.yml and
   // docker-compose.local-ocr.yml.
   local: 'http://embeddings:80/v1',
@@ -53,6 +62,7 @@ export const SDK_OPTIONS: { value: ProviderSDK; label: string }[] = [
   { value: 'openrouter', label: 'OpenRouter' },
   { value: 'mistral', label: 'Mistral' },
   { value: 'google_vision', label: 'Google Cloud Vision' },
+  { value: 'chatgpt', label: 'ChatGPT subscription' },
   { value: 'local', label: 'Local embeddings (self-hosted)' },
   { value: 'docling', label: 'Docling (local)' },
 ]
@@ -62,7 +72,29 @@ export function sdkLabel(sdk: ProviderSDK | string) {
 }
 
 export function isLLMProvider(sdk: string) {
-  return sdk === 'openai' || sdk === 'openrouter' || sdk === 'mistral'
+  return sdk === 'openai' || sdk === 'openrouter' || sdk === 'mistral' || sdk === 'chatgpt'
+}
+
+/**
+ * Mirrors aiprovider.RequiresOAuth. The one SDK whose credential is minted by
+ * signing in rather than typed, so the provider form shows a sign-in panel
+ * where every other SDK shows an API key field.
+ */
+export function requiresSignIn(sdk?: string) {
+  return sdk === 'chatgpt'
+}
+
+/**
+ * Whether a provider row can actually serve a request. Mirrors
+ * aiprovider.Provider.Configured, including the order it asks in: a signed-in
+ * SDK is judged by its token, a hosted one by its key, a sidecar by its address.
+ */
+export function providerConfigured(
+  item: Pick<AIProvider, 'sdk' | 'api_key_set' | 'signed_in' | 'base_url'>,
+) {
+  if (requiresSignIn(item.sdk)) return item.signed_in
+  if (requiresAPIKey(item.sdk)) return item.api_key_set
+  return item.base_url.trim() !== ''
 }
 
 /**
@@ -72,25 +104,29 @@ export function isLLMProvider(sdk: string) {
  * aiprovider.CanEmbed.
  */
 export function canEmbedProvider(sdk: string) {
-  return isLLMProvider(sdk) || sdk === 'local'
+  // chatgpt is the second SDK to force these apart: it chats without embedding,
+  // because the Codex backend serves no /embeddings at all.
+  return (isLLMProvider(sdk) && sdk !== 'chatgpt') || sdk === 'local'
 }
 
 /**
- * Mirrors aiprovider.RequiresAPIKey. Only the two sidecars are exempt: they run
- * on the operator's own host and are reached by address alone. Default-true
- * like the Go side, so an unknown SDK still asks.
+ * Mirrors aiprovider.RequiresAPIKey. The two sidecars are exempt because they
+ * run on the operator's own host and are reached by address alone; chatgpt is
+ * exempt because it signs in instead. Default-true like the Go side, so an
+ * unknown SDK still asks.
  */
 export function requiresAPIKey(sdk?: string) {
-  return sdk !== 'local' && sdk !== 'docling'
+  return sdk !== 'local' && sdk !== 'docling' && sdk !== 'chatgpt'
 }
 
 /** Which SDKs may be bound to a given task, for the provider pickers. */
 export function providerServesPurpose(sdk: string, purpose: ModelPurpose) {
   if (purpose === 'embedding') return canEmbedProvider(sdk)
   if (purpose === 'llm') return isLLMProvider(sdk)
-  // OCR is the binding google_vision and docling exist for, and the one a
-  // local embeddings endpoint cannot serve. Mirrors aiprovider.CanOCR.
-  return sdk !== 'local'
+  // OCR is the binding google_vision and docling exist for, and the one neither
+  // a local embeddings endpoint nor the Codex backend can serve. Mirrors
+  // aiprovider.CanOCR.
+  return sdk !== 'local' && sdk !== 'chatgpt'
 }
 
 /**
@@ -137,7 +173,10 @@ export function localOCRModelHint(sdk?: string) {
  * Empty for the hosted SDKs, which show the key field instead.
  */
 export function keylessProviderHint(sdk?: string) {
-  if (requiresAPIKey(sdk)) return ''
+  // requiresSignIn is checked too: chatgpt needs no key either, but it is not
+  // keyless — it has a credential, obtained by signing in, and the panel that
+  // does that stands where this hint would.
+  if (requiresAPIKey(sdk) || requiresSignIn(sdk)) return ''
   const overlay = sdk === 'local' ? 'docker-compose.embeddings.yml' : 'docker-compose.local-ocr.yml'
   return `Runs on your own host, so no API key is needed \u2014 the address is the whole configuration. The default is the service name from ${overlay}.`
 }
@@ -197,6 +236,50 @@ export async function listProviderModels(id: string, purpose: ModelPurpose = 'll
     { fallbackError: 'Failed to load models' },
   )
   return { models: data.models ?? [], sdk: data.sdk ?? '' }
+}
+
+export type ChatGPTDeviceLogin = {
+  user_code: string
+  verification_url: string
+  interval_seconds: number
+  expires_in: number
+}
+
+export type ChatGPTLoginStatus = {
+  status: 'pending' | 'complete' | 'expired'
+  provider?: AIProvider
+}
+
+/**
+ * Starts the device-code sign-in and returns the code to read out and the page
+ * to type it into. The device auth id stays on the server: it is the half that
+ * would let anyone holding it finish somebody else's login.
+ */
+export function startChatGPTLogin(id: string) {
+  return apiFetch<ChatGPTDeviceLogin>(`/api/app/providers/${id}/chatgpt/device`, {
+    method: 'POST',
+    fallbackError: 'Failed to start the ChatGPT sign-in',
+  })
+}
+
+/**
+ * Checks once whether the code has been approved. The caller drives the
+ * interval, so a sign-in nobody completes costs one small request every few
+ * seconds rather than a connection held open for fifteen minutes.
+ */
+export function pollChatGPTLogin(id: string) {
+  return apiFetch<ChatGPTLoginStatus>(`/api/app/providers/${id}/chatgpt/device/poll`, {
+    method: 'POST',
+    fallbackError: 'Failed to check the ChatGPT sign-in',
+  })
+}
+
+/** Clears the stored token. The provider row stays, ready for another account. */
+export function signOutChatGPT(id: string) {
+  return apiFetch<AIProvider>(`/api/app/providers/${id}/chatgpt`, {
+    method: 'DELETE',
+    fallbackError: 'Failed to sign out of ChatGPT',
+  })
 }
 
 export type OCRProviderInfo = {

--- a/frontend/src/lib/api/providers.ts
+++ b/frontend/src/lib/api/providers.ts
@@ -138,10 +138,11 @@ export function requiresAPIKey(sdk?: string) {
 export function providerServesPurpose(sdk: string, purpose: ModelPurpose) {
   if (purpose === 'embedding') return canEmbedProvider(sdk)
   if (purpose === 'llm') return isLLMProvider(sdk)
-  // OCR is the binding google_vision and docling exist for, and the one neither
-  // a local embeddings endpoint nor the Codex backend can serve. Mirrors
-  // aiprovider.CanOCR.
-  return sdk !== 'local' && sdk !== 'chatgpt'
+  // OCR is the binding google_vision and docling exist for, and every LLM SDK
+  // can serve it by sending the file to a model — chatgpt included, whose
+  // models take the same file and image input the metered ones do. Only a local
+  // embeddings endpoint cannot. Mirrors aiprovider.CanOCR.
+  return sdk !== 'local'
 }
 
 /**

--- a/frontend/src/lib/runId.test.ts
+++ b/frontend/src/lib/runId.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { runId } from './runId'
+
+describe('runId', () => {
+  // The bug this replaced: crypto.randomUUID is secure-context only, so Deep
+  // Search threw "crypto.randomUUID is not a function" on an instance reached
+  // over plain HTTP at a LAN address. Nothing here may touch crypto.
+  it('needs no Web Crypto', () => {
+    const real = globalThis.crypto
+    Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true })
+    try {
+      expect(() => runId()).not.toThrow()
+      expect(runId()).toMatch(/^run-/)
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { value: real, configurable: true })
+    }
+  })
+
+  it('is unique across calls', () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => runId()))
+    expect(ids.size).toBe(1000)
+  })
+
+  it('is a non-empty string safe to put in a JSON body', () => {
+    const id = runId()
+    expect(id.length).toBeGreaterThan(8)
+    expect(id).toBe(id.trim())
+    // The server trims and compares it verbatim, so nothing exotic.
+    expect(id).toMatch(/^[a-z0-9-]+$/)
+  })
+})

--- a/frontend/src/lib/runId.ts
+++ b/frontend/src/lib/runId.ts
@@ -1,0 +1,31 @@
+/**
+ * An id for one Deep Search run, generated here rather than by the server.
+ *
+ * Why the client mints it: a run outlives its connection, so aborting the
+ * stream does not stop the work — cancelling has to be said out loud, by
+ * POSTing this id to /search/cancel. If the server minted it and sent it back
+ * in the first event, Cancel would do nothing until that event arrived, which
+ * on a Deep Search is seconds of fanning out across documents and exactly when
+ * someone is most likely to press it.
+ *
+ * Why it needs no randomness worth the name: the server treats it as an opaque
+ * key and cancelSearchRun scopes the lookup to the owner, so a guessed id from
+ * another account finds nothing. Uniqueness among one account's live runs is
+ * the entire requirement. It is not a credential.
+ *
+ * So no crypto. `crypto.randomUUID` was the first spelling of this and it was
+ * a bug: it exists only in a secure context, so a self-hosted instance reached
+ * over plain HTTP at a LAN address — a normal way to run this app, which the
+ * passkey helpers already treat as one — threw "crypto.randomUUID is not a
+ * function" before a query could be sent.
+ */
+
+// Per page load, so two tabs starting a run in the same millisecond still
+// differ. Math.random is ample for that and needs no secure context.
+const session = Math.random().toString(36).slice(2, 10)
+let counter = 0
+
+export function runId(): string {
+  counter += 1
+  return `run-${Date.now().toString(36)}-${session}-${counter.toString(36)}`
+}

--- a/frontend/src/routes/search.tsx
+++ b/frontend/src/routes/search.tsx
@@ -6,6 +6,7 @@ import { ChatTranscript } from '../components/ChatTranscript'
 import { ChatComposer } from '../components/ChatComposer'
 import { ChatSessionList } from '../components/ChatSessionList'
 import { MarkdownContent } from '../components/MarkdownContent'
+import { runId } from '../lib/runId'
 import { useAsync } from '../hooks/useAsync'
 import { useChatSession, type ChatSendResult } from '../hooks/useChatSession'
 import {
@@ -172,7 +173,7 @@ export function SearchPage() {
    */
   const runTurn = useCallback(
     async (id: string | undefined, content: string, turnMode: SearchMode): Promise<ChatSendResult> => {
-      const run = { controller: new AbortController(), id: crypto.randomUUID() }
+      const run = { controller: new AbortController(), id: runId() }
       runRef.current = run
 
       // Collected outside React state as well: the finished turn is assembled

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -5,6 +5,7 @@ import {
   deleteAIProvider,
   listAIProviders,
   requiresAPIKey,
+  requiresSignIn,
   sdkLabel,
   updateAIProvider,
   keylessProviderHint,
@@ -13,6 +14,7 @@ import {
   type AIProvider,
   type ProviderSDK,
 } from '../lib/api/providers'
+import { ChatGPTSignIn } from '../components/ChatGPTSignIn'
 import {
   getAppSettings,
   getEmbeddingStats,
@@ -120,7 +122,7 @@ function EmbeddingStatsLine({ stats }: { stats: EmbeddingStats | null }) {
 // Admin access is enforced by the route's beforeLoad guard.
 export function SettingsPage() {
   // unknown/failed meta counts as managed; see AppMeta.aiManaged
-  const { aiManaged } = useAppMeta()
+  const { aiManaged, chatgptLogin } = useAppMeta()
   const aiEditable = aiManaged === false
   const [form, setForm] = useState<FormState | null>(null)
   const [embeddingStats, setEmbeddingStats] = useState<EmbeddingStats | null>(null)
@@ -324,12 +326,22 @@ export function SettingsPage() {
                   <p className="text-xs text-ink-soft">
                     {sdkLabel(item.sdk)}
                     {item.base_url ? ` · ${item.base_url}` : ''}
-                    {requiresAPIKey(item.sdk)
-                      ? item.api_key_set
-                        ? ' · key set'
-                        : ' · missing key'
-                      : ' · no key needed'}
+                    {requiresSignIn(item.sdk)
+                      ? item.signed_in
+                        ? ' · signed in'
+                        : ' · not signed in'
+                      : requiresAPIKey(item.sdk)
+                        ? item.api_key_set
+                          ? ' · key set'
+                          : ' · missing key'
+                        : ' · no key needed'}
                   </p>
+                  {/* The sign-in panel stands where the key field would, and on
+                      the saved row rather than in the add form: the flow needs
+                      a provider id to store the token against. */}
+                  {requiresSignIn(item.sdk) && (
+                    <ChatGPTSignIn provider={item} onChange={reloadProviders} />
+                  )}
                 </div>
                 <div className="flex gap-2">
                   <Button
@@ -394,7 +406,12 @@ export function SettingsPage() {
                     }))
                   }}
                 >
-                  {SDK_OPTIONS.map((option) => (
+                  {/* Offering an SDK the server will refuse is a dead end an
+                      admin cannot diagnose, so chatgpt appears only where
+                      AI_CHATGPT_LOGIN turned it on. */}
+                  {SDK_OPTIONS.filter(
+                    (option) => option.value !== 'chatgpt' || chatgptLogin === true,
+                  ).map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
@@ -438,6 +455,12 @@ export function SettingsPage() {
                     }
                   />
                 </label>
+              ) : requiresSignIn(draft.sdk) ? (
+                <p className={`${fieldHintClassName} sm:col-span-2`}>
+                  Save the provider first, then sign in to it from the list above. Chat,
+                  extraction and Deep Search can run on the subscription; embeddings and OCR
+                  cannot, and keep whichever provider they have.
+                </p>
               ) : (
                 <p className={`${fieldHintClassName} sm:col-span-2`}>
                   {keylessProviderHint(draft.sdk)}


### PR DESCRIPTION
## Why

Every LLM SDK Lemmary ships bills per token. For a self-hoster who already pays for ChatGPT Plus, Pro or Business, that is a second bill for the same model — and it is why a lot of people never get past the setup wizard: the archive is ready, the subscription is there, and the thing in the way is a card on file for an API account they do not otherwise want.

This adds one SDK, `chatgpt`, that signs in to OpenAI's Codex backend with a subscription and serves chat, extraction, Deep Search **and OCR** from that seat. Everything but embeddings — so an instance whose only AI credential is a ChatGPT seat is a complete install, with no API key anywhere. It is off unless `AI_CHATGPT_LOGIN=1`, and refused outright when `AI_MANAGED=1`.

## What it is, and what it costs

The endpoint is OpenAI's own, undocumented, and reserved for OpenAI's clients: this presents as one of them, using the Codex client id to sign in and the Codex `originator` header on requests. Three consequences [the docs](docs/chatgpt_login.md) state plainly rather than bury, because an operator turning this on is the party carrying them:

- OpenAI can treat a third-party client on subscription credentials as a terms violation.
- The endpoint can start refusing without warning.
- A subscription's allowance is a five-hour window rather than a meter — which Deep Search, fanning out across documents, can spend quickly.

Nothing here hides what Lemmary is doing. That is why the flag is strict like `AI_MANAGED` (`AI_CHATGPT_LOGIN=ture` is an error, not a silent off), and why the two are refused together: on a managed instance the tenant is not the party whose account would be at stake.

## Credentials the app mints rather than reads

This is the first provider whose credential is not a string somebody pastes. A device code, typed into any browser, because a server has no redirect listener to hand OAuth. The token pair lands in a new `oauth` column beside `api_key`, covered by the vault exactly as a key is and returned by the API exactly as often — never.

That forced apart a question the codebase had been answering with `APIKey != ""` in eight more places than the keyless-sidecar pass already fixed. `aiprovider` gains `RequiresOAuth` beside `RequiresAPIKey`, `Provider.OAuth` beside `Provider.APIKey`, and every LLM binding in `config.Runtime` now asks `Configured()` through a new `usableLLM` helper. `HasLLM` asks it too, which is what keeps a signed-in instance from sitting on the setup wizard with a working provider in front of it.

`AI_SDK=chatgpt` is refused, and the message says why: the environment can carry a key, it cannot carry a sign-in, so naming it in `.env` would seed a row the file naming it can never complete. `EnvLLMSDKs` is that list, derived rather than written out, and the two error messages that used to spell their alternatives by hand now build them the same way.

## The middleware, and why nothing above it knows

The Codex backend serves one endpoint, `/responses`, and speaks SSE. Everything above it — extractor, chatter, splitter, helper, search agent — sends Chat Completions through `openai-go`. Rather than teach five call sites a second protocol, `internal/chatgpt/transport.go` is an `openai-go` middleware that rewrites `POST /chat/completions` into `POST /responses` on the way out and reassembles the answer on the way in, buffered or streamed. The five `NewX` constructors grew a variadic option tail and pass it through; that is the whole of the change visible outside the package.

The token behind it refreshes about once an hour. That is why the `ai_providers` update hook now skips the reload for a rotation — rebuilding every AI client on a timer would swap the extractor out from under a running job, and re-read a row the token source has just written.

## It chats, it reads, it does not embed

OCR runs on the seat the way it runs on `openai`: the file goes to the bound model as an `input_file` (PDF) or `input_image` (scan) part, so `CanOCR` admits it and Settings offers the binding.

Embeddings are the one refusal, and it is a real absence rather than a policy: that endpoint has no `/embeddings` at all. `CanEmbed` refuses it, and Deep Search's dense half keeps a keyed provider or the local sidecar.

`OCR_SDK=chatgpt` is still refused in `.env`, but for the credential rather than the capability — the environment can carry a key, not a sign-in — hence `EnvOCRSDKs` beside `EnvLLMSDKs`, derived the same way. `NewFromAIProvider` asks `CanOCR` first regardless, so an SDK that can never read a document says that instead of complaining about a missing model it would have no use for.

The setup wizard offers the SDK too, so a first-boot instance can be configured without an API key: it saves the provider row, holds the step open for the device-code sign-in, and moves on to the model bindings once the reloaded row reads as signed in.

The model picker is written out in `aiprovider.ChatGPTModels`, with Codex's own one-line descriptions. `/models` does not exist on this backend, so the alternative was an empty picker and the custom-model box for everybody. Which of those an account may actually use depends on its plan, and only the backend knows; one it may not use fails on the first request with the backend's own message.

A migration widens `ai_providers.sdk` and adds the `oauth` column, for the same reason `1730000024` exists: `EnsureCollection` returns an existing collection untouched, so without it every install past its first boot would refuse a `chatgpt` row with a PocketBase validation message that names no SDK at all.

## Review fixes

Three findings from the automated review, all confirmed against the code before fixing:

**Tools were dropped by the middleware.** `chatRequest` declared only messages, token caps and `response_format`, so `json.Unmarshal` silently discarded the `tools`/`tool_choice` that Deep Search and Research set on every round, and nothing mapped `function_call` back. Bound to ChatGPT the model could not reach the archive, and `search.go` reads a round with no tool calls as a finished answer — a confident reply with no documents behind it, not a 4xx. The middleware now speaks the whole protocol in both directions, streamed and buffered.

`ai.CompleteChat`'s Responses fallback is also off for this SDK: a 403 classifies as an endpoint mismatch, and taking that fallback POSTs `/responses` past the middleware with the placeholder key and no `originator`. Four reroutes had to close, not two — the test written for the first found a second pair inside `completeStreaming`.

**Sign-out could be undone.** `Forget` only dropped the registry entry, so a refresh already in flight came back and persisted its rotated pair — which `onlyTokenRotated` reads as a sign-in, rebuilding signed-in clients with no error anywhere. A source is now retired by an atomic flag (atomic, not under `mu`, which is held across the refresh round trip), both handlers Forget before the write rather than after, and provider delete forgets too.

**Overlapping device polls** could 502 a login that had just succeeded, since the authorization code is single-use. The sequence holds a per-provider mutex, reads the pending login after the lock, and reports the stored sign-in rather than a gateway error; the frontend skips a tick while one poll is in the air.

## Merge with main

Two collisions, both where main touched the same lines. `NewHelper` grew the variadic option tail here while main clamped its timeout with `helperTimeout`; the merged signature keeps both. Main also renamed the local providers in the docs from bare SDK codes to the names Settings shows, so the ChatGPT rows follow that convention — **ChatGPT subscription**, SDK value `chatgpt` — while keeping this branch's note that it is refused as both `AI_SDK` and `OCR_SDK`.

## Verification

`./scripts/test-all.sh` passes and the backend is clean under `-race`.

The device-code flow, the refresh, the rotation write-back and the `/responses` rewrite are covered against stub servers built from the real request and response shapes — including the ones only a real endpoint reveals: quoted numbers in the device auth response, a refusal that means "still waiting", a refresh grant that returns no `expires_in` (so the expiry comes from the access token's own `exp` claim) and no `id_token` (so the identity is carried forward rather than lost), and a stream that fails mid-answer leaving a partial completion rather than an error.

The review fixes add: seven middleware tests for the tool round trip (outbound tools, `tool_choice` including `"none"` shipped with its tools, a replayed tool round, the returned call from either event shape, no double-counting, a streamed call) — all seven verified to fail with the fix neutered; six more for the multimodal parts; a refresh held open across `Forget` that must store nothing and serve nothing; and the Responses guard for 401/403/404 and for streams, asserting the stub's `/responses` was never reached.

### End-to-end coverage

The two gaps this PR could not close on its own are now covered in the overlay suite (branch `chatgpt-subscription-login` there), which is why this PR adds a seam:

- `browser/chatgpt-signin.spec.ts` drives the wizard: the SDK appears only behind the flag, choosing it saves a row and holds the step open rather than advancing, the wizard moves on once the reloaded row reads as signed in, and the seat is then bound to both OCR and extraction to finish setup with no API key anywhere.
- `e2e/chatgpt_signin_test.go` drives the handlers against a live PocketBase: the token lands in `oauth` and never in a response or the listing, the device auth id never reaches the browser, four concurrent polls all report the completed sign-in with the code exchanged exactly once, sign-out clears the token and keeps the row, the endpoints are refused when the flag is off, and the local model picker answers for chat and OCR but not embeddings.

Both were verified to fail without their fix: remove the poll lock and the concurrent polls report `expired` for a sign-in that succeeded; restore the old `CanOCR` and the OCR binding comes back 400.

**The seam.** The sign-in handlers built their client inline from `DefaultEndpoints`, so nothing outside the package could drive the flow. They read a package variable now (`chatgpt.SetAuthEndpointsForTesting`) — deliberately not an env var, which would ship a setting redirecting an OAuth flow to an arbitrary host, and not a parameter threaded through `Register` for one suite's sake.

**Binding refusals, while in there.** All three "requires an X, Y or Z provider" sentences were hand-written and two were wrong: the OCR one had omitted `docling` since the sidecar shipped (`aiprovider.sdksWhere`'s own comment complains about that exact list) and would now have omitted `chatgpt`; the LLM one had stopped naming `chatgpt`. They are derived from `LLMSDKs`/`EmbeddingSDKs`/`OCRSDKs` now, with the SDK check split into `providerServes` so the messages are testable without a database.

## Not covered

**Whether Codex `/responses` really accepts `input_file` and `input_image`** on these models. The shapes are the documented Responses ones and the stubs are built from them, but the endpoint is undocumented and nothing here has hit a real seat. First thing to check if OCR comes back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
