### PR TITLE
Give Opencode Go its own SDK instead of inferring it from a base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,16 +43,19 @@ WORKER_CRON_EXPR=* * * * *
 
 # One key is usually the whole configuration: with AI_API_KEY and nothing else
 # the app creates one provider and routes extraction, chat, Deep Search and OCR
-# to it. Mistral is the provider to reach for first -- it is the only SDK that
-# serves all three jobs (Document OCR, chat completions and mistral-embed), so
-# one key needs nothing else bound. See docs/ai_providers.md.
-AI_SDK=openai
-# mistral | openai | openrouter
+# to it. Opencode Go is the provider to reach for first -- one subscription
+# covers a catalogue of models, and its endpoint is the default below. Mistral
+# is the other one-key option: it is the only SDK that serves all three jobs
+# from its own models (Document OCR, chat completions and mistral-embed).
+# See docs/ai_providers.md.
+AI_SDK=opencode
+# opencode | mistral | openai | openrouter
 AI_API_KEY=
 # Be sure the model supports the result language you pick in Settings.
 AI_MODEL=deepseek-v4-flash
-# Optional; defaults to the SDK's own endpoint.
-AI_BASE_URL=https://opencode.ai/zen/go/v1
+# Optional; defaults to the SDK's own endpoint, which for opencode is
+# https://opencode.ai/zen/go/v1.
+# AI_BASE_URL=
 
 # Sign in with a ChatGPT subscription instead of paying per token. Off unless
 # set; refused together with AI_MANAGED=1.
@@ -78,7 +81,9 @@ AI_BASE_URL=https://opencode.ai/zen/go/v1
 # AI_MANAGED=1; removing it there turns the feature off.
 #
 # The model runs on the AI_SDK provider above unless AI_EMBEDDING_SDK names
-# another one; see the block below that.
+# another one; see the block below that. Under AI_SDK=opencode that block is
+# required rather than optional: Opencode serves no /embeddings, so there is no
+# provider to fall back to, and setting this without it is refused at boot.
 #
 # What it costs, because none of it is free:
 #  - Tokens. Every document is embedded once, in ~1100-character passages plus

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Admin Settings: providers, models and worker timeouts as runtime configuration:
 - **Backend:** Go, [PocketBase as a framework](https://pocketbase.io/docs/use-as-framework/)
 - **Frontend:** React, TanStack Router, PocketBase JS SDK
 - **OCR:** Mistral Document OCR (`mistral`), Google Cloud Vision (`google_vision`), a file-capable OpenAI/OpenRouter model, or Docling (`docling`) — a keyless sidecar on your own host running PaddleOCR's PP-OCR models, so scans never leave the machine; see [docs/local_ocr.md](docs/local_ocr.md). Configured in Settings
-- **AI:** OpenAI-compatible chat completions (Mistral, OpenAI, or OpenRouter) via the official OpenAI Go SDK — see [docs/ai_providers.md](docs/ai_providers.md)
+- **AI:** Opencode Go (`opencode`), Mistral, OpenAI, OpenRouter, or a ChatGPT subscription (`chatgpt`), via the official OpenAI and Anthropic Go SDKs — Opencode serves a third of its catalogue on Anthropic's Messages API, so the `opencode` SDK wraps both — see [docs/ai_providers.md](docs/ai_providers.md)
 - **Search:** [Bleve](https://github.com/blevesearch/bleve) full-text index (token AND for the search box, relaxed to most-terms for the agent, BM25 ranking) over titles, OCR, tags, and metadata
 - **Deep Search:** natural-language archive search via a tool-calling agent over that index (hybrid keyword and embedding retrieval; keyword expansion across configured languages when no embedding model is set), in two modes — **Search** lists matching documents, **Research** reads them, surveys and counts across the archive with a cheaper helper model, and writes a cited answer
 
@@ -143,4 +143,4 @@ For commercial licensing, contact Alexander Arutyunov <licensing@lemmary.app>.
 
 ## Recommended: Opencode Go
 
-[Opencode Go](https://opencode.ai/go?ref=84VDFS18QN) is a perfect plan to use with this project as AI provider. See the [docs](https://opencode.ai/docs/go/).
+[Opencode Go](https://opencode.ai/go?ref=84VDFS18QN) is a perfect plan to use with this project as AI provider: one subscription covers a catalogue of models, and `AI_SDK=opencode` is the whole configuration — it knows which of Opencode's three endpoints each model is served on, so nothing else needs binding. See the [docs](https://opencode.ai/docs/go/).

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.27.1
 
 require (
 	cloud.google.com/go/vision/v2 v2.14.0
+	github.com/anthropics/anthropic-sdk-go v1.71.0
 	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/blevesearch/bleve_index_api v1.2.11
 	github.com/go-webauthn/webauthn v0.17.4
@@ -29,6 +30,7 @@ require (
 	cloud.google.com/go/longrunning v0.9.0 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.22.0 // indirect
 	github.com/blevesearch/geo v0.2.4 // indirect
 	github.com/blevesearch/go-faiss v1.0.26 // indirect
@@ -46,6 +48,7 @@ require (
 	github.com/blevesearch/zapx/v14 v14.4.2 // indirect
 	github.com/blevesearch/zapx/v15 v15.4.2 // indirect
 	github.com/blevesearch/zapx/v16 v16.2.8 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/domodwyer/mailyak/v3 v3.6.2 // indirect
@@ -67,18 +70,21 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.4 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
@@ -94,6 +100,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/image v0.45.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -12,9 +12,13 @@ cloud.google.com/go/vision/v2 v2.14.0 h1:l4CjEOm9veghGSutx79p+WG6vI6/5DPjRsAasmi
 cloud.google.com/go/vision/v2 v2.14.0/go.mod h1:ODlLCajJOq4t8thoi1uVvbnfIfix73HsYWhZuIveagQ=
 github.com/RoaringBitmap/roaring/v2 v2.4.5 h1:uGrrMreGjvAtTBobc0g5IrW1D5ldxDQYe2JW2gggRdg=
 github.com/RoaringBitmap/roaring/v2 v2.4.5/go.mod h1:FiJcsfkGje/nZBZgCu0ZxCPOKD/hVXDS2dXi7/eUFE0=
+github.com/anthropics/anthropic-sdk-go v1.71.0 h1:DK9xG3s5t+xUIOp+R+1LIRjkU/wG57YyQO3630+gYOE=
+github.com/anthropics/anthropic-sdk-go v1.71.0/go.mod h1:x+lPk/cCl48uRegeP0hlYYBN1b7bEBTveInIMgLicnY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
@@ -54,6 +58,8 @@ github.com/blevesearch/zapx/v15 v15.4.2 h1:sWxpDE0QQOTjyxYbAVjt3+0ieu8NCE0fDRaFx
 github.com/blevesearch/zapx/v15 v15.4.2/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtmr/0/11H0Z8+Nw=
 github.com/blevesearch/zapx/v16 v16.2.8 h1:SlnzF0YGtSlrsOE3oE7EgEX6BIepGpeqxs1IjMbHLQI=
 github.com/blevesearch/zapx/v16 v16.2.8/go.mod h1:murSoCJPCk25MqURrcJaBQ1RekuqSCSfMjXH4rHyA14=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
@@ -64,6 +70,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/domodwyer/mailyak/v3 v3.6.2 h1:x3tGMsyFhTCaxp6ycgR0FE/bu5QiNp+hetUuCOBXMn8=
 github.com/domodwyer/mailyak/v3 v3.6.2/go.mod h1:lOm/u9CyCVWHeaAmHIdF4RiKVxKUT/H5XX10lIKAL6c=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -129,6 +137,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede h1:YrgBGwxMRK0Vq0WSCWFaZUnTsrA/PZE/xs1QZh+/edg=
@@ -147,6 +157,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
@@ -176,14 +188,16 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 h1:uOfcYT+3QungH6tIGSVCR/Y3KJmgJiHcojJbMTPDZAI=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
-github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -224,6 +238,8 @@ go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUS
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
 golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
@@ -271,6 +287,8 @@ google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBN
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/backend/internal/ai/chat.go
+++ b/backend/internal/ai/chat.go
@@ -66,7 +66,7 @@ func (c *OpenAIClient) Chat(ctx context.Context, ocrText string, messages []Chat
 	}
 
 	requestStart := time.Now()
-	chatResp, err := c.complete(ctx, openai.ChatCompletionNewParams{
+	chatResp, err := c.Complete(ctx, openai.ChatCompletionNewParams{
 		Model:       shared.ChatModel(c.model),
 		Messages:    apiMessages,
 		Temperature: CompletionTemperature(c.model, 0.3),

--- a/backend/internal/ai/embed.go
+++ b/backend/internal/ai/embed.go
@@ -81,13 +81,19 @@ type openAIEmbedder struct {
 // endpoint. dims is the length already recorded for this model (0 when
 // unknown); a response that disagrees with a non-zero value is refused.
 func NewEmbedder(sdk, apiKey, model, baseURL string, dims int, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) Embedder {
+	if strings.TrimSpace(sdk) == "" {
+		sdk = aiprovider.SDKOpenAI
+	}
 	opts := []option.RequestOption{
 		option.WithHTTPClient(&http.Client{Timeout: timeout}),
 		option.WithRequestTimeout(timeout),
 		// Retries are ours: only 429/5xx/network are worth repeating, and the
 		// backoff has to be long enough to outlast a rate-limit window.
 		option.WithMaxRetries(0),
-		option.WithMiddleware(aiprovider.SessionMiddleware()),
+	}
+	// Only OpenCode asks for the session header; see NewOpenAIClient.
+	if sdk == aiprovider.SDKOpenCode {
+		opts = append(opts, option.WithMiddleware(aiprovider.SessionMiddleware()))
 	}
 	// A keyless provider sends no Authorization header at all, rather than an
 	// empty "Bearer ". The local SDK is the case: a sidecar on the compose
@@ -96,14 +102,9 @@ func NewEmbedder(sdk, apiKey, model, baseURL string, dims int, timeout time.Dura
 	if strings.TrimSpace(apiKey) != "" {
 		opts = append(opts, option.WithAPIKey(apiKey))
 	}
-	// Tests pass RewriteHostMiddleware here so a base URL of opencode.ai still
-	// lands on httptest. Production callers pass none.
 	opts = append(opts, extra...)
 	if strings.TrimSpace(baseURL) != "" {
 		opts = append(opts, option.WithBaseURL(strings.TrimRight(baseURL, "/")))
-	}
-	if strings.TrimSpace(sdk) == "" {
-		sdk = aiprovider.SDKOpenAI
 	}
 	if logger == nil {
 		logger = slog.Default()

--- a/backend/internal/ai/embed_test.go
+++ b/backend/internal/ai/embed_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/openai/openai-go/option"
-
 	"lemmary/backend/internal/aiprovider"
 )
 
@@ -432,9 +430,8 @@ func TestEmbedSendsSessionHeaderToOpenCode(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	e, ok := NewEmbedder("openai", "test-key", "test-embed",
-		"http://opencode.ai/zen/go/v1", 0, 5*time.Second, slog.Default(),
-		option.WithMiddleware(aiprovider.RewriteHostMiddleware(srv.Listener.Addr().String())),
+	e, ok := NewEmbedder(aiprovider.SDKOpenCode, "test-key", "test-embed",
+		srv.URL+"/zen/go/v1", 0, 5*time.Second, slog.Default(),
 	).(*openAIEmbedder)
 	if !ok {
 		t.Fatal("NewEmbedder did not return the OpenAI implementation")
@@ -447,6 +444,19 @@ func TestEmbedSendsSessionHeaderToOpenCode(t *testing.T) {
 	}
 	if seen != "conv123" {
 		t.Errorf("%s = %q, want %q", aiprovider.SessionHeader, seen, "conv123")
+	}
+
+	// The other half of the gate: an openai row installs no middleware.
+	seen = "unset"
+	plain, _ := NewEmbedder(aiprovider.SDKOpenAI, "test-key", "test-embed",
+		srv.URL+"/v1", 0, 5*time.Second, slog.Default(),
+	).(*openAIEmbedder)
+	plain.sleep = func(time.Duration) {}
+	if _, err := plain.Embed(ctx, []string{"hello"}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if seen != "" {
+		t.Errorf("%s = %q, want empty for an openai provider", aiprovider.SessionHeader, seen)
 	}
 }
 

--- a/backend/internal/ai/extract.go
+++ b/backend/internal/ai/extract.go
@@ -194,7 +194,7 @@ func (c *OpenAIClient) ExtractMetadata(ctx context.Context, ocrText string, cata
 	)
 
 	requestStart := time.Now()
-	chatResp, err := c.complete(ctx, openai.ChatCompletionNewParams{
+	chatResp, err := c.Complete(ctx, openai.ChatCompletionNewParams{
 		Model: shared.ChatModel(c.model),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage(buildExtractionSystemPrompt(c.resultLanguage, catalog)),

--- a/backend/internal/ai/extract.go
+++ b/backend/internal/ai/extract.go
@@ -227,8 +227,16 @@ func (c *OpenAIClient) ExtractMetadata(ctx context.Context, ocrText string, cata
 		c.logger.Warn("extraction metadata repaired", "note", note)
 	}
 	if err != nil {
+		// The reply itself, bounded, not only its length. "title is required"
+		// is raised after the JSON parsed cleanly, so the length alone cannot
+		// tell a model that answered `{}` from one that answered at length
+		// about the wrong thing -- and those want opposite fixes. It is the
+		// model's own answer about the operator's own document, and a failure
+		// path only.
 		c.logger.Error("parse failed",
 			"content_chars", len(content),
+			"content", strutil.TruncateRunes(strings.TrimSpace(content), 500),
+			"finish_reason", chatResp.Choices[0].FinishReason,
 			slog.Any("error", err),
 		)
 		return nil, err

--- a/backend/internal/ai/helper.go
+++ b/backend/internal/ai/helper.go
@@ -139,7 +139,7 @@ func (h *openAIHelper) Distill(ctx context.Context, req DistillRequest) (Distill
 	}
 
 	requestStart := time.Now()
-	resp, err := h.client.complete(ctx, openai.ChatCompletionNewParams{
+	resp, err := h.client.Complete(ctx, openai.ChatCompletionNewParams{
 		Model: shared.ChatModel(h.client.model),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage(buildDistillSystemPrompt(req.Fields)),

--- a/backend/internal/ai/modelnotes.go
+++ b/backend/internal/ai/modelnotes.go
@@ -33,14 +33,9 @@ var (
 	// Models that would not take function tools alongside their default
 	// reasoning_effort, and had to be pinned to "none".
 	noReasoningEffortNotes sync.Map
-	// Models this endpoint does not serve on /chat/completions at all.
+	// Models this endpoint would not serve on /chat/completions with tools
+	// present, and that the Responses API served instead.
 	responsesAPINotes sync.Map
-	// Models /chat/completions has answered at least once, which makes a later
-	// refusal a transient failure rather than a wrong endpoint.
-	chatCompletionsWorked sync.Map
-	// How many times /chat/completions has refused a model with a status that
-	// could mean either.
-	ambiguousRefusals sync.Map
 )
 
 func rememberNoReasoningEffort(baseURL, model string) { store(&noReasoningEffortNotes, baseURL, model) }
@@ -51,30 +46,6 @@ func needsNoReasoningEffort(baseURL, model string) bool {
 func rememberResponsesAPI(baseURL, model string) { store(&responsesAPINotes, baseURL, model) }
 func needsResponsesAPI(baseURL, model string) bool {
 	return loaded(&responsesAPINotes, baseURL, model)
-}
-
-// rememberChatCompletionsWorked records a completion this endpoint served, so a
-// later failure is read as the provider having a bad minute rather than as a
-// model that lives somewhere else.
-func rememberChatCompletionsWorked(baseURL, model string) {
-	store(&chatCompletionsWorked, baseURL, model)
-}
-func chatCompletionsHasWorked(baseURL, model string) bool {
-	return loaded(&chatCompletionsWorked, baseURL, model)
-}
-
-// countAmbiguousRefusal returns how many times this endpoint has now refused
-// the model with a status that does not say which of the two it means.
-func countAmbiguousRefusal(baseURL, model string) int {
-	note := noteFor(baseURL, model)
-	if note.empty() {
-		return 0
-	}
-	count, _ := ambiguousRefusals.Load(note)
-	n, _ := count.(int)
-	n++
-	ambiguousRefusals.Store(note, n)
-	return n
 }
 
 func store(m *sync.Map, baseURL, model string) {
@@ -94,9 +65,7 @@ func loaded(m *sync.Map, baseURL, model string) bool {
 
 // resetModelNotes clears everything this process has learned. Tests only.
 func resetModelNotes() {
-	for _, m := range []*sync.Map{
-		&noReasoningEffortNotes, &responsesAPINotes, &chatCompletionsWorked, &ambiguousRefusals,
-	} {
+	for _, m := range []*sync.Map{&noReasoningEffortNotes, &responsesAPINotes} {
 		m.Range(func(k, _ any) bool {
 			m.Delete(k)
 			return true

--- a/backend/internal/ai/modelnotes_test.go
+++ b/backend/internal/ai/modelnotes_test.go
@@ -1,15 +1,6 @@
 package ai
 
-import (
-	"context"
-	"log/slog"
-	"net/http"
-	"testing"
-	"time"
-
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/shared"
-)
+import "testing"
 
 // A model name means nothing on its own. An instance can bind several providers
 // at once, so what one gateway does with "gpt-5.6-luna" must not follow the
@@ -43,41 +34,5 @@ func TestModelNotesAreScopedToTheirEndpoint(t *testing.T) {
 	rememberResponsesAPI(zen, "  ")
 	if needsResponsesAPI(zen, "") {
 		t.Fatal("an empty model name was stored as a note")
-	}
-}
-
-// The same model behind two providers must be discovered separately, all the
-// way through CompleteChat rather than only in the note store.
-func TestDiscoveryDoesNotLeakBetweenProviders(t *testing.T) {
-	resetModelNotes()
-	t.Cleanup(resetModelNotes)
-	const model = "shared-model-name"
-
-	// One provider serves this model only on /responses.
-	responsesOnly := &responsesHarness{chatStatus: http.StatusNotFound, respTurns: []scriptedTurn{{content: "from responses"}}}
-	responsesBase := newResponsesHarness(t, responsesOnly)
-	// The other serves it perfectly well on /chat/completions.
-	ordinary := &responsesHarness{}
-	ordinaryBase := newResponsesHarness(t, ordinary)
-
-	params := openai.ChatCompletionNewParams{
-		Model:    shared.ChatModel(model),
-		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
-	}
-	first := NewOpenAIClient("openai", "k", model, responsesBase, "v1", "", 5*time.Second, slog.Default())
-	if _, err := CompleteChat(context.Background(), first.client, slog.Default(), "openai", responsesBase, params); err != nil {
-		t.Fatalf("responses-only provider: %v", err)
-	}
-
-	second := NewOpenAIClient("openai", "k", model, ordinaryBase, "v1", "", 5*time.Second, slog.Default())
-	resp, err := CompleteChat(context.Background(), second.client, slog.Default(), "openai", ordinaryBase, params)
-	if err != nil {
-		t.Fatalf("ordinary provider: %v", err)
-	}
-	if resp.Choices[0].Message.Content != "served by chat completions" {
-		t.Fatalf("content = %q", resp.Choices[0].Message.Content)
-	}
-	if _, r := ordinary.counts(); r != 0 {
-		t.Fatalf("the other provider's discovery sent %d requests to this one's /responses", r)
 	}
 }

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/shared"
 	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/opencode"
 )
 
 type OpenAIClient struct {
@@ -23,30 +25,40 @@ type OpenAIClient struct {
 	resultLanguage string
 	client         openai.Client
 	logger         *slog.Logger
+
+	// messages is the Anthropic client the opencode SDK needs for the third of
+	// its catalogue served on /messages. The zero value is never used: whether
+	// a model goes there is opencode.Endpoint's answer, and it only ever says
+	// so for SDKOpenCode.
+	messages anthropic.Client
 }
 
 func NewOpenAIClient(sdk, apiKey, model, baseURL, promptVer, resultLanguage string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) *OpenAIClient {
+	if strings.TrimSpace(sdk) == "" {
+		sdk = aiprovider.SDKOpenAI
+	}
 	opts := []option.RequestOption{
 		option.WithAPIKey(apiKey),
 		option.WithHTTPClient(&http.Client{Timeout: timeout}),
 		option.WithRequestTimeout(timeout),
 		option.WithMaxRetries(0),
-		option.WithMiddleware(aiprovider.SessionMiddleware()),
 	}
-	// Tests pass RewriteHostMiddleware here so a base URL of opencode.ai still
-	// lands on httptest. Production callers pass none.
+	// Only OpenCode asks for the session header, and now it is the SDK saying
+	// so rather than the middleware sniffing the request host for opencode.ai.
+	if sdk == aiprovider.SDKOpenCode {
+		opts = append(opts, option.WithMiddleware(aiprovider.SessionMiddleware()))
+	}
+	// Production callers pass the chatgpt middleware here, which mints a bearer
+	// token per request; see config.providerCredential.
 	opts = append(opts, extra...)
 	if strings.TrimSpace(baseURL) != "" {
 		opts = append(opts, option.WithBaseURL(strings.TrimRight(baseURL, "/")))
-	}
-	if strings.TrimSpace(sdk) == "" {
-		sdk = "openai"
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
 
-	return &OpenAIClient{
+	c := &OpenAIClient{
 		sdk:            sdk,
 		apiKey:         apiKey,
 		model:          model,
@@ -56,6 +68,10 @@ func NewOpenAIClient(sdk, apiKey, model, baseURL, promptVer, resultLanguage stri
 		client:         openai.NewClient(opts...),
 		logger:         logger,
 	}
+	if sdk == aiprovider.SDKOpenCode {
+		c.messages = opencode.NewMessages(apiKey, baseURL, timeout)
+	}
+	return c
 }
 
 func (c *OpenAIClient) Name() string {
@@ -66,33 +82,50 @@ func (c *OpenAIClient) Model() string {
 	return c.model
 }
 
-func (c *OpenAIClient) complete(ctx context.Context, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
-	return CompleteChat(ctx, c.client, c.logger, c.sdk, c.baseURL, params, extra...)
+// Complete sends a chat completion, and gives a provider that refuses it a
+// second chance rather than treating the model as broken.
+//
+// It first asks opencode.Endpoint whether this model is served somewhere other
+// than /chat/completions at all -- the opencode SDK routes each model to one of
+// three endpoints, and it is the only SDK that does. Everything after that is
+// degradation on the endpoint the model does live on: JSON mode is dropped if
+// response_format is rejected, reasoning_effort is pinned to "none" if the model
+// will not take tools alongside it, and temperature falls back to the API
+// default. The reasoning_effort case prefers the Responses API, which keeps both
+// the tools and the reasoning, and is remembered per model and endpoint so the
+// discovery costs one rejected request per process rather than one per call.
+func (c *OpenAIClient) Complete(ctx context.Context, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
+	switch opencode.Endpoint(c.sdk, string(params.Model)) {
+	case opencode.EndpointMessages:
+		resp, err := opencode.CompleteViaMessages(ctx, c.messages, c.logger, c.baseURL, params, extra...)
+		if err == nil {
+			logUsage(c.logger, string(params.Model), usageOf(resp), extra...)
+		}
+		return resp, err
+	case opencode.EndpointResponses:
+		resp, err := CompleteViaResponses(ctx, c.client, c.logger, c.sdk, c.baseURL, params, extra...)
+		if err == nil {
+			logUsage(c.logger, string(params.Model), usageOf(resp), extra...)
+		}
+		return resp, err
+	}
+	return c.completeChat(ctx, params, extra...)
 }
 
-// CompleteChat sends a chat completion, and gives a provider that refuses it a
-// second chance rather than treating the model as broken. In order: JSON mode
-// is dropped if response_format is rejected, reasoning_effort is pinned to
-// "none" if the model will not take tools alongside it, temperature falls back
-// to the API default, and finally the whole request is translated to the
-// Responses API if this endpoint turns out not to serve the model at all. Each
-// of the last two is remembered per model and endpoint, so the discovery costs
-// one rejected request per process rather than one per call.
-func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger, sdk, baseURL string, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
-	if logger == nil {
-		logger = slog.Default()
-	}
+func (c *OpenAIClient) completeChat(ctx context.Context, params openai.ChatCompletionNewParams, extra ...any) (*openai.ChatCompletion, error) {
+	logger := c.logger
+	baseURL := c.baseURL
 	// The chatgpt SDK already speaks the Responses API, from underneath: its
 	// middleware rewrites /chat/completions into /responses and only it knows
 	// the Codex auth headers. Translating again up here would post to
-	// /responses with the placeholder key and no originator, so every
-	// degradation path below stays on the endpoint the middleware owns.
-	viaResponses := !aiprovider.RequiresOAuth(sdk)
+	// /responses with the placeholder key and no originator, so the degradation
+	// path below stays on the endpoint the middleware owns.
+	viaResponses := !aiprovider.RequiresOAuth(c.sdk)
 
 	// A model already known to live on the Responses API never touches
 	// /chat/completions again.
 	if viaResponses && needsResponsesAPI(baseURL, string(params.Model)) {
-		resp, err := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...)
+		resp, err := CompleteViaResponses(ctx, c.client, logger, c.sdk, baseURL, params, extra...)
 		if err == nil {
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
 		}
@@ -108,15 +141,14 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 	}
 	aiprovider.LogRequest(
 		logger,
-		sdk,
+		c.sdk,
 		http.MethodPost,
 		aiprovider.ChatCompletionsURL(baseURL),
 		string(params.Model),
 		extra...,
 	)
-	resp, err := client.Chat.Completions.New(ctx, params)
+	resp, err := c.client.Chat.Completions.New(ctx, params)
 	if err == nil {
-		rememberChatCompletionsWorked(baseURL, string(params.Model))
 		logUsage(logger, string(params.Model), usageOf(resp), extra...)
 		return resp, nil
 	}
@@ -131,13 +163,13 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 		params.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{}
 		aiprovider.LogRequest(
 			logger,
-			sdk,
+			c.sdk,
 			http.MethodPost,
 			aiprovider.ChatCompletionsURL(baseURL),
 			string(params.Model),
 			append(extra, "retry", "omit_response_format")...,
 		)
-		resp, err = client.Chat.Completions.New(ctx, params)
+		resp, err = c.client.Chat.Completions.New(ctx, params)
 		if err == nil {
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
 			return resp, nil
@@ -154,7 +186,7 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 			"model", params.Model,
 			slog.Any("error", err),
 		)
-		if viaResponses, respErr := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...); respErr == nil {
+		if viaResponses, respErr := CompleteViaResponses(ctx, c.client, logger, c.sdk, baseURL, params, extra...); respErr == nil {
 			rememberResponsesAPI(baseURL, string(params.Model))
 			logUsage(logger, string(params.Model), usageOf(viaResponses), extra...)
 			return viaResponses, nil
@@ -167,18 +199,17 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 		params.ReasoningEffort = shared.ReasoningEffort(reasoningEffortNone)
 		aiprovider.LogRequest(
 			logger,
-			sdk,
+			c.sdk,
 			http.MethodPost,
 			aiprovider.ChatCompletionsURL(baseURL),
 			string(params.Model),
 			append(extra, "retry", "reasoning_effort_none")...,
 		)
-		resp, err = client.Chat.Completions.New(ctx, params)
+		resp, err = c.client.Chat.Completions.New(ctx, params)
 		if err == nil {
 			// Remembered only now that the value is known to work: a "none"
 			// the provider also refuses is not worth pinning.
 			rememberNoReasoningEffort(baseURL, string(params.Model))
-			rememberChatCompletionsWorked(baseURL, string(params.Model))
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
 			return resp, nil
 		}
@@ -191,35 +222,15 @@ func CompleteChat(ctx context.Context, client openai.Client, logger *slog.Logger
 		params.Temperature = param.Opt[float64]{}
 		aiprovider.LogRequest(
 			logger,
-			sdk,
+			c.sdk,
 			http.MethodPost,
 			aiprovider.ChatCompletionsURL(baseURL),
 			string(params.Model),
 			append(extra, "retry", "omit_temperature")...,
 		)
-		resp, err = client.Chat.Completions.New(ctx, params)
+		resp, err = c.client.Chat.Completions.New(ctx, params)
 		if err == nil {
-			rememberChatCompletionsWorked(baseURL, string(params.Model))
 			logUsage(logger, string(params.Model), usageOf(resp), extra...)
-		}
-	}
-	// Last resort: the endpoint may simply not serve this model. OpenCode Zen
-	// routes gpt-5.6-luna and friends to /responses and answers 500 here for
-	// anything at all. Try there once, and keep the original error if that was
-	// not the problem -- a Responses error for a provider that has no such
-	// endpoint would only mislead.
-	if try, remember := shouldTryResponses(err, baseURL, string(params.Model)); viaResponses && try {
-		logger.Warn("chat completions refused this model; retrying on the Responses API",
-			"model", params.Model,
-			"remember", remember,
-			slog.Any("error", err),
-		)
-		if viaResponses, respErr := CompleteViaResponses(ctx, client, logger, sdk, baseURL, params, extra...); respErr == nil {
-			if remember {
-				rememberResponsesAPI(baseURL, string(params.Model))
-			}
-			logUsage(logger, string(params.Model), usageOf(viaResponses), extra...)
-			return viaResponses, nil
 		}
 	}
 	return resp, err
@@ -282,11 +293,20 @@ func (c *OpenAIClient) completeStreaming(
 	onDelta func(string),
 	extra ...any,
 ) (string, Usage, error) {
-	// See CompleteChat: the chatgpt SDK reaches /responses through its own
-	// middleware, which is the only thing holding the Codex headers. Both
-	// reroutes below are off for it -- this one and the one after a refusal.
-	viaResponses := !aiprovider.RequiresOAuth(c.sdk)
-	if viaResponses && needsResponsesAPI(c.baseURL, string(params.Model)) {
+	switch opencode.Endpoint(c.sdk, string(params.Model)) {
+	case opencode.EndpointMessages:
+		text, u, err := opencode.CompleteStreamingViaMessages(ctx, c.messages, c.logger, c.baseURL, params, onDelta, extra...)
+		usage := usageFrom(u)
+		if err == nil {
+			logUsage(c.logger, string(params.Model), usage, append(extra, "stream", true, "api", "messages")...)
+		}
+		return text, usage, err
+	case opencode.EndpointResponses:
+		return c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
+	}
+	// See Complete: the chatgpt SDK reaches /responses through its own
+	// middleware, which is the only thing holding the Codex headers.
+	if !aiprovider.RequiresOAuth(c.sdk) && needsResponsesAPI(c.baseURL, string(params.Model)) {
 		return c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
 	}
 	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
@@ -323,30 +343,7 @@ func (c *OpenAIClient) completeStreaming(
 	}
 	err := stream.Err()
 	if err == nil {
-		rememberChatCompletionsWorked(c.baseURL, string(params.Model))
 		logUsage(c.logger, string(params.Model), usage, append(extra, "stream", true)...)
-		return b.String(), usage, nil
-	}
-	// Same fallback as CompleteChat, but only while nothing has reached the
-	// reader yet: once deltas are on the wire, a second stream would replay a
-	// different answer over the first.
-	if viaResponses && b.Len() == 0 {
-		try, remember := shouldTryResponses(err, c.baseURL, string(params.Model))
-		if !try {
-			return b.String(), usage, err
-		}
-		c.logger.Warn("chat completions refused this model; retrying the stream on the Responses API",
-			"model", params.Model,
-			"remember", remember,
-			slog.Any("error", err),
-		)
-		text, respUsage, respErr := c.completeStreamingViaResponses(ctx, params, onDelta, extra...)
-		if respErr == nil {
-			if remember {
-				rememberResponsesAPI(c.baseURL, string(params.Model))
-			}
-			return text, respUsage, nil
-		}
 	}
 	return b.String(), usage, err
 }

--- a/backend/internal/ai/opencode_test.go
+++ b/backend/internal/ai/opencode_test.go
@@ -1,0 +1,132 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// The wiring internal/opencode's own tests cannot cover: NewOpenAIClient has to
+// build the Anthropic client, and build it against the right base URL.
+// anthropic-sdk-go appends "v1/messages" itself, so a base URL left with its
+// /v1 on would post to /zen/go/v1/v1/messages -- which no unit test over the
+// translation would notice.
+func TestAnOpenCodeMessagesModelReachesTheAnthropicEndpoint(t *testing.T) {
+	var path string
+	var session string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		session = r.Header.Get(aiprovider.SessionHeader)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_1", "type": "message", "role": "assistant",
+			"model": "minimax-m3", "stop_reason": "end_turn",
+			"content": []any{map[string]any{"type": "text", "text": "from messages"}},
+			"usage":   map[string]any{"input_tokens": 6, "output_tokens": 2},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewOpenAIClient(aiprovider.SDKOpenCode, "k", "minimax-m3",
+		srv.URL+"/zen/go/v1", "", "", 5*time.Second, slog.Default())
+
+	ctx := aiprovider.WithSession(context.Background(), "conv123")
+	resp, err := client.Complete(ctx, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "from messages" {
+		t.Fatalf("content = %q", resp.Choices[0].Message.Content)
+	}
+	if path != "/zen/go/v1/messages" {
+		t.Errorf("path = %q, want /zen/go/v1/messages", path)
+	}
+	if session != "conv123" {
+		t.Errorf("%s = %q, want the conversation from the context", aiprovider.SessionHeader, session)
+	}
+	if u := usageOf(resp); u.Prompt != 6 || u.Completion != 2 {
+		t.Errorf("usage = %+v, want 6 prompt and 2 completion", u)
+	}
+}
+
+// The same wiring for the streamed path, which chat uses.
+func TestAnOpenCodeMessagesModelStreams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, event := range [][2]string{
+			{"message_start", `{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"qwen3.8-max","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}`},
+			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi "}}`},
+			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"there"}}`},
+			{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":4,"output_tokens":2}}`},
+			{"message_stop", `{"type":"message_stop"}`},
+		} {
+			_, _ = w.Write([]byte("event: " + event[0] + "\ndata: " + event[1] + "\n\n"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewOpenAIClient(aiprovider.SDKOpenCode, "k", "qwen3.8-max",
+		srv.URL+"/zen/go/v1", "", "", 5*time.Second, slog.Default())
+
+	var deltas []string
+	text, usage, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("qwen3.8-max"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}, func(d string) { deltas = append(deltas, d) })
+	if err != nil {
+		t.Fatalf("completeStreaming: %v", err)
+	}
+	if text != "hi there" {
+		t.Fatalf("text = %q", text)
+	}
+	if strings.Join(deltas, "|") != "hi |there" {
+		t.Errorf("deltas = %v, want them handed over as they arrived", deltas)
+	}
+	if usage.Prompt != 4 || usage.Completion != 2 {
+		t.Errorf("usage = %+v, want 4 prompt and 2 completion", usage)
+	}
+}
+
+// An opencode model the table puts on /chat/completions takes the ordinary
+// path, Anthropic client built but unused.
+func TestAnOpenCodeChatModelStaysOnChatCompletions(t *testing.T) {
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "chatcmpl-1", "object": "chat.completion", "created": 1, "model": "deepseek-v4-flash",
+			"choices": []map[string]any{{
+				"index":         0,
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewOpenAIClient(aiprovider.SDKOpenCode, "k", "deepseek-v4-flash",
+		srv.URL+"/zen/go/v1", "", "", 5*time.Second, slog.Default())
+	if _, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("deepseek-v4-flash"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if path != "/zen/go/v1/chat/completions" {
+		t.Errorf("path = %q, want /zen/go/v1/chat/completions", path)
+	}
+}

--- a/backend/internal/ai/reasoning_test.go
+++ b/backend/internal/ai/reasoning_test.go
@@ -273,7 +273,7 @@ func TestReasoningEffortNoneIsNotRememberedWhenItAlsoFails(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := NewOpenAIClient("openai", "test-key", model, srv.URL, "v1", "", 5*time.Second, slog.Default())
-	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", srv.URL, openai.ChatCompletionNewParams{
+	_, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
 		Model:    shared.ChatModel(model),
 		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
 		Tools:    []openai.ChatCompletionToolParam{{Function: shared.FunctionDefinitionParam{Name: "search_documents"}}},

--- a/backend/internal/ai/research.go
+++ b/backend/internal/ai/research.go
@@ -222,7 +222,7 @@ func (a *openAISearchAgent) Research(ctx context.Context, req ResearchRequest, e
 		}
 
 		requestStart := time.Now()
-		chatResp, err := a.client.complete(ctx, openai.ChatCompletionNewParams{
+		chatResp, err := a.client.Complete(ctx, openai.ChatCompletionNewParams{
 			Model:       shared.ChatModel(a.client.model),
 			Messages:    apiMessages,
 			Temperature: CompletionTemperature(a.client.model, 0.2),
@@ -362,7 +362,7 @@ func (a *openAISearchAgent) answerResearch(
 		a.client.logger.Warn("research answer stream failed; falling back to a blocking call",
 			slog.Any("error", err),
 		)
-		chatResp, fallbackErr := a.client.complete(ctx, params, "purpose", "research_answer_fallback")
+		chatResp, fallbackErr := a.client.Complete(ctx, params, "purpose", "research_answer_fallback")
 		if fallbackErr != nil {
 			return "", false, usage, fmt.Errorf("openai research answer: %w", fallbackErr)
 		}

--- a/backend/internal/ai/responses.go
+++ b/backend/internal/ai/responses.go
@@ -2,7 +2,6 @@ package ai
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,77 +15,21 @@ import (
 	"lemmary/backend/internal/aiprovider"
 )
 
-// Some models are served only by the Responses API. OpenCode Zen documents a
-// per-model endpoint and routes gpt-5.6-luna, grok-4.6 and the muse-spark
-// models there; /chat/completions answers for those with a bare 500. Rather
-// than carry a list of model names that goes stale, the request shape stays
-// chat-completions-shaped everywhere and is translated here for the models that
-// turn out to need it.
+// Some models are served only by the Responses API: OpenAI's gpt-5 family
+// refuses function tools alongside its server-side reasoning_effort on
+// /chat/completions, and OpenCode routes a quarter of its catalogue there
+// outright. Rather than teach forty call sites a second request shape, the
+// request stays chat-completions-shaped everywhere and is translated here.
 //
 // Everything below converts in one direction and back: ChatCompletionNewParams
 // to ResponseNewParams, and the Response to a *openai.ChatCompletion the
 // existing call sites already know how to read. No caller changes.
-
-// endpointVerdict is what a failed /chat/completions request says about
-// whether this endpoint serves this model at all.
-type endpointVerdict int
-
-const (
-	// notAMismatch: the failure says nothing about the endpoint.
-	notAMismatch endpointVerdict = iota
-	// ambiguousMismatch: could be either. 500 is what OpenCode Zen answers for
-	// a Responses-only model, and also the generic internal error every
-	// provider returns when it is having a bad minute.
-	ambiguousMismatch
-	// certainMismatch: a status a working endpoint does not return for a model
-	// it serves.
-	certainMismatch
-)
-
-// classifyEndpointError reads a failed /chat/completions request for whether
-// the endpoint is refusing to serve this model at all, rather than disliking
-// something we sent. 502/503/504 are deliberately absent: those are ordinary
-// transient failures, and rerouting on them would be guessing.
-func classifyEndpointError(err error) endpointVerdict {
-	if err == nil {
-		return notAMismatch
-	}
-	var apiErr *openai.Error
-	if !errors.As(err, &apiErr) {
-		return notAMismatch
-	}
-	switch apiErr.StatusCode {
-	case http.StatusInternalServerError:
-		return ambiguousMismatch
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
-		http.StatusMethodNotAllowed, http.StatusNotImplemented:
-		return certainMismatch
-	}
-	return notAMismatch
-}
-
-// shouldTryResponses decides whether to translate a refused request, and
-// whether a success would be worth remembering.
 //
-// An endpoint that has already served this model is not an endpoint that does
-// not serve it, so a later refusal there is transient however it is worded --
-// the SDK is configured with no retries of its own, so a single hiccup would
-// otherwise be enough to reroute a model permanently. An ambiguous refusal on a
-// model never seen to work is worth translating immediately, because the caller
-// is waiting, but only worth remembering once it has happened twice: a
-// provider's bad minute does not repeat, a wrong endpoint does.
-func shouldTryResponses(err error, baseURL, model string) (try bool, remember bool) {
-	switch classifyEndpointError(err) {
-	case certainMismatch:
-		return true, true
-	case ambiguousMismatch:
-		if chatCompletionsHasWorked(baseURL, model) {
-			return false, false
-		}
-		return true, countAmbiguousRefusal(baseURL, model) > 1
-	}
-	return false, false
-}
+// Which models need it used to be inferred from the shape of a failed request
+// -- a 500 read as "possibly the wrong endpoint", believed on the second
+// occurrence. That existed because OpenCode's per-model routing was invisible
+// from an `openai` provider row; internal/opencode now carries the table, so
+// the guessing is gone and only the translation remains.
 
 // CompleteViaResponses runs a chat-completions-shaped request through the
 // Responses API and hands back a chat completion.

--- a/backend/internal/ai/responses_live_test.go
+++ b/backend/internal/ai/responses_live_test.go
@@ -7,30 +7,41 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"lemmary/backend/internal/aiprovider"
 )
 
-// TestLiveResponsesOnlyModel exercises the whole Responses path against a real
-// provider. It is skipped unless the three variables below are set, because it
-// spends somebody's tokens:
+// TestLiveTranslatedModel exercises a whole translated path -- Responses or
+// Messages, whichever the model routes to -- against a real provider. It is
+// skipped unless the variables below are set, because it spends somebody's
+// tokens:
 //
-//	LIVE_AI_KEY=... LIVE_AI_BASE_URL=https://opencode.ai/zen/go/v1 \
-//	LIVE_AI_MODEL=gpt-5.6-luna go test ./internal/ai/ -run Live -v
+//	LIVE_AI_KEY=... LIVE_AI_SDK=opencode LIVE_AI_MODEL=gpt-5.6-luna \
+//	  go test ./internal/ai/ -run Live -v
+//
+// LIVE_AI_MODEL is what picks the endpoint: gpt-5.6-luna for /responses,
+// minimax-m3 for Anthropic's /messages, deepseek-v4-flash for the untranslated
+// /chat/completions. LIVE_AI_BASE_URL is optional; it defaults to the SDK's own.
 //
 // It is the only way to check the parts a fake server cannot: that the
 // translated request is one the provider actually accepts.
-func TestLiveResponsesOnlyModel(t *testing.T) {
+func TestLiveTranslatedModel(t *testing.T) {
 	key := strings.TrimSpace(os.Getenv("LIVE_AI_KEY"))
-	base := strings.TrimSpace(os.Getenv("LIVE_AI_BASE_URL"))
+	sdk := strings.TrimSpace(os.Getenv("LIVE_AI_SDK"))
 	model := strings.TrimSpace(os.Getenv("LIVE_AI_MODEL"))
-	if key == "" || base == "" || model == "" {
-		t.Skip("set LIVE_AI_KEY, LIVE_AI_BASE_URL and LIVE_AI_MODEL to run the live check")
+	if key == "" || model == "" {
+		t.Skip("set LIVE_AI_KEY and LIVE_AI_MODEL to run the live check")
 	}
+	if sdk == "" {
+		sdk = aiprovider.SDKOpenCode
+	}
+	base := aiprovider.NormalizeBaseURL(sdk, os.Getenv("LIVE_AI_BASE_URL"))
 	resetModelNotes()
 	t.Cleanup(resetModelNotes)
 	ctx := context.Background()
 
 	t.Run("research", func(t *testing.T) {
-		agent := NewSearchAgent("openai", key, model, base, 120*time.Second, "en,de", "en", slog.Default())
+		agent := NewSearchAgent(sdk, key, model, base, 120*time.Second, "en,de", "en", slog.Default())
 		var read bool
 		result, err := agent.Research(ctx, ResearchRequest{
 			Messages: []ChatMessage{{Role: "user", Content: "How much did I pay for car insurance?"}},
@@ -55,7 +66,7 @@ func TestLiveResponsesOnlyModel(t *testing.T) {
 	})
 
 	t.Run("extract in json mode", func(t *testing.T) {
-		client := NewOpenAIClient("openai", key, model, base, "v1", "", 120*time.Second, slog.Default())
+		client := NewOpenAIClient(sdk, key, model, base, "v1", "", 120*time.Second, slog.Default())
 		metadata, err := client.ExtractMetadata(ctx,
 			"Rechnung Nr. 4711\nAllianz SE\nDatum: 2026-03-14\nBetrag: 412,90 EUR", ExtractionCatalog{})
 		if err != nil {

--- a/backend/internal/ai/responses_test.go
+++ b/backend/internal/ai/responses_test.go
@@ -3,7 +3,6 @@ package ai
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -195,20 +195,20 @@ func newResponsesHarness(t *testing.T, h *responsesHarness) string {
 	return srv.URL
 }
 
-// A model served only on /responses must be discovered once and then addressed
-// there directly, for tool rounds and the streamed answer alike.
-func TestResearchFallsBackToResponsesAndRemembers(t *testing.T) {
-	model := "responses-only-research"
+// A model the routing table puts on /responses runs there for the tool rounds
+// and the streamed answer alike, and never touches /chat/completions.
+func TestResearchRunsOnTheResponsesAPI(t *testing.T) {
+	const model = "gpt-5.6-luna"
 	resetModelNotes()
 	t.Cleanup(resetModelNotes)
 
-	h := &responsesHarness{chatStatus: http.StatusInternalServerError, respTurns: []scriptedTurn{
+	h := &responsesHarness{respTurns: []scriptedTurn{
 		{toolCalls: []scriptedToolCall{{name: "search_documents", args: `{"query":"car insurance"}`}}},
 		{content: "ready"},
 		{content: "You paid 200 EUR, see [Doc doc1](/document/doc1)."},
 	}}
 	base := newResponsesHarness(t, h)
-	agent := NewSearchAgent("openai", "test-key", model, base, 5*time.Second, "en,de", "en", slog.Default())
+	agent := NewSearchAgent(aiprovider.SDKOpenCode, "test-key", model, base, 5*time.Second, "en,de", "en", slog.Default())
 
 	var searched bool
 	result, err := agent.Research(context.Background(), ResearchRequest{
@@ -232,18 +232,14 @@ func TestResearchFallsBackToResponsesAndRemembers(t *testing.T) {
 	}
 
 	chat, resp := h.counts()
-	// Two, not one. A 500 does not say whether the endpoint refuses this model
-	// or is simply having a bad minute, so the first one is acted on but not
-	// believed; the second makes it a pattern and the model is rerouted for
-	// good. Both requests still succeed, via the fallback.
-	if chat != 2 {
-		t.Fatalf("chat/completions attempts = %d, want 2 before an ambiguous refusal is believed", chat)
+	// None. The table already knew, so there is no rejected request to pay for
+	// -- which is what the error-shape discovery this replaced cost, twice per
+	// model before it would believe an ambiguous refusal.
+	if chat != 0 {
+		t.Fatalf("chat/completions attempts = %d, want none", chat)
 	}
 	if resp < 3 {
 		t.Fatalf("responses requests = %d, want the tool rounds and the answer", resp)
-	}
-	if !needsResponsesAPI(base, model) {
-		t.Fatal("model was not remembered")
 	}
 }
 
@@ -286,8 +282,8 @@ func TestResponsesRequestShape(t *testing.T) {
 			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
 		},
 	}
-	if _, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, params); err != nil {
-		t.Fatalf("CompleteChat: %v", err)
+	if _, err := client.Complete(context.Background(), params); err != nil {
+		t.Fatalf("Complete: %v", err)
 	}
 	if chat, _ := h.counts(); chat != 0 {
 		t.Fatalf("a remembered model still tried chat/completions %d times", chat)
@@ -387,16 +383,11 @@ func TestChatCompletionFromResponse(t *testing.T) {
 	}
 }
 
-func TestStreamingFallsBackToResponses(t *testing.T) {
-	model := "responses-only-stream"
-	resetModelNotes()
-	t.Cleanup(resetModelNotes)
-
-	h := &responsesHarness{chatStatus: http.StatusInternalServerError, respTurns: []scriptedTurn{
-		{content: "streamed from responses"},
-	}}
+func TestStreamingRunsOnTheResponsesAPI(t *testing.T) {
+	const model = "grok-4.6"
+	h := &responsesHarness{respTurns: []scriptedTurn{{content: "streamed from responses"}}}
 	base := newResponsesHarness(t, h)
-	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
+	client := NewOpenAIClient(aiprovider.SDKOpenCode, "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
 
 	var deltas []string
 	text, usage, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
@@ -415,87 +406,8 @@ func TestStreamingFallsBackToResponses(t *testing.T) {
 	if usage.Prompt != 7 || usage.Completion != 2 || usage.Cached != 3 {
 		t.Fatalf("usage = %+v, want the totals from response.completed", usage)
 	}
-	// One ambiguous 500 is acted on but not believed.
-	if needsResponsesAPI(base, model) {
-		t.Fatal("a single 500 rerouted the model for the rest of the process")
-	}
-	h.respTurns = append(h.respTurns, scriptedTurn{content: "again"})
-	h.respNext = 0
-	if _, _, err := client.completeStreaming(context.Background(), openai.ChatCompletionNewParams{
-		Model:    shared.ChatModel(model),
-		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
-	}, nil); err != nil {
-		t.Fatalf("second completeStreaming: %v", err)
-	}
-	if !needsResponsesAPI(base, model) {
-		t.Fatal("a second refusal should have settled it")
-	}
-}
-
-// A 500 from an endpoint that has already served this model is the provider
-// having a bad minute, not a model that lives elsewhere. The SDK is configured
-// with no retries of its own, so without this one hiccup would be enough to
-// reroute a model permanently.
-func TestAProvenModelIsNotReroutedByATransient500(t *testing.T) {
-	model := "dual-api-model"
-	resetModelNotes()
-	t.Cleanup(resetModelNotes)
-
-	h := &responsesHarness{respTurns: []scriptedTurn{{content: "from responses"}}}
-	base := newResponsesHarness(t, h)
-	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
-	params := openai.ChatCompletionNewParams{
-		Model:    shared.ChatModel(model),
-		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
-	}
-
-	// It works here first.
-	if _, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, params); err != nil {
-		t.Fatalf("first CompleteChat: %v", err)
-	}
-	// Then the provider has a bad minute.
-	h.mu.Lock()
-	h.chatStatus = http.StatusInternalServerError
-	h.mu.Unlock()
-	if _, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, params); err == nil {
-		t.Fatal("expected the 500 to surface rather than being papered over")
-	}
-	if _, resp := h.counts(); resp != 0 {
-		t.Fatalf("a proven model was sent to /responses %d times", resp)
-	}
-	if needsResponsesAPI(base, model) {
-		t.Fatal("a proven model was rerouted by one 500")
-	}
-}
-
-// 401 and 403 are what OpenCode Zen returns for grok-4.6 and the muse-spark
-// models. Unlike a 500 they are not something a working endpoint says about a
-// model it serves, so one is enough.
-func TestCertainMismatchIsBelievedImmediately(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			model := fmt.Sprintf("certain-%d", status)
-			resetModelNotes()
-			t.Cleanup(resetModelNotes)
-
-			h := &responsesHarness{chatStatus: status, respTurns: []scriptedTurn{{content: "from responses"}}}
-			base := newResponsesHarness(t, h)
-			client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
-
-			resp, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
-				Model:    shared.ChatModel(model),
-				Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
-			})
-			if err != nil {
-				t.Fatalf("CompleteChat: %v", err)
-			}
-			if resp.Choices[0].Message.Content != "from responses" {
-				t.Fatalf("content = %q", resp.Choices[0].Message.Content)
-			}
-			if !needsResponsesAPI(base, model) {
-				t.Fatal("an unambiguous mismatch should be believed the first time")
-			}
-		})
+	if chat, _ := h.counts(); chat != 0 {
+		t.Fatalf("the stream tried chat/completions %d times", chat)
 	}
 }
 
@@ -511,7 +423,7 @@ func TestFailedResponseIsNotASuccess(t *testing.T) {
 	base := newResponsesHarness(t, h)
 	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
 
-	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+	_, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
 		Model:    shared.ChatModel(model),
 		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
 	})
@@ -559,7 +471,7 @@ func TestTransientErrorDoesNotFallBackToResponses(t *testing.T) {
 	base := newResponsesHarness(t, h)
 	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
 
-	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+	_, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
 		Model:    shared.ChatModel(model),
 		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
 	})
@@ -585,7 +497,7 @@ func TestFallbackKeepsTheOriginalError(t *testing.T) {
 	base := newResponsesHarness(t, h)
 	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
 
-	_, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+	_, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
 		Model:    shared.ChatModel(model),
 		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
 	})
@@ -610,12 +522,12 @@ func TestOrdinaryModelStaysOnChatCompletions(t *testing.T) {
 	base := newResponsesHarness(t, h)
 	client := NewOpenAIClient("openai", "test-key", model, base, "v1", "", 5*time.Second, slog.Default())
 
-	resp, err := CompleteChat(context.Background(), client.client, slog.Default(), "openai", base, openai.ChatCompletionNewParams{
+	resp, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
 		Model:    shared.ChatModel(model),
 		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
 	})
 	if err != nil {
-		t.Fatalf("CompleteChat: %v", err)
+		t.Fatalf("Complete: %v", err)
 	}
 	if resp.Choices[0].Message.Content != "served by chat completions" {
 		t.Fatalf("content = %q", resp.Choices[0].Message.Content)
@@ -627,45 +539,76 @@ func TestOrdinaryModelStaysOnChatCompletions(t *testing.T) {
 
 // The chatgpt SDK reaches the Responses API from underneath: its middleware
 // rewrites /chat/completions into /responses and is the only thing holding the
-// Codex auth headers. A 403 from that endpoint -- a model the plan does not
-// cover, or a rejected originator -- looks exactly like the endpoint-mismatch
-// this fallback exists for, and taking it would POST /responses directly, past
-// the middleware, with the placeholder key and no originator.
+// Codex auth headers. So the one remaining route up here -- the
+// reasoning_effort/tools conflict, which every gpt-5-family model can raise --
+// must not be taken for it: doing so would POST /responses directly, past the
+// middleware, with the placeholder key and no originator.
 func TestTheChatGPTSDKNeverTranslatesToResponsesItself(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			model := fmt.Sprintf("chatgpt-%d", status)
-			resetModelNotes()
-			t.Cleanup(resetModelNotes)
+	const model = "gpt-5.6-luna"
+	resetModelNotes()
+	t.Cleanup(resetModelNotes)
 
-			h := &responsesHarness{chatStatus: status, respTurns: []scriptedTurn{{content: "should never be reached"}}}
-			base := newResponsesHarness(t, h)
-			client := NewOpenAIClient(aiprovider.SDKChatGPT, "chatgpt-oauth", model, base, "v1", "", 5*time.Second, slog.Default())
+	var conflicts atomic.Int64
+	var posted atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/responses") {
+			posted.Add(1)
+			writeResponsesJSON(w, scriptedTurn{content: "should never be reached"}, "")
+			return
+		}
+		conflicts.Add(1)
+		writeReasoningEffortConflict(w)
+	}))
+	t.Cleanup(srv.Close)
 
-			_, err := CompleteChat(context.Background(), client.client, slog.Default(),
-				aiprovider.SDKChatGPT, base, openai.ChatCompletionNewParams{
-					Model:    shared.ChatModel(model),
-					Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
-				})
-			if err == nil {
-				t.Fatal("the refusal was swallowed by a fallback that cannot carry the Codex headers")
-			}
-			// The backend's own message is what an operator needs to see.
-			var apiErr *openai.Error
-			if !errors.As(err, &apiErr) || apiErr.StatusCode != status {
-				t.Fatalf("err = %v, want the original %d", err, status)
-			}
+	client := NewOpenAIClient(aiprovider.SDKChatGPT, "chatgpt-oauth", model, srv.URL, "v1", "", 5*time.Second, slog.Default())
+	_, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+		Tools:    []openai.ChatCompletionToolParam{{Function: shared.FunctionDefinitionParam{Name: "search_documents"}}},
+	})
+	if err == nil {
+		t.Fatal("the refusal was swallowed by a fallback that cannot carry the Codex headers")
+	}
+	if posted.Load() != 0 {
+		t.Fatalf("posted %d requests straight to /responses, bypassing the middleware", posted.Load())
+	}
+	if needsResponsesAPI(srv.URL, model) {
+		t.Fatal("the chatgpt SDK was pinned to a /responses route its middleware does not serve")
+	}
+	// And it did not retry at all: the whole reasoning_effort block is behind
+	// the same guard, because for this SDK the request is already a Responses
+	// one by the time it leaves -- the middleware made it so, and the
+	// parameters chat completions would argue about never reach the backend.
+	if conflicts.Load() != 1 {
+		t.Fatalf("chat/completions requests = %d, want just the one", conflicts.Load())
+	}
+}
 
-			h.mu.Lock()
-			posted := len(h.respBodies)
-			h.mu.Unlock()
-			if posted != 0 {
-				t.Fatalf("posted %d requests straight to /responses, bypassing the middleware", posted)
-			}
-			if needsResponsesAPI(base, model) {
-				t.Fatal("the chatgpt SDK was pinned to a /responses route its middleware does not serve")
-			}
-		})
+// The routing for an opencode model comes from the table, not from a failed
+// request: /chat/completions is never tried for a model the docs put on
+// /responses.
+func TestAnOpenCodeResponsesModelSkipsChatCompletionsEntirely(t *testing.T) {
+	h := &responsesHarness{respTurns: []scriptedTurn{{content: "from responses"}}}
+	base := newResponsesHarness(t, h)
+	client := NewOpenAIClient(aiprovider.SDKOpenCode, "k", "gpt-5.6-luna", base, "v1", "", 5*time.Second, slog.Default())
+
+	resp, err := client.Complete(context.Background(), openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("gpt-5.6-luna"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "from responses" {
+		t.Fatalf("content = %q", resp.Choices[0].Message.Content)
+	}
+	chat, responses := h.counts()
+	if chat != 0 {
+		t.Errorf("chat/completions requests = %d, want none; the table already knew", chat)
+	}
+	if responses != 1 {
+		t.Errorf("/responses requests = %d, want 1", responses)
 	}
 }
 

--- a/backend/internal/ai/search.go
+++ b/backend/internal/ai/search.go
@@ -222,7 +222,7 @@ func (a *openAISearchAgent) Search(ctx context.Context, messages []ChatMessage, 
 		}
 
 		requestStart := time.Now()
-		chatResp, err := a.client.complete(ctx, params,
+		chatResp, err := a.client.Complete(ctx, params,
 			"purpose", "search",
 			"round", round,
 			"allow_tools", allowTools,
@@ -308,7 +308,7 @@ If nothing relevant was found, say so clearly.`,
 	))
 
 	requestStart := time.Now()
-	chatResp, err := a.client.complete(ctx, openai.ChatCompletionNewParams{
+	chatResp, err := a.client.Complete(ctx, openai.ChatCompletionNewParams{
 		Model:       shared.ChatModel(a.client.model),
 		Messages:    msgs,
 		Temperature: CompletionTemperature(a.client.model, 0.2),

--- a/backend/internal/ai/session_test.go
+++ b/backend/internal/ai/session_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openai/openai-go/option"
-
 	"lemmary/backend/internal/aiprovider"
 )
 
@@ -37,16 +35,13 @@ func chatCompletionServer(t *testing.T, seen *string) *httptest.Server {
 
 // TestChatSendsSessionHeaderToOpenCode is the production-client case the
 // middleware unit tests cannot cover: NewOpenAIClient itself must install
-// SessionMiddleware. The base URL names opencode.ai so the gate opens;
-// RewriteHostMiddleware (test-only, after ours) sends the bytes to httptest.
+// SessionMiddleware, and only for the opencode SDK.
 func TestChatSendsSessionHeaderToOpenCode(t *testing.T) {
 	var seen string
 	srv := chatCompletionServer(t, &seen)
 
-	client := NewOpenAIClient("openai", "test-key", "test-model",
-		"http://opencode.ai/zen/go/v1", "", "", 5*time.Second, slog.Default(),
-		option.WithMiddleware(aiprovider.RewriteHostMiddleware(srv.Listener.Addr().String())),
-	)
+	client := NewOpenAIClient(aiprovider.SDKOpenCode, "test-key", "test-model",
+		srv.URL+"/zen/go/v1", "", "", 5*time.Second, slog.Default())
 	ctx := aiprovider.WithSession(context.Background(), "conv123")
 	if _, err := client.Chat(ctx, "some ocr text", []ChatMessage{{Role: "user", Content: "hi"}}); err != nil {
 		t.Fatalf("chat: %v", err)
@@ -58,12 +53,14 @@ func TestChatSendsSessionHeaderToOpenCode(t *testing.T) {
 
 // TestChatSendsNoSessionHeaderToOtherProviders pins the gate on the client
 // every completion in the app goes through: a provider that is not OpenCode
-// sees the request it has always seen, session on the context or not.
+// sees the request it has always seen, session on the context or not -- and
+// now the same address as the case above, since the gate is the SDK rather
+// than the hostname.
 func TestChatSendsNoSessionHeaderToOtherProviders(t *testing.T) {
 	var seen string
 	srv := chatCompletionServer(t, &seen)
 
-	client := NewOpenAIClient("openai", "test-key", "test-model", srv.URL, "", "", 5*time.Second, slog.Default())
+	client := NewOpenAIClient(aiprovider.SDKOpenAI, "test-key", "test-model", srv.URL, "", "", 5*time.Second, slog.Default())
 	ctx := aiprovider.WithSession(context.Background(), "conv123")
 	if _, err := client.Chat(ctx, "some ocr text", []ChatMessage{{Role: "user", Content: "hi"}}); err != nil {
 		t.Fatalf("chat: %v", err)

--- a/backend/internal/ai/split.go
+++ b/backend/internal/ai/split.go
@@ -77,7 +77,7 @@ func (c *OpenAIClient) DetectSplitPoints(ctx context.Context, pages []PageText) 
 	)
 
 	requestStart := time.Now()
-	chatResp, err := c.complete(ctx, openai.ChatCompletionNewParams{
+	chatResp, err := c.Complete(ctx, openai.ChatCompletionNewParams{
 		Model: shared.ChatModel(c.model),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage(splitSystemPrompt),

--- a/backend/internal/aiprovider/models.go
+++ b/backend/internal/aiprovider/models.go
@@ -202,7 +202,7 @@ func ListModels(ctx context.Context, p Provider, purpose ModelPurpose, client *h
 	req.Header.Set("Accept", "application/json")
 	// Hand-rolled request, so the SDK middleware that stamps this everywhere
 	// else does not see it.
-	if SessionHost(req.URL.Host) {
+	if p.SDK == SDKOpenCode {
 		req.Header.Set(SessionHeader, SessionFor("models"))
 	}
 

--- a/backend/internal/aiprovider/models_test.go
+++ b/backend/internal/aiprovider/models_test.go
@@ -103,41 +103,45 @@ func TestListModels(t *testing.T) {
 	}
 }
 
-// rewriteHostTransport delivers a ListModels request to an httptest server
-// after SessionHost has already seen opencode.ai and stamped the header.
-type rewriteHostTransport struct{ host string }
-
-func (t rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	clone := req.Clone(req.Context())
-	clone.URL.Host = t.host
-	clone.Host = t.host
-	return http.DefaultTransport.RoundTrip(clone)
-}
-
 // TestListModelsSendsSessionHeaderToOpenCode is the hand-rolled path: ListModels
 // does not go through the SDK middleware, so dropping the header set there
-// would stay green without this.
+// would stay green without this. And an openai row is checked alongside,
+// because that is the case the old host-sniffing gate could not tell apart.
 func TestListModelsSendsSessionHeaderToOpenCode(t *testing.T) {
 	t.Parallel()
-	var seen string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		seen = r.Header.Get(SessionHeader)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"kimi-k3"}]}`))
-	}))
-	t.Cleanup(srv.Close)
+	for _, tc := range []struct {
+		sdk      string
+		wantSent bool
+	}{
+		{SDKOpenCode, true},
+		{SDKOpenAI, false},
+	} {
+		t.Run(tc.sdk, func(t *testing.T) {
+			t.Parallel()
+			var seen string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen = r.Header.Get(SessionHeader)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":[{"id":"kimi-k3"}]}`))
+			}))
+			t.Cleanup(srv.Close)
 
-	client := &http.Client{Transport: rewriteHostTransport{host: srv.Listener.Addr().String()}}
-	p := Provider{SDK: SDKOpenAI, BaseURL: "http://opencode.ai/zen/go/v1", APIKey: "test-key"}
-	models, err := ListModels(t.Context(), p, PurposeLLM, client, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(models) != 1 || models[0].ID != "kimi-k3" {
-		t.Fatalf("got %+v", models)
-	}
-	if want := SessionFor("models"); seen != want {
-		t.Errorf("%s = %q, want the models purpose id %q", SessionHeader, seen, want)
+			p := Provider{SDK: tc.sdk, BaseURL: srv.URL + "/v1", APIKey: "test-key"}
+			models, err := ListModels(t.Context(), p, PurposeLLM, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(models) != 1 || models[0].ID != "kimi-k3" {
+				t.Fatalf("got %+v", models)
+			}
+			want := ""
+			if tc.wantSent {
+				want = SessionFor("models")
+			}
+			if seen != want {
+				t.Errorf("%s = %q, want %q", SessionHeader, seen, want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/aiprovider/sdk.go
+++ b/backend/internal/aiprovider/sdk.go
@@ -8,6 +8,29 @@ const (
 	SDKGoogleVision = "google_vision"
 	SDKMistral      = "mistral"
 
+	// SDKOpenCode is OpenCode Go (Zen), a gateway in front of a catalogue of
+	// third-party models. It is its own SDK rather than an `openai` row with a
+	// base URL because it differs from an OpenAI-compatible endpoint in two ways
+	// that no base URL can express.
+	//
+	// It requires the x-opencode-session header -- requests that arrive without
+	// one are liable to be refused outright -- and it serves each model on one of
+	// three endpoints: /chat/completions, /responses or /messages, the last of
+	// which speaks Anthropic's Messages API rather than OpenAI's. Which one is a
+	// property of the model, and /v1/models does not say, so internal/opencode
+	// carries the table and wraps both SDKs behind it.
+	//
+	// Before this SDK existed both facts were guessed at: the header was sent to
+	// any host under opencode.ai, and the endpoint was discovered by reading the
+	// shape of a failed request -- one rejected request per model per process,
+	// and no way to reach the /messages third of the catalogue at all.
+	//
+	// It chats and reads documents; it does not embed. Its catalogue is chat
+	// models only and the gateway serves no /embeddings, so CanEmbed refuses it
+	// -- point AI_EMBEDDING_SDK at a provider that does, or leave Deep Search
+	// on keyword retrieval.
+	SDKOpenCode = "opencode"
+
 	// SDKChatGPT reaches OpenAI's Codex backend with a ChatGPT subscription
 	// instead of a metered API key: the operator signs in once and the
 	// conversation is billed against the seat they already pay for.
@@ -51,11 +74,11 @@ const (
 	CollectionName = "ai_providers"
 )
 
-var ValidSDKs = []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKChatGPT, SDKLocalEmbeddings, SDKDocling}
+var ValidSDKs = []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKOpenCode, SDKChatGPT, SDKLocalEmbeddings, SDKDocling}
 
 func ValidSDK(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKChatGPT, SDKLocalEmbeddings, SDKDocling:
+	case SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKOpenCode, SDKChatGPT, SDKLocalEmbeddings, SDKDocling:
 		return true
 	default:
 		return false
@@ -64,7 +87,7 @@ func ValidSDK(sdk string) bool {
 
 func IsLLM(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
-	case SDKOpenAI, SDKOpenRouter, SDKMistral, SDKChatGPT:
+	case SDKOpenAI, SDKOpenRouter, SDKMistral, SDKOpenCode, SDKChatGPT:
 		return true
 	default:
 		return false
@@ -79,6 +102,12 @@ func IsLLM(sdk string) bool {
 // -- and asking the right question at each binding is what keeps a local
 // provider out of the extraction picker and a Google Vision provider out of the
 // embedding one.
+//
+// SDKOpenCode and SDKChatGPT are the two that chat without embedding: neither
+// catalogue has an embedding model in it, and neither endpoint serves
+// /embeddings. Deep Search's vectors want a second provider on those --
+// AI_EMBEDDING_SDK, or a local sidecar -- and keyword retrieval alone is a
+// working state until there is one.
 func CanEmbed(sdk string) bool {
 	switch strings.TrimSpace(sdk) {
 	case SDKOpenAI, SDKOpenRouter, SDKMistral, SDKLocalEmbeddings:
@@ -238,6 +267,8 @@ func DefaultBaseURL(sdk string) string {
 		return "https://openrouter.ai/api/v1"
 	case SDKMistral:
 		return "https://api.mistral.ai/v1"
+	case SDKOpenCode:
+		return "https://opencode.ai/zen/go/v1"
 	// Not a /v1 root: the Codex backend serves one endpoint, /responses, which
 	// the chatgpt middleware rewrites the SDK's /chat/completions into.
 	case SDKChatGPT:
@@ -266,6 +297,8 @@ func DefaultAlias(sdk string) string {
 		return "Google Cloud Vision"
 	case SDKMistral:
 		return "Mistral"
+	case SDKOpenCode:
+		return "Opencode Go"
 	case SDKChatGPT:
 		return "ChatGPT subscription"
 	case SDKLocalEmbeddings:

--- a/backend/internal/aiprovider/sdk_test.go
+++ b/backend/internal/aiprovider/sdk_test.go
@@ -186,13 +186,13 @@ func TestSDKListsMatchTheirPredicates(t *testing.T) {
 		got  []string
 		want []string
 	}{
-		"llm":       {LLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKChatGPT}},
+		"llm":       {LLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKOpenCode, SDKChatGPT}},
 		"embedding": {EmbeddingSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKLocalEmbeddings}},
-		"ocr":       {OCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKChatGPT, SDKDocling}},
+		"ocr":       {OCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKOpenCode, SDKChatGPT, SDKDocling}},
 		// The environment lists are the same minus chatgpt, whose credential
 		// is minted by signing in and so cannot be seeded from a file.
-		"env llm": {EnvLLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral}},
-		"env ocr": {EnvOCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKDocling}},
+		"env llm": {EnvLLMSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKMistral, SDKOpenCode}},
+		"env ocr": {EnvOCRSDKs(), []string{SDKOpenAI, SDKOpenRouter, SDKGoogleVision, SDKMistral, SDKOpenCode, SDKDocling}},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -219,6 +219,17 @@ func TestCanEmbed(t *testing.T) {
 	// Google Vision reads documents; it has no /embeddings endpoint at all.
 	if CanEmbed(SDKGoogleVision) || CanEmbed("unknown") || CanEmbed("") {
 		t.Fatal("google_vision, an unknown SDK and an empty SDK cannot embed")
+	}
+	// The two that chat without embedding, which is what forces CanEmbed apart
+	// from IsLLM in the other direction: neither catalogue has an embedding
+	// model, and neither endpoint serves /embeddings.
+	for _, sdk := range []string{SDKOpenCode, SDKChatGPT} {
+		if !IsLLM(sdk) {
+			t.Errorf("IsLLM(%q) = false; this case is only interesting for an LLM SDK", sdk)
+		}
+		if CanEmbed(sdk) {
+			t.Errorf("CanEmbed(%q) = true; it serves no /embeddings", sdk)
+		}
 	}
 }
 

--- a/backend/internal/aiprovider/seed.go
+++ b/backend/internal/aiprovider/seed.go
@@ -1,6 +1,7 @@
 package aiprovider
 
 import (
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -54,6 +55,25 @@ func MigrateLegacySettings(app core.App, settings *core.Record) error {
 	}
 	bindFromIDs(settings, openaiID, mistralID, googleID, models)
 	return nil
+}
+
+// IsOpenCodeURL reports whether a base URL addresses OpenCode.
+//
+// It exists for the migration that moves the rows which reached OpenCode
+// through an `openai` SDK and a base URL -- the only way to do it before
+// SDKOpenCode, and what .env.example shipped -- onto the SDK itself. See
+// migrations/1730000026_opencode_provider.go.
+//
+// Matched on the host rather than by substring, so a path or query mentioning
+// the name does not count, and by suffix so a regional or staging subdomain
+// does.
+func IsOpenCodeURL(baseURL string) bool {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return false
+	}
+	h := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	return h == "opencode.ai" || strings.HasSuffix(h, ".opencode.ai")
 }
 
 type taskModels struct {

--- a/backend/internal/aiprovider/seed.go
+++ b/backend/internal/aiprovider/seed.go
@@ -57,6 +57,29 @@ func MigrateLegacySettings(app core.App, settings *core.Record) error {
 	return nil
 }
 
+// NormalizeOpenCodeSDK answers SDKOpenCode for an OpenAI-compatible SDK aimed
+// at OpenCode, and leaves every other pairing alone.
+//
+// `openai` plus a base URL was the only way to reach OpenCode before this SDK
+// existed, and it is what .env.example shipped. It never meant "use OpenAI's
+// semantics" -- the old code honoured the real intent by sniffing the request
+// host for opencode.ai -- so reading it as SDKOpenCode preserves what the
+// operator asked for rather than overriding it.
+//
+// It has to be the environment's rule as well as the migration's. A managed
+// instance re-applies its environment on every boot and has no Settings page,
+// so an AI_SDK=openai that the migration moved would be moved back every boot,
+// with no way for anyone inside to intervene.
+func NormalizeOpenCodeSDK(sdk, baseURL string) string {
+	switch strings.TrimSpace(sdk) {
+	case SDKOpenAI, SDKOpenRouter:
+		if IsOpenCodeURL(baseURL) {
+			return SDKOpenCode
+		}
+	}
+	return strings.TrimSpace(sdk)
+}
+
 // IsOpenCodeURL reports whether a base URL addresses OpenCode.
 //
 // It exists for the migration that moves the rows which reached OpenCode

--- a/backend/internal/aiprovider/session.go
+++ b/backend/internal/aiprovider/session.go
@@ -79,39 +79,21 @@ func SessionFor(purpose string) string {
 	return id
 }
 
-// SessionHost reports whether the header means anything to this host. Only
-// OpenCode asks for it; every other provider sees the request it saw before.
-func SessionHost(host string) bool {
-	h := strings.ToLower(strings.TrimSpace(host))
-	if i := strings.LastIndexByte(h, ':'); i >= 0 && !strings.Contains(h[i:], "]") {
-		h = h[:i]
-	}
-	h = strings.TrimSuffix(h, ".")
-	return h == "opencode.ai" || strings.HasSuffix(h, ".opencode.ai")
-}
-
 // SessionMiddleware stamps the session id from the request context onto
 // outbound OpenCode requests. It sits in the SDK's middleware chain, which runs
 // per attempt on a request clone, so retries are stamped too.
+//
+// It stamps unconditionally: the caller installs it only on an SDKOpenCode
+// client. It used to be installed on every client and gate itself by sniffing
+// the request host for opencode.ai, which needed a second middleware
+// (RewriteHostMiddleware) so that a test could reach httptest with the gate
+// open, and left an operator's choice of provider implied by a URL.
 func SessionMiddleware() option.Middleware {
 	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-		if req != nil && req.URL != nil && SessionHost(req.URL.Host) {
+		if req != nil {
 			if id := SessionFrom(req.Context()); id != "" {
 				req.Header.Set(SessionHeader, id)
 			}
-		}
-		return next(req)
-	}
-}
-
-// RewriteHostMiddleware sends the request to host instead of req.URL.Host.
-// Tests register it after SessionMiddleware so a client whose base URL is
-// opencode.ai (the session gate opens) still talks to an httptest server
-// rather than the internet. Production callers never pass it.
-func RewriteHostMiddleware(host string) option.Middleware {
-	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-		if req != nil && req.URL != nil {
-			req.URL.Host = host
 		}
 		return next(req)
 	}

--- a/backend/internal/aiprovider/session_sdk_test.go
+++ b/backend/internal/aiprovider/session_sdk_test.go
@@ -48,31 +48,9 @@ func completeOnce(t *testing.T, client openai.Client, ctx context.Context) {
 
 // TestSessionMiddlewareStampsThroughTheSDK is the end-to-end case: the SDK must
 // hand the middleware a request carrying the caller's context, or the header
-// never gets a value. The base URL names opencode.ai so the gate opens, and a
-// second middleware -- running after ours -- redirects the connection to the
-// test server rather than the internet.
+// never gets a value -- it is a request clone per attempt, and an earlier
+// version of this read the context off the wrong one.
 func TestSessionMiddlewareStampsThroughTheSDK(t *testing.T) {
-	var seen string
-	srv := completionServer(t, &seen)
-
-	client := openai.NewClient(
-		option.WithAPIKey("test"),
-		option.WithBaseURL("http://opencode.ai/zen/go/v1"),
-		option.WithMaxRetries(0),
-		option.WithMiddleware(SessionMiddleware()),
-		option.WithMiddleware(RewriteHostMiddleware(srv.Listener.Addr().String())),
-	)
-
-	completeOnce(t, client, WithSession(context.Background(), "conv123"))
-
-	if seen != "conv123" {
-		t.Errorf("%s = %q, want %q", SessionHeader, seen, "conv123")
-	}
-}
-
-// TestSessionMiddlewareSkipsOtherProvidersThroughTheSDK is the same wiring
-// against a base URL that is not OpenCode: nothing is added to the request.
-func TestSessionMiddlewareSkipsOtherProvidersThroughTheSDK(t *testing.T) {
 	var seen string
 	srv := completionServer(t, &seen)
 
@@ -85,7 +63,26 @@ func TestSessionMiddlewareSkipsOtherProvidersThroughTheSDK(t *testing.T) {
 
 	completeOnce(t, client, WithSession(context.Background(), "conv123"))
 
+	if seen != "conv123" {
+		t.Errorf("%s = %q, want %q", SessionHeader, seen, "conv123")
+	}
+}
+
+// TestAClientWithoutTheMiddlewareSendsNoHeader is the other half: a provider
+// that is not OpenCode never installs it, and that is the whole of the gate.
+func TestAClientWithoutTheMiddlewareSendsNoHeader(t *testing.T) {
+	var seen string
+	srv := completionServer(t, &seen)
+
+	client := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL(srv.URL),
+		option.WithMaxRetries(0),
+	)
+
+	completeOnce(t, client, WithSession(context.Background(), "conv123"))
+
 	if seen != "" {
-		t.Errorf("%s = %q, want empty for a non-OpenCode host", SessionHeader, seen)
+		t.Errorf("%s = %q, want empty without the middleware", SessionHeader, seen)
 	}
 }

--- a/backend/internal/aiprovider/session_test.go
+++ b/backend/internal/aiprovider/session_test.go
@@ -7,29 +7,6 @@ import (
 	"testing"
 )
 
-func TestSessionHost(t *testing.T) {
-	cases := map[string]bool{
-		"opencode.ai":      true,
-		"opencode.ai:443":  true,
-		"OpenCode.AI":      true,
-		"opencode.ai.":     true,
-		"api.opencode.ai":  true,
-		"zen.opencode.ai":  true,
-		"api.openai.com":   false,
-		"openrouter.ai":    false,
-		"notopencode.ai":   false,
-		"opencode.ai.evil": false,
-		"localhost:8090":   false,
-		"127.0.0.1:1234":   false,
-		"":                 false,
-	}
-	for host, want := range cases {
-		if got := SessionHost(host); got != want {
-			t.Errorf("SessionHost(%q) = %v, want %v", host, got, want)
-		}
-	}
-}
-
 func TestSessionForIsStablePerPurpose(t *testing.T) {
 	a := SessionFor("extract")
 	if a == "" {
@@ -71,7 +48,7 @@ func TestEnsureSessionKeepsTheConversation(t *testing.T) {
 	}
 }
 
-func TestSessionMiddlewareStampsOpenCodeRequests(t *testing.T) {
+func TestSessionMiddlewareStampsTheRequest(t *testing.T) {
 	mw := SessionMiddleware()
 
 	req := httptest.NewRequest(http.MethodPost, "https://opencode.ai/zen/go/v1/chat/completions", nil)
@@ -90,26 +67,25 @@ func TestSessionMiddlewareStampsOpenCodeRequests(t *testing.T) {
 	}
 }
 
-func TestSessionMiddlewareLeavesOtherProvidersAlone(t *testing.T) {
+// Which providers see the header is now the caller's decision -- only an
+// SDKOpenCode client installs this middleware -- so the middleware itself no
+// longer looks at the URL. That gate used to be a host match on opencode.ai,
+// which meant a test could only exercise it by rewriting the host underneath.
+func TestSessionMiddlewareDoesNotLookAtTheHost(t *testing.T) {
 	mw := SessionMiddleware()
 
-	for _, url := range []string{
-		"https://api.openai.com/v1/chat/completions",
-		"https://openrouter.ai/api/v1/chat/completions",
-	} {
-		req := httptest.NewRequest(http.MethodPost, url, nil)
-		req = req.WithContext(WithSession(req.Context(), "conv123"))
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:9/v1/chat/completions", nil)
+	req = req.WithContext(WithSession(req.Context(), "conv123"))
 
-		var seen string
-		if _, err := mw(req, func(r *http.Request) (*http.Response, error) {
-			seen = r.Header.Get(SessionHeader)
-			return &http.Response{StatusCode: http.StatusOK}, nil
-		}); err != nil {
-			t.Fatalf("middleware: %v", err)
-		}
-		if seen != "" {
-			t.Errorf("%s sent to %s: %q", SessionHeader, url, seen)
-		}
+	var seen string
+	if _, err := mw(req, func(r *http.Request) (*http.Response, error) {
+		seen = r.Header.Get(SessionHeader)
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}); err != nil {
+		t.Fatalf("middleware: %v", err)
+	}
+	if seen != "conv123" {
+		t.Errorf("%s = %q, want it stamped whatever the host", SessionHeader, seen)
 	}
 }
 

--- a/backend/internal/chatgpt/sdk_test.go
+++ b/backend/internal/chatgpt/sdk_test.go
@@ -42,13 +42,12 @@ func TestTheMiddlewareRewritesThePathTheSDKBuilds(t *testing.T) {
 	var path string
 	srv := codexServer(t, &seen, &path)
 
+	// The host is httptest's; the path is the real one, which is the half this
+	// test is about.
 	client := openai.NewClient(
 		option.WithAPIKey(PlaceholderKey),
-		option.WithBaseURL("http://chatgpt.com"+chatgptBasePath),
+		option.WithBaseURL(srv.URL+chatgptBasePath),
 		option.WithMiddleware(Middleware(signedInSource(t, "sdk1"), nil)),
-		// Runs after ours, so the connection lands on httptest rather than the
-		// internet. The same trick the session middleware's SDK test uses.
-		option.WithMiddleware(aiprovider.RewriteHostMiddleware(srv.Listener.Addr().String())),
 	)
 
 	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{

--- a/backend/internal/config/aienv.go
+++ b/backend/internal/config/aienv.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/strutil"
 )
 
 // AIEnv is the AI configuration read from the environment, once, before the app exists.
@@ -164,7 +165,13 @@ func strictBool(key string) (bool, error) {
 }
 
 func parseLLM() (aiprovider.ProviderSpec, error) {
-	sdk := strings.TrimSpace(getEnv(EnvAISDK, aiprovider.SDKOpenAI))
+	baseURL := aiprovider.NormalizeBaseURL(
+		strings.TrimSpace(getEnv(EnvAISDK, aiprovider.SDKOpenAI)), os.Getenv(EnvAIBaseURL))
+	// An OpenAI-compatible SDK aimed at OpenCode is the opencode SDK; see
+	// aiprovider.NormalizeOpenCodeSDK. Read before the checks below, so the
+	// capability questions are asked of the SDK that will actually serve.
+	sdk := aiprovider.NormalizeOpenCodeSDK(
+		strings.TrimSpace(getEnv(EnvAISDK, aiprovider.SDKOpenAI)), baseURL)
 	// EnvLLMSDKs, not LLMSDKs: chatgpt chats, but its credential is minted by
 	// signing in rather than written down, so naming it here would seed a
 	// provider row that the file naming it can never complete.
@@ -177,7 +184,7 @@ func parseLLM() (aiprovider.ProviderSpec, error) {
 	spec := aiprovider.ProviderSpec{
 		SDK:            sdk,
 		APIKey:         strings.TrimSpace(os.Getenv(EnvAIAPIKey)),
-		BaseURL:        aiprovider.NormalizeBaseURL(sdk, os.Getenv(EnvAIBaseURL)),
+		BaseURL:        baseURL,
 		Model:          strings.TrimSpace(getEnv(EnvAIModel, aiprovider.DefaultExtractModel)),
 		EmbeddingModel: strings.TrimSpace(os.Getenv(EnvAIEmbeddingModel)),
 		HelperModel:    strings.TrimSpace(os.Getenv(EnvAISearchHelperModel)),
@@ -191,6 +198,11 @@ func parseOCR(llm aiprovider.ProviderSpec) (aiprovider.ProviderSpec, error) {
 	key := strings.TrimSpace(os.Getenv(EnvOCRAPIKey))
 	baseURL := strings.TrimSpace(os.Getenv(EnvOCRBaseURL))
 	model := strings.TrimSpace(os.Getenv(EnvOCRModel))
+	// Same reading as parseLLM, and before the SDK is compared with the
+	// language model's -- otherwise an OCR_SDK=openai on the same OpenCode
+	// endpoint would look like a second provider and be refused for having no
+	// key of its own.
+	sdk = aiprovider.NormalizeOpenCodeSDK(sdk, strutil.FirstNonEmpty(baseURL, llm.BaseURL))
 
 	if sdk == "" {
 		if key != "" || baseURL != "" || model != "" {
@@ -274,6 +286,10 @@ func parseEmbedding(llm aiprovider.ProviderSpec) (aiprovider.ProviderSpec, error
 	key := strings.TrimSpace(os.Getenv(EnvAIEmbeddingAPIKey))
 	baseURL := strings.TrimSpace(os.Getenv(EnvAIEmbeddingBaseURL))
 	model := strings.TrimSpace(os.Getenv(EnvAIEmbeddingModel))
+	// Same reading as parseLLM. It makes CanEmbed below refuse an
+	// AI_EMBEDDING_SDK=openai pointed at OpenCode, which is the honest answer:
+	// that endpoint has no /embeddings whatever the variable calls it.
+	sdk = aiprovider.NormalizeOpenCodeSDK(sdk, strutil.FirstNonEmpty(baseURL, llm.BaseURL))
 
 	if sdk == "" {
 		if key != "" || baseURL != "" {

--- a/backend/internal/config/aienv.go
+++ b/backend/internal/config/aienv.go
@@ -285,6 +285,17 @@ func parseEmbedding(llm aiprovider.ProviderSpec) (aiprovider.ProviderSpec, error
 				"%s or %s is set without %s; name the embedding provider's SDK, or leave them both unset to embed on the %s provider",
 				EnvAIEmbeddingAPIKey, EnvAIEmbeddingBaseURL, EnvAIEmbeddingSDK, EnvAISDK)
 		}
+		// ...unless the language model's SDK cannot embed. opencode is the case:
+		// it chats but serves no /embeddings, so the default of embedding on
+		// that provider is not available and there is nothing to fall back to.
+		// Caught here rather than at the first document, whose embed step would
+		// fail on every upload with the binding still reading as configured.
+		if model != "" && !aiprovider.CanEmbed(llm.SDK) {
+			return aiprovider.ProviderSpec{}, fmt.Errorf(
+				"%s is set but %s=%q cannot serve embeddings; name a %s (one of %s), or unset %s to search by keywords alone",
+				EnvAIEmbeddingModel, EnvAISDK, llm.SDK, EnvAIEmbeddingSDK,
+				strings.Join(aiprovider.EmbeddingSDKs(), ", "), EnvAIEmbeddingModel)
+		}
 		return aiprovider.ProviderSpec{}, nil
 	}
 	if !aiprovider.CanEmbed(sdk) {

--- a/backend/internal/config/aienv_test.go
+++ b/backend/internal/config/aienv_test.go
@@ -414,3 +414,99 @@ func TestChatGPTLoginIsRefusedOnAManagedInstance(t *testing.T) {
 		t.Fatal("AI_MANAGED and AI_CHATGPT_LOGIN were accepted together")
 	}
 }
+
+// AI_SDK=openai with an opencode.ai base URL was the only way to reach OpenCode
+// before the SDK existed, and it is what .env.example shipped. It has to keep
+// working, and it has to keep working on a *managed* instance in particular:
+// migration 1730000026 moves the provider row, but ApplyManaged re-applies the
+// environment on every boot and would move it straight back, with no Settings
+// page for anyone inside to intervene.
+func TestAnOpenCodeBaseURLIsReadAsTheOpenCodeSDK(t *testing.T) {
+	for _, sdk := range []string{aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter} {
+		t.Run(sdk, func(t *testing.T) {
+			clearAIEnv(t)
+			t.Setenv(EnvAISDK, sdk)
+			t.Setenv(EnvAIAPIKey, "sk-test")
+			t.Setenv(EnvAIBaseURL, "https://opencode.ai/zen/go/v1")
+
+			env, err := AIEnvFromEnv()
+			if err != nil {
+				t.Fatalf("AIEnvFromEnv: %v", err)
+			}
+			if got := env.Providers.LLM.SDK; got != aiprovider.SDKOpenCode {
+				t.Fatalf("LLM SDK = %q, want %q", got, aiprovider.SDKOpenCode)
+			}
+			// The address the operator gave is still the address used.
+			if got := env.Providers.LLM.BaseURL; got != "https://opencode.ai/zen/go/v1" {
+				t.Fatalf("base URL = %q", got)
+			}
+		})
+	}
+}
+
+// The rule is narrow on purpose: a real OpenAI endpoint, and a URL that merely
+// mentions the name in a path, are both left alone.
+func TestOtherBaseURLsAreLeftOnTheirSDK(t *testing.T) {
+	for name, baseURL := range map[string]string{
+		"openai's own":     "https://api.openai.com/v1",
+		"a lookalike path": "https://gateway.example.com/opencode.ai/v1",
+		"unset":            "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			clearAIEnv(t)
+			t.Setenv(EnvAISDK, aiprovider.SDKOpenAI)
+			t.Setenv(EnvAIAPIKey, "sk-test")
+			if baseURL != "" {
+				t.Setenv(EnvAIBaseURL, baseURL)
+			}
+
+			env, err := AIEnvFromEnv()
+			if err != nil {
+				t.Fatalf("AIEnvFromEnv: %v", err)
+			}
+			if got := env.Providers.LLM.SDK; got != aiprovider.SDKOpenAI {
+				t.Fatalf("LLM SDK = %q, want %q", got, aiprovider.SDKOpenAI)
+			}
+		})
+	}
+}
+
+// OCR named as openai on the same OpenCode endpoint is still the same endpoint.
+// Read before the two SDKs are compared, or it would look like a second
+// provider and be refused for having no key of its own.
+func TestOCROnTheSameOpenCodeEndpointSharesTheProvider(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAISDK, aiprovider.SDKOpenAI)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+	t.Setenv(EnvAIBaseURL, "https://opencode.ai/zen/go/v1")
+	t.Setenv(EnvOCRSDK, aiprovider.SDKOpenAI)
+	t.Setenv(EnvOCRModel, "deepseek-v4-flash-vision-exp")
+
+	env, err := AIEnvFromEnv()
+	if err != nil {
+		t.Fatalf("AIEnvFromEnv: %v", err)
+	}
+	if !env.Providers.SharesOneProvider() {
+		t.Fatal("OCR was read as a second provider on the same endpoint")
+	}
+	if got := env.Providers.OCRSDK(); got != aiprovider.SDKOpenCode {
+		t.Fatalf("OCR SDK = %q, want %q", got, aiprovider.SDKOpenCode)
+	}
+	if got := env.Providers.OCR.APIKey; got != "sk-test" {
+		t.Fatalf("OCR key = %q, want the language model's", got)
+	}
+}
+
+// And the embedding binding is refused on it, which is the honest answer: that
+// endpoint has no /embeddings whatever the variable calls it.
+func TestEmbeddingsOnAnOpenCodeBaseURLAreRefused(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAISDK, aiprovider.SDKOpenAI)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+	t.Setenv(EnvAIBaseURL, "https://opencode.ai/zen/go/v1")
+	t.Setenv(EnvAIEmbeddingModel, "text-embedding-3-small")
+
+	if _, err := AIEnvFromEnv(); err == nil {
+		t.Fatal("an embedding model on an OpenCode endpoint was accepted")
+	}
+}

--- a/backend/internal/config/embedding_test.go
+++ b/backend/internal/config/embedding_test.go
@@ -279,3 +279,62 @@ func TestEmbeddingSDKMatchingTheLanguageModelReusesItsEndpoint(t *testing.T) {
 		t.Fatal("the same SDK is the same endpoint, so no second provider row")
 	}
 }
+
+// AI_EMBEDDING_MODEL alone means "embed on the AI_SDK provider", which is no
+// longer always available: opencode chats but serves no /embeddings. Refused
+// here rather than at the first upload, where the binding would read as
+// configured and every document's embed step would fail.
+func TestAnEmbeddingModelIsRefusedOnAnSDKThatCannotEmbed(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAISDK, aiprovider.SDKOpenCode)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+	t.Setenv(EnvAIEmbeddingModel, "text-embedding-3-small")
+
+	_, err := AIEnvFromEnv()
+	if err == nil {
+		t.Fatal("an embedding model bound to opencode was accepted")
+	}
+	// The message has to name the way out, not just the problem.
+	for _, want := range []string{EnvAIEmbeddingSDK, aiprovider.SDKLocalEmbeddings} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+// And the way out works: a second provider for embeddings, which is what the
+// AI_EMBEDDING_SDK block exists for.
+func TestOpenCodeEmbedsThroughASecondProvider(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAISDK, aiprovider.SDKOpenCode)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+	t.Setenv(EnvAIEmbeddingSDK, aiprovider.SDKLocalEmbeddings)
+	t.Setenv(EnvAIEmbeddingModel, "BAAI/bge-m3")
+
+	env, err := AIEnvFromEnv()
+	if err != nil {
+		t.Fatalf("AIEnvFromEnv: %v", err)
+	}
+	if env.Providers.SharesEmbeddingProvider() {
+		t.Fatal("embeddings were folded onto the opencode provider")
+	}
+	if got := env.Providers.Embedding.SDK; got != aiprovider.SDKLocalEmbeddings {
+		t.Fatalf("embedding SDK = %q", got)
+	}
+}
+
+// Without an embedding model, opencode is a complete configuration on its own:
+// keyword retrieval is the pre-feature behaviour and still a working state.
+func TestOpenCodeWithoutAnEmbeddingModelIsFine(t *testing.T) {
+	clearAIEnv(t)
+	t.Setenv(EnvAISDK, aiprovider.SDKOpenCode)
+	t.Setenv(EnvAIAPIKey, "sk-test")
+
+	env, err := AIEnvFromEnv()
+	if err != nil {
+		t.Fatalf("AIEnvFromEnv: %v", err)
+	}
+	if env.Providers.LLM.EmbeddingModel != "" {
+		t.Fatalf("embedding model = %q, want empty", env.Providers.LLM.EmbeddingModel)
+	}
+}

--- a/backend/internal/ocr/llm.go
+++ b/backend/internal/ocr/llm.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,46 +22,31 @@ const llmOCRMaxFileBytes = 10 * 1024 * 1024
 
 const llmOCRPrompt = "Extract all text from this document. Return plain text only, preserving reading order. Do not add commentary."
 
+// LLMProvider reads a document by sending it to a language model.
+//
+// The client is ai.OpenAIClient rather than an openai.Client of its own: which
+// endpoint a model is served on, and which of the two SDKs speaks to it, is
+// that type's business, and building a second client here meant two places had
+// to agree about it. The four fields this struct used to carry -- sdk, base
+// URL, client, and the request options behind them -- all live there.
 type LLMProvider struct {
-	sdk     string
-	model   string
-	baseURL string
-	client  openai.Client
-	logger  *slog.Logger
+	llm    *ai.OpenAIClient
+	model  string
+	logger *slog.Logger
 }
 
 func NewLLMProvider(p aiprovider.Provider, model string, timeout time.Duration, logger *slog.Logger, extra ...option.RequestOption) *LLMProvider {
 	if timeout <= 0 {
 		timeout = 40 * time.Second
 	}
-	opts := []option.RequestOption{
-		option.WithAPIKey(p.APIKey),
-		option.WithHTTPClient(&http.Client{Timeout: timeout}),
-		option.WithRequestTimeout(timeout),
-		option.WithMaxRetries(0),
-		option.WithMiddleware(aiprovider.SessionMiddleware()),
-	}
-	// Tests pass RewriteHostMiddleware here so a base URL of opencode.ai still
-	// lands on httptest. Production callers pass none.
-	opts = append(opts, extra...)
-	if strings.TrimSpace(p.BaseURL) != "" {
-		opts = append(opts, option.WithBaseURL(strings.TrimRight(p.BaseURL, "/")))
-	}
 	return &LLMProvider{
-		sdk:     p.SDK,
-		model:   model,
-		baseURL: strings.TrimRight(p.BaseURL, "/"),
-		client:  openai.NewClient(opts...),
-		logger:  logger,
+		llm:    ai.NewOpenAIClient(p.SDK, p.APIKey, model, p.BaseURL, "", "", timeout, logger, extra...),
+		model:  model,
+		logger: logger,
 	}
 }
 
-func (p *LLMProvider) Name() string {
-	if p.sdk != "" {
-		return p.sdk
-	}
-	return "llm"
-}
+func (p *LLMProvider) Name() string { return p.llm.Name() }
 
 func (p *LLMProvider) ExtractText(ctx context.Context, filePath string, mimeType string) (string, error) {
 	start := time.Now()
@@ -83,7 +67,7 @@ func (p *LLMProvider) ExtractText(ctx context.Context, filePath string, mimeType
 	}
 
 	p.logger.Info("llm ocr starting",
-		"sdk", p.sdk,
+		"sdk", p.llm.Name(),
 		"model", p.model,
 		"file", filepath.Base(filePath),
 		"mime", effectiveMime,
@@ -98,7 +82,7 @@ func (p *LLMProvider) ExtractText(ctx context.Context, filePath string, mimeType
 		},
 		Temperature: ai.CompletionTemperature(p.model, 0),
 	}
-	chatResp, err := ai.CompleteChat(ctx, p.client, p.logger, p.sdk, p.baseURL, ocrParams, "purpose", "ocr", "messages", 2)
+	chatResp, err := p.llm.Complete(ctx, ocrParams, "purpose", "ocr", "messages", 2)
 	if err != nil {
 		p.logger.Error("llm ocr failed",
 			"file", filepath.Base(filePath),

--- a/backend/internal/ocr/llm_test.go
+++ b/backend/internal/ocr/llm_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
 	"lemmary/backend/internal/aiprovider"
 )
 
@@ -171,12 +170,10 @@ func TestExtractTextSendsSessionHeaderToOpenCode(t *testing.T) {
 	}
 
 	p := NewLLMProvider(aiprovider.Provider{
-		SDK:     aiprovider.SDKOpenAI,
+		SDK:     aiprovider.SDKOpenCode,
 		APIKey:  "test-key",
-		BaseURL: "http://opencode.ai/zen/go/v1",
-	}, "test-model", 5*time.Second, slog.Default(),
-		option.WithMiddleware(aiprovider.RewriteHostMiddleware(srv.Listener.Addr().String())),
-	)
+		BaseURL: srv.URL + "/zen/go/v1",
+	}, "test-model", 5*time.Second, slog.Default())
 	ctx := aiprovider.WithSession(context.Background(), "conv123")
 	text, err := p.ExtractText(ctx, path, "image/png")
 	if err != nil {
@@ -187,5 +184,20 @@ func TestExtractTextSendsSessionHeaderToOpenCode(t *testing.T) {
 	}
 	if seen != "conv123" {
 		t.Errorf("%s = %q, want %q", aiprovider.SessionHeader, seen, "conv123")
+	}
+
+	// The other half of the gate: an openai row installs no middleware, so a
+	// request to the same address carries nothing.
+	seen = "unset"
+	plain := NewLLMProvider(aiprovider.Provider{
+		SDK:     aiprovider.SDKOpenAI,
+		APIKey:  "test-key",
+		BaseURL: srv.URL + "/v1",
+	}, "test-model", 5*time.Second, slog.Default())
+	if _, err := plain.ExtractText(ctx, path, "image/png"); err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if seen != "" {
+		t.Errorf("%s = %q, want empty for an openai provider", aiprovider.SessionHeader, seen)
 	}
 }

--- a/backend/internal/ocr/provider.go
+++ b/backend/internal/ocr/provider.go
@@ -72,11 +72,12 @@ func NewFromAIProvider(p aiprovider.Provider, model string, timeout time.Duratio
 	case aiprovider.SDKMistral:
 		logger.Info("using provider", "provider", p.Alias, "sdk", p.SDK, "model", model)
 		return NewMistralProvider(p.APIKey, model, p.BaseURL, timeout, logger), nil
-	case aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter, aiprovider.SDKChatGPT:
-		// chatgpt joins the metered LLM SDKs here rather than getting a branch
-		// of its own: the request is the same multimodal chat completion, and
-		// what differs -- a minted bearer token, and the Responses rewrite
-		// underneath -- is entirely inside the options in extra.
+	case aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter, aiprovider.SDKOpenCode, aiprovider.SDKChatGPT:
+		// chatgpt and opencode join the metered LLM SDKs here rather than getting
+		// branches of their own: the request is the same multimodal chat
+		// completion, and what differs -- a minted bearer token for one, a second
+		// wire protocol for the other -- is entirely inside the client that
+		// NewLLMProvider builds.
 		logger.Info("using provider", "provider", p.Alias, "sdk", p.SDK, "model", model)
 		return NewLLMProvider(p, model, timeout, logger, extra...), nil
 	case aiprovider.SDKDocling:

--- a/backend/internal/opencode/endpoint.go
+++ b/backend/internal/opencode/endpoint.go
@@ -1,0 +1,76 @@
+// Package opencode is the OpenCode Go (Zen) SDK.
+//
+// OpenCode Go is a gateway in front of a catalogue of third-party models, and it
+// does not serve them all the same way: each model lives on one of
+// /chat/completions, /responses or /messages, the last of which speaks
+// Anthropic's Messages API rather than OpenAI's. So this SDK is a wrapper over
+// two others -- openai-go for the first two endpoints, anthropic-sdk-go for the
+// third -- with the routing table below deciding which.
+//
+// The table is static because there is nothing to ask: /v1/models answers with
+// {id, object, created, owned_by} and says nothing about the shape of the API
+// behind each id. Endpoint routing used to be inferred from the shape of a
+// failed request instead, which cost one rejected request per model per process
+// and could not reach /messages at all.
+//
+// It is a leaf package: it may use aiprovider, but internal/ai does the routing
+// and so imports this, never the other way round.
+package opencode
+
+import (
+	"strings"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+const (
+	// EndpointChat is the OpenAI-compatible /chat/completions endpoint, which
+	// serves most of the catalogue.
+	EndpointChat = "chat_completions"
+	// EndpointResponses is OpenAI's /responses endpoint.
+	EndpointResponses = "responses"
+	// EndpointMessages is Anthropic's /messages endpoint.
+	EndpointMessages = "messages"
+)
+
+// Prefixes rather than the ~28 exact model ids the docs list, so a point
+// release routes without a code change: the endpoint is a property of the model
+// family, and OpenCode versions within a family (glm-5.1 through glm-5.3,
+// qwen3.6 through qwen3.8) without moving it.
+//
+// Only the two smaller sets are written out. /chat/completions is the default
+// because it is the majority and because it is the endpoint whose failure is
+// legible -- an unknown model sent there gets a normal API error naming the
+// problem, where /messages would answer a malformed request.
+var (
+	messagesPrefixes  = []string{"minimax", "qwen"}
+	responsesPrefixes = []string{"grok", "gpt-", "muse-spark"}
+)
+
+// Endpoint is which of OpenCode Go's three endpoints serves model.
+//
+// It answers "" for every other SDK, so a caller can switch on it and fall
+// through to the generic OpenAI-compatible path without asking about the SDK
+// twice.
+func Endpoint(sdk, model string) string {
+	if strings.TrimSpace(sdk) != aiprovider.SDKOpenCode {
+		return ""
+	}
+	m := strings.ToLower(strings.TrimSpace(model))
+	if hasAnyPrefix(m, messagesPrefixes) {
+		return EndpointMessages
+	}
+	if hasAnyPrefix(m, responsesPrefixes) {
+		return EndpointResponses
+	}
+	return EndpointChat
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/opencode/endpoint_test.go
+++ b/backend/internal/opencode/endpoint_test.go
@@ -1,0 +1,101 @@
+package opencode
+
+import (
+	"testing"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// Every model id OpenCode Go's docs list, against the endpoint they list it
+// under. The prefixes are the implementation; this is the contract they were
+// derived from, so a prefix edited into overlapping with another family fails
+// here rather than at the first request.
+func TestEveryDocumentedModelRoutesToItsEndpoint(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		// OpenAI-compatible /chat/completions
+		"glm-5.3-flash":                EndpointChat,
+		"glm-5.3":                      EndpointChat,
+		"glm-5.2":                      EndpointChat,
+		"glm-5.1":                      EndpointChat,
+		"kimi-k3":                      EndpointChat,
+		"kimi-k2.7-code":               EndpointChat,
+		"kimi-k2.6":                    EndpointChat,
+		"longcat-2.0":                  EndpointChat,
+		"deepseek-v4-pro":              EndpointChat,
+		"deepseek-v4-flash":            EndpointChat,
+		"deepseek-v4-flash-vision-exp": EndpointChat,
+		"mimo-v2.5":                    EndpointChat,
+		"mimo-v2.5-pro":                EndpointChat,
+		"hy4-preview":                  EndpointChat,
+		"hy3":                          EndpointChat,
+		"omen-alpha":                   EndpointChat,
+		// /responses
+		"grok-4.6":                   EndpointResponses,
+		"gpt-5.6-luna":               EndpointResponses,
+		"muse-spark-1.3-contributor": EndpointResponses,
+		"muse-spark-1.2-contributor": EndpointResponses,
+		// Anthropic /messages
+		"minimax-m3":    EndpointMessages,
+		"minimax-m2.7":  EndpointMessages,
+		"minimax-m2.5":  EndpointMessages,
+		"qwen3.8-max":   EndpointMessages,
+		"qwen3.8-flash": EndpointMessages,
+		"qwen3.7-max":   EndpointMessages,
+		"qwen3.7-plus":  EndpointMessages,
+		"qwen3.6-plus":  EndpointMessages,
+	}
+	for model, want := range cases {
+		if got := Endpoint(aiprovider.SDKOpenCode, model); got != want {
+			t.Errorf("Endpoint(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+// The default matters as much as the table: OpenCode adds models, and one this
+// build has never heard of has to go somewhere. /chat/completions is the
+// endpoint whose refusal is legible.
+func TestAnUnknownModelGoesToChatCompletions(t *testing.T) {
+	t.Parallel()
+	for _, model := range []string{"something-new-1", "", "  "} {
+		if got := Endpoint(aiprovider.SDKOpenCode, model); got != EndpointChat {
+			t.Errorf("Endpoint(%q) = %q, want %q", model, got, EndpointChat)
+		}
+	}
+}
+
+// The routing is OpenCode's, not the model name's. gpt-5.6-luna at
+// api.openai.com is served by /chat/completions like anything else there, and
+// answering EndpointResponses for it would send an `openai` row down a path its
+// own degradation ladder owns.
+func TestOnlyTheOpenCodeSDKIsRouted(t *testing.T) {
+	t.Parallel()
+	for _, sdk := range []string{aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter, aiprovider.SDKMistral, aiprovider.SDKChatGPT, ""} {
+		for _, model := range []string{"gpt-5.6-luna", "minimax-m3", "deepseek-v4-flash"} {
+			if got := Endpoint(sdk, model); got != "" {
+				t.Errorf("Endpoint(%q, %q) = %q, want the empty string", sdk, model, got)
+			}
+		}
+	}
+}
+
+// anthropic-sdk-go appends "v1/messages" to the base URL itself, so the /v1
+// that every provider row carries has to come off -- left on, the request goes
+// to /zen/go/v1/v1/messages and the endpoint 404s.
+func TestMessagesBaseURLDropsTheVersionSegment(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"https://opencode.ai/zen/go/v1":  "https://opencode.ai/zen/go/v1/messages",
+		"https://opencode.ai/zen/go/v1/": "https://opencode.ai/zen/go/v1/messages",
+		// A test server's base URL has no /v1 to strip.
+		"http://127.0.0.1:8080": "http://127.0.0.1:8080/v1/messages",
+		// Empty falls back to the SDK's documented endpoint rather than
+		// building a relative path.
+		"": "https://opencode.ai/zen/go/v1/messages",
+	}
+	for base, want := range cases {
+		if got := MessagesURL(base); got != want {
+			t.Errorf("MessagesURL(%q) = %q, want %q", base, got, want)
+		}
+	}
+}

--- a/backend/internal/opencode/messages.go
+++ b/backend/internal/opencode/messages.go
@@ -1,0 +1,480 @@
+package opencode
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared/constant"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// The models on EndpointMessages speak Anthropic's Messages API. Everything
+// below converts in one direction and back -- openai.ChatCompletionNewParams to
+// anthropic.MessageNewParams, and the Message to a *openai.ChatCompletion the
+// existing call sites already know how to read -- so no caller changes. It is
+// the same trade internal/ai/responses.go makes for /responses, and for the
+// same reason: the archive has one request shape, and a gateway's choice of
+// endpoint is not something forty call sites should know about.
+//
+// Only the fields this codebase actually sends are carried across. A field
+// nobody sets is a field that cannot silently mistranslate.
+
+// defaultMaxTokens caps a Messages reply.
+//
+// The parameter is required there and optional on /chat/completions, so no
+// caller in this codebase sets it and one has to be invented. This is generous
+// enough for the longest thing the archive asks for -- a Deep Search distil
+// over a batch of documents -- and the tokens are only spent if the model
+// writes them.
+//
+// ponytail: one number for every purpose. If a caller ever needs a different
+// ceiling, thread it through openai.ChatCompletionNewParams.MaxTokens, which
+// responsesParamsFrom already honours and this already prefers.
+const defaultMaxTokens = 32768
+
+// NewMessages builds the Anthropic client for an OpenCode base URL.
+//
+// Both credentials are sent: x-api-key, which is what @ai-sdk/anthropic (the
+// package OpenCode's own docs pair with this endpoint) presents, and an
+// Authorization bearer, which is what its other two endpoints take. The docs
+// specify neither, and one header costs nothing.
+func NewMessages(apiKey, baseURL string, timeout time.Duration) anthropic.Client {
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	return anthropic.NewClient(
+		// This is an OpenCode endpoint reached with an OpenCode key. Without
+		// this marker the SDK also walks its own credential chain --
+		// ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, a config profile -- and a
+		// developer with Claude configured on the same host would have it
+		// contribute to these requests.
+		anthropicoption.WithoutEnvironmentDefaults(),
+		anthropicoption.WithAPIKey(apiKey),
+		anthropicoption.WithAuthToken(apiKey),
+		anthropicoption.WithBaseURL(MessagesBaseURL(baseURL)),
+		anthropicoption.WithHTTPClient(&http.Client{Timeout: timeout}),
+		anthropicoption.WithRequestTimeout(timeout),
+		anthropicoption.WithMaxRetries(0),
+		anthropicoption.WithMiddleware(sessionMiddleware()),
+	)
+}
+
+// sessionMiddleware is aiprovider.SessionMiddleware for the Anthropic SDK,
+// whose option package is its own type. Same header, same context value; the
+// two SDKs simply cannot share a middleware.
+func sessionMiddleware() anthropicoption.Middleware {
+	return func(req *http.Request, next anthropicoption.MiddlewareNext) (*http.Response, error) {
+		if req != nil {
+			if id := aiprovider.SessionFrom(req.Context()); id != "" {
+				req.Header.Set(aiprovider.SessionHeader, id)
+			}
+		}
+		return next(req)
+	}
+}
+
+// MessagesBaseURL is the base URL to build the Anthropic client with.
+//
+// anthropic-sdk-go appends the relative path "v1/messages" itself, so the /v1
+// that every other endpoint's base URL carries has to come off first -- left on,
+// the request would go to /zen/go/v1/v1/messages.
+func MessagesBaseURL(baseURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = strings.TrimRight(aiprovider.DefaultBaseURL(aiprovider.SDKOpenCode), "/")
+	}
+	return strings.TrimSuffix(base, "/v1") + "/"
+}
+
+// MessagesURL is the /messages endpoint for an OpenCode base URL. It exists for
+// the outbound request log: the SDK builds the real URL itself, and a log line
+// that guessed a different one would be worse than none.
+func MessagesURL(baseURL string) string {
+	return MessagesBaseURL(baseURL) + "v1/messages"
+}
+
+// CompleteViaMessages runs a chat-completions-shaped request through the
+// Messages API and hands back a chat completion.
+func CompleteViaMessages(
+	ctx context.Context,
+	client anthropic.Client,
+	logger *slog.Logger,
+	baseURL string,
+	params openai.ChatCompletionNewParams,
+	extra ...any,
+) (*openai.ChatCompletion, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	req, err := messagesParamsFrom(params)
+	if err != nil {
+		return nil, err
+	}
+	aiprovider.LogRequest(
+		logger,
+		aiprovider.SDKOpenCode,
+		http.MethodPost,
+		MessagesURL(baseURL),
+		string(params.Model),
+		append(extra, "api", "messages")...,
+	)
+	msg, err := client.Messages.New(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return chatCompletionFrom(msg), nil
+}
+
+// CompleteStreamingViaMessages is the streaming twin: text arrives as
+// content_block_delta events and the usage totals ride on message_delta.
+//
+// It returns openai.CompletionUsage rather than internal/ai's own Usage type
+// because this package is a leaf: internal/ai imports it, so it cannot import
+// internal/ai back. The caller folds it with the same usageFrom it uses for an
+// ordinary completion.
+func CompleteStreamingViaMessages(
+	ctx context.Context,
+	client anthropic.Client,
+	logger *slog.Logger,
+	baseURL string,
+	params openai.ChatCompletionNewParams,
+	onDelta func(string),
+	extra ...any,
+) (string, openai.CompletionUsage, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var usage openai.CompletionUsage
+	req, err := messagesParamsFrom(params)
+	if err != nil {
+		return "", usage, err
+	}
+	aiprovider.LogRequest(
+		logger,
+		aiprovider.SDKOpenCode,
+		http.MethodPost,
+		MessagesURL(baseURL),
+		string(params.Model),
+		append(extra, "stream", true, "api", "messages")...,
+	)
+
+	stream := client.Messages.NewStreaming(ctx, req)
+	defer stream.Close()
+
+	var b strings.Builder
+	for stream.Next() {
+		event := stream.Current()
+		switch event.Type {
+		case "message_start":
+			usage = usageFrom(event.Message.Usage)
+		case "content_block_delta":
+			// text_delta only. A thinking_delta carries no answer text, and
+			// an input_json_delta belongs to a tool call, which the streaming
+			// call sites do not send.
+			delta := event.Delta.Text
+			if delta == "" {
+				continue
+			}
+			b.WriteString(delta)
+			if onDelta != nil {
+				onDelta(delta)
+			}
+		case "message_delta":
+			// Cumulative, and the last word on what the request cost.
+			usage = openai.CompletionUsage{
+				PromptTokens:     event.Usage.InputTokens,
+				CompletionTokens: event.Usage.OutputTokens,
+				TotalTokens:      event.Usage.InputTokens + event.Usage.OutputTokens,
+				PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+					CachedTokens: event.Usage.CacheReadInputTokens,
+				},
+			}
+		}
+	}
+	return b.String(), usage, stream.Err()
+}
+
+// messagesParamsFrom translates a chat completion request into a Messages one.
+func messagesParamsFrom(params openai.ChatCompletionNewParams) (anthropic.MessageNewParams, error) {
+	system, messages, err := messagesFrom(params.Messages)
+	if err != nil {
+		return anthropic.MessageNewParams{}, err
+	}
+	req := anthropic.MessageNewParams{
+		Model:     anthropic.Model(params.Model),
+		Messages:  messages,
+		System:    system,
+		MaxTokens: defaultMaxTokens,
+	}
+	if params.MaxTokens.Valid() {
+		req.MaxTokens = params.MaxTokens.Value
+	}
+	if params.Temperature.Valid() {
+		// The two APIs scale it differently: chat completions takes 0-2,
+		// Messages takes 0-1. Everything this codebase sends is already inside
+		// 0-1 (see ai.CompletionTemperature), so this only guards a future
+		// caller from having its 1.4 silently rejected.
+		req.Temperature = anthropic.Float(min(params.Temperature.Value, 1))
+	}
+	// params.ResponseFormat is deliberately dropped. The Messages API has no
+	// bare "give me JSON" mode -- its structured output wants a full schema, and
+	// the callers here ask for json_object with none. Every one of them already
+	// says "Return one JSON object" in its own prompt and parses the answer
+	// leniently through models.NormalizeJSONObject, which is why the
+	// chat-completions path already retries without the parameter when a
+	// provider rejects it.
+	for _, tool := range params.Tools {
+		fn := anthropic.ToolParam{
+			Name:        tool.Function.Name,
+			InputSchema: toolInputSchemaFrom(tool.Function.Parameters),
+		}
+		if tool.Function.Description.Valid() {
+			fn.Description = anthropic.String(tool.Function.Description.Value)
+		}
+		req.Tools = append(req.Tools, anthropic.ToolUnionParam{OfTool: &fn})
+	}
+	if choice := params.ToolChoice.OfAuto.Or(""); choice != "" {
+		switch choice {
+		case "none":
+			req.ToolChoice = anthropic.ToolChoiceUnionParam{OfNone: &anthropic.ToolChoiceNoneParam{}}
+		case "required":
+			req.ToolChoice = anthropic.ToolChoiceUnionParam{OfAny: &anthropic.ToolChoiceAnyParam{}}
+		default:
+			req.ToolChoice = anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{}}
+		}
+	}
+	return req, nil
+}
+
+// toolInputSchemaFrom carries a function's JSON schema across. Only properties
+// and required are named fields there; anything else the schema declares rides
+// in ExtraFields, so a hand-written schema is not quietly trimmed.
+func toolInputSchemaFrom(schema map[string]any) anthropic.ToolInputSchemaParam {
+	out := anthropic.ToolInputSchemaParam{}
+	extras := map[string]any{}
+	for key, value := range schema {
+		switch key {
+		case "type":
+			// Always "object"; the field is a constant on the param.
+		case "properties":
+			out.Properties = value
+		case "required":
+			out.Required = stringsFrom(value)
+		default:
+			extras[key] = value
+		}
+	}
+	if len(extras) > 0 {
+		out.ExtraFields = extras
+	}
+	return out
+}
+
+func stringsFrom(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// messagesFrom splits the chat message list into the top-level system prompt
+// and the conversation.
+//
+// The two shapes disagree twice. There is no system role in Messages -- it is a
+// parameter of its own -- and a tool call is a content block on the turn rather
+// than a field beside it, answered by a user turn carrying a tool_result block
+// instead of a message with its own role.
+func messagesFrom(messages []openai.ChatCompletionMessageParamUnion) ([]anthropic.TextBlockParam, []anthropic.MessageParam, error) {
+	var system []anthropic.TextBlockParam
+	out := make([]anthropic.MessageParam, 0, len(messages))
+	for _, msg := range messages {
+		switch {
+		// Developer messages join the system prompt: Messages has no separate
+		// notion of them, and dropping one would drop instructions.
+		case msg.OfSystem != nil:
+			if text := msg.OfSystem.Content.OfString.Or(""); text != "" {
+				system = append(system, anthropic.TextBlockParam{Text: text})
+			}
+		case msg.OfDeveloper != nil:
+			if text := msg.OfDeveloper.Content.OfString.Or(""); text != "" {
+				system = append(system, anthropic.TextBlockParam{Text: text})
+			}
+		case msg.OfUser != nil:
+			blocks, err := userBlocksFrom(*msg.OfUser)
+			if err != nil {
+				return nil, nil, err
+			}
+			out = append(out, anthropic.NewUserMessage(blocks...))
+		case msg.OfAssistant != nil:
+			var blocks []anthropic.ContentBlockParamUnion
+			if text := msg.OfAssistant.Content.OfString.Or(""); text != "" {
+				blocks = append(blocks, anthropic.NewTextBlock(text))
+			}
+			for _, call := range msg.OfAssistant.ToolCalls {
+				// Arguments arrive as a JSON string; the block wants the value.
+				var input any
+				if err := json.Unmarshal([]byte(call.Function.Arguments), &input); err != nil {
+					input = call.Function.Arguments
+				}
+				blocks = append(blocks, anthropic.NewToolUseBlock(call.ID, input, call.Function.Name))
+			}
+			if len(blocks) == 0 {
+				continue
+			}
+			out = append(out, anthropic.NewAssistantMessage(blocks...))
+		case msg.OfTool != nil:
+			out = append(out, anthropic.NewUserMessage(
+				anthropic.NewToolResultBlock(msg.OfTool.ToolCallID, msg.OfTool.Content.OfString.Or(""), false)))
+		default:
+			return nil, nil, fmt.Errorf("messages: unsupported message shape")
+		}
+	}
+	return system, out, nil
+}
+
+// userBlocksFrom carries a user message across, including the image and file
+// parts LLM OCR sends.
+func userBlocksFrom(msg openai.ChatCompletionUserMessageParam) ([]anthropic.ContentBlockParamUnion, error) {
+	if msg.Content.OfString.Valid() {
+		return []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock(msg.Content.OfString.Value)}, nil
+	}
+	blocks := make([]anthropic.ContentBlockParamUnion, 0, len(msg.Content.OfArrayOfContentParts))
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		switch {
+		case part.OfText != nil:
+			blocks = append(blocks, anthropic.NewTextBlock(part.OfText.Text))
+		case part.OfImageURL != nil:
+			mediaType, data, ok := splitDataURI(part.OfImageURL.ImageURL.URL)
+			if !ok {
+				// A remote URL, which Messages does accept -- unlike the file
+				// part below, which only ever carries inline data.
+				blocks = append(blocks, anthropic.NewImageBlock(anthropic.URLImageSourceParam{
+					URL: part.OfImageURL.ImageURL.URL,
+				}))
+				continue
+			}
+			blocks = append(blocks, anthropic.NewImageBlockBase64(mediaType, data))
+		case part.OfFile != nil:
+			mediaType, data, ok := splitDataURI(part.OfFile.File.FileData.Or(""))
+			if !ok {
+				return nil, fmt.Errorf("messages: file part carries no inline data")
+			}
+			// ocr.LLMUserContentParts refuses anything but a PDF before it gets
+			// here, and a PDF is the only document source the Messages API takes
+			// as base64. Checked anyway: sent as one, a docx would come back as
+			// an opaque upstream error.
+			if mediaType != "application/pdf" {
+				return nil, fmt.Errorf("messages: cannot send %s as a document; use a PDF or an image", mediaType)
+			}
+			blocks = append(blocks, anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: data}))
+		default:
+			return nil, fmt.Errorf("messages: unsupported user content part")
+		}
+	}
+	return blocks, nil
+}
+
+// splitDataURI reads "data:<media type>;base64,<data>" into its two halves.
+// Anything else -- a remote URL, a bare string -- is reported as not one rather
+// than guessed at.
+func splitDataURI(uri string) (mediaType, data string, ok bool) {
+	if !strings.HasPrefix(uri, "data:") {
+		return "", "", false
+	}
+	header, payload, found := strings.Cut(strings.TrimPrefix(uri, "data:"), ",")
+	if !found {
+		return "", "", false
+	}
+	mediaType, encoding, _ := strings.Cut(header, ";")
+	if strings.TrimSpace(encoding) != "base64" {
+		return "", "", false
+	}
+	if _, err := base64.StdEncoding.DecodeString(payload); err != nil {
+		return "", "", false
+	}
+	return strings.TrimSpace(mediaType), payload, true
+}
+
+// chatCompletionFrom folds a Message back into the one-choice chat completion
+// the call sites read. Thinking blocks are dropped: they carry no text to show,
+// and replaying them would mean threading provider-specific state through every
+// caller.
+func chatCompletionFrom(msg *anthropic.Message) *openai.ChatCompletion {
+	if msg == nil {
+		return nil
+	}
+	var text strings.Builder
+	var calls []openai.ChatCompletionMessageToolCall
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			text.WriteString(block.Text)
+		case "tool_use":
+			calls = append(calls, openai.ChatCompletionMessageToolCall{
+				ID:   block.ID,
+				Type: constant.ValueOf[constant.Function](),
+				Function: openai.ChatCompletionMessageToolCallFunction{
+					Name:      block.Name,
+					Arguments: string(block.Input),
+				},
+			})
+		}
+	}
+
+	finish := "stop"
+	switch {
+	case len(calls) > 0:
+		finish = "tool_calls"
+	case msg.StopReason == "max_tokens":
+		finish = "length"
+	}
+
+	return &openai.ChatCompletion{
+		ID:    msg.ID,
+		Model: string(msg.Model),
+		Choices: []openai.ChatCompletionChoice{{
+			Index:        0,
+			FinishReason: finish,
+			Message: openai.ChatCompletionMessage{
+				Role:      constant.ValueOf[constant.Assistant](),
+				Content:   text.String(),
+				ToolCalls: calls,
+			},
+		}},
+		Usage: usageFrom(msg.Usage),
+	}
+}
+
+// usageFrom folds Anthropic's token counts into the chat-completions shape.
+// cache_read_input_tokens is Anthropic's CachedTokens: the part of the prompt
+// served from the prefix cache, included in the input total rather than
+// additional to it -- the same convention ai.Usage documents.
+func usageFrom(u anthropic.Usage) openai.CompletionUsage {
+	return openai.CompletionUsage{
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      u.InputTokens + u.OutputTokens,
+		PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+			CachedTokens: u.CacheReadInputTokens,
+		},
+	}
+}

--- a/backend/internal/opencode/messages.go
+++ b/backend/internal/opencode/messages.go
@@ -323,7 +323,7 @@ func messagesFrom(messages []openai.ChatCompletionMessageParamUnion) ([]anthropi
 			if err != nil {
 				return nil, nil, err
 			}
-			out = append(out, anthropic.NewUserMessage(blocks...))
+			out = appendBlocks(out, anthropic.MessageParamRoleUser, blocks...)
 		case msg.OfAssistant != nil:
 			var blocks []anthropic.ContentBlockParamUnion
 			if text := msg.OfAssistant.Content.OfString.Or(""); text != "" {
@@ -340,15 +340,41 @@ func messagesFrom(messages []openai.ChatCompletionMessageParamUnion) ([]anthropi
 			if len(blocks) == 0 {
 				continue
 			}
-			out = append(out, anthropic.NewAssistantMessage(blocks...))
+			out = appendBlocks(out, anthropic.MessageParamRoleAssistant, blocks...)
 		case msg.OfTool != nil:
-			out = append(out, anthropic.NewUserMessage(
-				anthropic.NewToolResultBlock(msg.OfTool.ToolCallID, msg.OfTool.Content.OfString.Or(""), false)))
+			out = appendBlocks(out, anthropic.MessageParamRoleUser,
+				anthropic.NewToolResultBlock(msg.OfTool.ToolCallID, msg.OfTool.Content.OfString.Or(""), false))
 		default:
 			return nil, nil, fmt.Errorf("messages: unsupported message shape")
 		}
 	}
 	return system, out, nil
+}
+
+// appendBlocks adds blocks to the conversation under role, merging them into
+// the previous turn when that turn has the same role.
+//
+// The Messages API alternates user and assistant turns, and a chat completion
+// list does not: a round of parallel tool calls answers with one tool-role
+// message per call, and Deep Search then appends a user instruction after them
+// -- three messages that all become user turns. Anthropic's own API documents
+// that it combines consecutive same-role turns, but OpenCode's /messages
+// models are MiniMax and Qwen behind a translating gateway, and a tool_use left
+// unanswered in the turn that immediately follows it is a 400 wherever the
+// combining does not happen. Merging here costs a few lines and removes the
+// question.
+//
+// Order within the merged turn is preserved, which is what keeps the
+// tool_result blocks ahead of the instruction that follows them.
+func appendBlocks(out []anthropic.MessageParam, role anthropic.MessageParamRole, blocks ...anthropic.ContentBlockParamUnion) []anthropic.MessageParam {
+	if len(blocks) == 0 {
+		return out
+	}
+	if n := len(out); n > 0 && out[n-1].Role == role {
+		out[n-1].Content = append(out[n-1].Content, blocks...)
+		return out
+	}
+	return append(out, anthropic.MessageParam{Role: role, Content: blocks})
 }
 
 // userBlocksFrom carries a user message across, including the image and file

--- a/backend/internal/opencode/messages_test.go
+++ b/backend/internal/opencode/messages_test.go
@@ -415,3 +415,89 @@ func TestStreamingDeltasAndUsage(t *testing.T) {
 		t.Errorf("usage = %+v, want 9/2/4 from message_delta", usage)
 	}
 }
+
+// A round of parallel tool calls answers with one tool-role message per call,
+// and Deep Search then appends its answer instruction after them. All three are
+// user turns on this API, and the Messages shape alternates roles: a tool_use
+// left unanswered in the turn immediately following it is a 400 wherever the
+// gateway does not combine them for us.
+//
+// This is the shape research.go actually builds -- the tool loop appends a
+// ToolMessage per call, then answerResearch appends a UserMessage.
+func TestParallelToolResultsLandInOneUserTurn(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("ok"))
+	client := NewMessages("k", base, time.Second)
+
+	_, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model: shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("how much did I pay?"),
+			{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				ToolCalls: []openai.ChatCompletionMessageToolCallParam{
+					{ID: "call_1", Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name: "search_documents", Arguments: `{"q":"rent"}`}},
+					{ID: "call_2", Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name: "read_documents", Arguments: `{"ids":["doc1"]}`}},
+				},
+			}},
+			openai.ToolMessage("two hits", "call_1"),
+			openai.ToolMessage("the text", "call_2"),
+			openai.UserMessage("now write the answer"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+
+	messages, ok := srv.body["messages"].([]any)
+	if !ok {
+		t.Fatalf("messages = %v", srv.body["messages"])
+	}
+	// user / assistant / user, not user / assistant / user / user / user.
+	var roles []string
+	for _, m := range messages {
+		roles = append(roles, m.(map[string]any)["role"].(string))
+	}
+	if strings.Join(roles, ",") != "user,assistant,user" {
+		t.Fatalf("roles = %v, want the turns to alternate", roles)
+	}
+
+	// Both tool_results are in the turn right after the tool_use blocks, and
+	// the instruction that followed them is still after them.
+	last, _ := json.Marshal(messages[2])
+	for _, want := range []string{`"tool_use_id":"call_1"`, `"tool_use_id":"call_2"`, "now write the answer"} {
+		if !strings.Contains(string(last), want) {
+			t.Errorf("final user turn missing %s: %s", want, last)
+		}
+	}
+	if i, j := strings.Index(string(last), "call_2"), strings.Index(string(last), "now write"); i > j {
+		t.Errorf("the instruction was merged ahead of a tool_result: %s", last)
+	}
+}
+
+// The merge must not run two separate exchanges together: an assistant turn
+// between two user turns is what keeps them apart.
+func TestSeparateTurnsAreNotMerged(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("ok"))
+	client := NewMessages("k", base, time.Second)
+
+	_, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model: shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("first"),
+			openai.AssistantMessage("answer"),
+			openai.UserMessage("second"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	messages, _ := srv.body["messages"].([]any)
+	if len(messages) != 3 {
+		t.Fatalf("messages = %d, want the three turns kept apart", len(messages))
+	}
+}

--- a/backend/internal/opencode/messages_test.go
+++ b/backend/internal/opencode/messages_test.go
@@ -1,0 +1,417 @@
+package opencode
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// messagesServer stands in for the /messages endpoint. It records the request
+// it was reached with and answers whatever the test supplies.
+type messagesServer struct {
+	body   map[string]any
+	header http.Header
+	path   string
+}
+
+func (m *messagesServer) start(t *testing.T, reply any) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.header = r.Header.Clone()
+		m.path = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&m.body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(reply)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// textReply is the smallest well-formed Message.
+func textReply(text string) map[string]any {
+	return map[string]any{
+		"id": "msg_1", "type": "message", "role": "assistant",
+		"model": "minimax-m3", "stop_reason": "end_turn",
+		"content": []any{map[string]any{"type": "text", "text": text}},
+		"usage":   map[string]any{"input_tokens": 11, "output_tokens": 3, "cache_read_input_tokens": 7},
+	}
+}
+
+func fieldOf(t *testing.T, body map[string]any, key string) any {
+	t.Helper()
+	value, ok := body[key]
+	if !ok {
+		t.Fatalf("request has no %q; body was %v", key, body)
+	}
+	return value
+}
+
+// The shape the two APIs disagree about most: a system message is a parameter
+// there, not a role, so left in the message list it would either be rejected or
+// silently read as a user turn -- and every prompt in this codebase is a system
+// message.
+func TestSystemPromptIsHoistedOutOfTheMessageList(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("ok"))
+	client := NewMessages("k", base, time.Second)
+
+	resp, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model: shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("you transcribe documents"),
+			openai.UserMessage("hello"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "ok" {
+		t.Errorf("content = %q, want %q", resp.Choices[0].Message.Content, "ok")
+	}
+	if srv.path != "/v1/messages" {
+		t.Errorf("path = %q, want /v1/messages", srv.path)
+	}
+
+	system, _ := json.Marshal(fieldOf(t, srv.body, "system"))
+	if !strings.Contains(string(system), "you transcribe documents") {
+		t.Errorf("system = %s, want the system message", system)
+	}
+	messages, ok := fieldOf(t, srv.body, "messages").([]any)
+	if !ok || len(messages) != 1 {
+		t.Fatalf("messages = %v, want only the user turn", srv.body["messages"])
+	}
+	if role := messages[0].(map[string]any)["role"]; role != "user" {
+		t.Errorf("the one message has role %v, want user", role)
+	}
+}
+
+// max_tokens is required by the Messages API and set by nobody in this
+// codebase, so the translation has to invent one. Without it every request is
+// rejected before a model sees it.
+func TestMaxTokensIsAlwaysSent(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("ok"))
+	client := NewMessages("k", base, time.Second)
+
+	params := openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}
+	if _, err := CompleteViaMessages(context.Background(), client, nil, base, params); err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	if got := fieldOf(t, srv.body, "max_tokens"); got != float64(defaultMaxTokens) {
+		t.Errorf("max_tokens = %v, want the default %d", got, defaultMaxTokens)
+	}
+
+	// A caller that does name one is not overridden by it.
+	params.MaxTokens = openai.Int(64)
+	if _, err := CompleteViaMessages(context.Background(), client, nil, base, params); err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	if got := fieldOf(t, srv.body, "max_tokens"); got != float64(64) {
+		t.Errorf("max_tokens = %v, want the caller's 64", got)
+	}
+}
+
+// The Messages API has no bare json_object mode -- its structured output wants
+// a full schema, which none of these callers has. Sent anyway it would be an
+// unknown parameter; dropped, the prompts' own "Return one JSON object" and the
+// lenient parsers carry it, exactly as they do when /chat/completions rejects
+// the parameter.
+func TestJSONModeIsDroppedRatherThanSentUntranslated(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply(`{"ok":true}`))
+	client := NewMessages("k", base, time.Second)
+
+	_, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	for _, key := range []string{"response_format", "output_config"} {
+		if _, present := srv.body[key]; present {
+			t.Errorf("request carries %q: %v", key, srv.body[key])
+		}
+	}
+}
+
+// A research turn replays its whole thread every round, tool calls included. On
+// this API a call is a content block on the assistant turn and its answer is a
+// tool_result block on a user turn -- not an assistant field and a tool-role
+// message. Getting this wrong loses the tool results, so the model re-runs the
+// same searches forever.
+func TestToolCallsRoundTripThroughContentBlocks(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, map[string]any{
+		"id": "msg_2", "type": "message", "role": "assistant",
+		"model": "minimax-m3", "stop_reason": "tool_use",
+		"content": []any{
+			map[string]any{"type": "text", "text": "looking"},
+			map[string]any{"type": "tool_use", "id": "call_9", "name": "search", "input": map[string]any{"q": "rent"}},
+		},
+		"usage": map[string]any{"input_tokens": 5, "output_tokens": 2},
+	})
+	client := NewMessages("k", base, time.Second)
+
+	resp, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model: shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("find the rent"),
+			{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				ToolCalls: []openai.ChatCompletionMessageToolCallParam{{
+					ID: "call_1",
+					Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name: "search", Arguments: `{"q":"rent"}`,
+					},
+				}},
+			}},
+			openai.ToolMessage("two hits", "call_1"),
+		},
+		Tools: []openai.ChatCompletionToolParam{{
+			Function: shared.FunctionDefinitionParam{
+				Name:        "search",
+				Description: openai.String("search the archive"),
+				Parameters: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"q": map[string]any{"type": "string"}},
+					"required":   []string{"q"},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+
+	// Outbound: the call became a tool_use block, its answer a user turn with a
+	// tool_result block.
+	sent, _ := json.Marshal(srv.body["messages"])
+	for _, want := range []string{`"type":"tool_use"`, `"type":"tool_result"`, `"tool_use_id":"call_1"`} {
+		if !strings.Contains(string(sent), want) {
+			t.Errorf("messages missing %s: %s", want, sent)
+		}
+	}
+	// The schema arrived whole, not just its named fields.
+	tools, _ := json.Marshal(srv.body["tools"])
+	for _, want := range []string{`"name":"search"`, `"input_schema"`, `"required":["q"]`} {
+		if !strings.Contains(string(tools), want) {
+			t.Errorf("tools missing %s: %s", want, tools)
+		}
+	}
+
+	// Inbound: the tool_use block became a chat tool call the callers read.
+	calls := resp.Choices[0].Message.ToolCalls
+	if len(calls) != 1 || calls[0].ID != "call_9" || calls[0].Function.Name != "search" {
+		t.Fatalf("tool calls = %+v, want the one from the reply", calls)
+	}
+	if calls[0].Function.Arguments != `{"q":"rent"}` {
+		t.Errorf("arguments = %q, want the input as JSON", calls[0].Function.Arguments)
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", resp.Choices[0].FinishReason)
+	}
+}
+
+// LLM OCR is the reason this translation handles content parts at all: it sends
+// the document as a data URI in an image_url or file part, and the Messages API
+// wants the media type and the base64 payload as separate fields.
+func TestOCRPartsBecomeImageAndDocumentBlocks(t *testing.T) {
+	t.Parallel()
+	png := base64.StdEncoding.EncodeToString([]byte("not really a png"))
+	pdf := base64.StdEncoding.EncodeToString([]byte("%PDF-1.4"))
+
+	for _, tc := range []struct {
+		name string
+		part openai.ChatCompletionContentPartUnionParam
+		want []string
+	}{
+		{
+			name: "image",
+			part: openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+				URL: "data:image/png;base64," + png,
+			}),
+			want: []string{`"type":"image"`, `"media_type":"image/png"`, `"data":"` + png + `"`},
+		},
+		{
+			name: "pdf",
+			part: openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
+				Filename: openai.String("statement.pdf"),
+				FileData: openai.String("data:application/pdf;base64," + pdf),
+			}),
+			want: []string{`"type":"document"`, `"media_type":"application/pdf"`, `"data":"` + pdf + `"`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &messagesServer{}
+			base := srv.start(t, textReply("transcribed"))
+			client := NewMessages("k", base, time.Second)
+
+			_, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+				Model: shared.ChatModel("minimax-m3"),
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+						openai.TextContentPart("read this"), tc.part,
+					}),
+				},
+			})
+			if err != nil {
+				t.Fatalf("CompleteViaMessages: %v", err)
+			}
+			sent, _ := json.Marshal(srv.body["messages"])
+			for _, want := range tc.want {
+				if !strings.Contains(string(sent), want) {
+					t.Errorf("messages missing %s: %s", want, sent)
+				}
+			}
+		})
+	}
+}
+
+// A docx reaches the Messages API as neither an image nor a PDF, and the only
+// base64 document source it has is a PDF one. Refused here it names the
+// problem; sent, it comes back as an opaque upstream error.
+func TestANonPDFDocumentIsRefusedWithAUsefulError(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("unused"))
+	client := NewMessages("k", base, time.Second)
+
+	_, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model: shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+				openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
+					FileData: openai.String("data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,eA=="),
+				}),
+			}),
+		},
+	})
+	if err == nil {
+		t.Fatal("a docx was accepted; want an error naming the mime type")
+	}
+	if !strings.Contains(err.Error(), "wordprocessingml") {
+		t.Errorf("error = %v, want it to name the mime type", err)
+	}
+}
+
+// The header OpenCode requires. It is the whole reason this SDK exists
+// separately, and the Anthropic client needs its own middleware for it because
+// the two SDKs' option types are unrelated -- so an untested one is an easy
+// thing to leave off.
+func TestTheSessionHeaderIsSentOnMessagesToo(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("ok"))
+	client := NewMessages("k", base, time.Second)
+
+	ctx := aiprovider.WithSession(context.Background(), "session-abc")
+	if _, err := CompleteViaMessages(ctx, client, nil, base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}); err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	if got := srv.header.Get(aiprovider.SessionHeader); got != "session-abc" {
+		t.Errorf("%s = %q, want the session on the context", aiprovider.SessionHeader, got)
+	}
+	// Both credential headers, because the docs name neither.
+	if got := srv.header.Get("X-Api-Key"); got != "k" {
+		t.Errorf("X-Api-Key = %q, want the key", got)
+	}
+	if got := srv.header.Get("Authorization"); got != "Bearer k" {
+		t.Errorf("Authorization = %q, want a bearer token", got)
+	}
+}
+
+// Usage is what a Deep Search run is budgeted against, and the two APIs name
+// the numbers differently -- cache_read_input_tokens is the cached part of the
+// input, included in it rather than additional to it.
+func TestUsageIsFoldedIntoTheChatCompletionShape(t *testing.T) {
+	t.Parallel()
+	srv := &messagesServer{}
+	base := srv.start(t, textReply("ok"))
+	client := NewMessages("k", base, time.Second)
+
+	resp, err := CompleteViaMessages(context.Background(), client, nil, base, openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel("minimax-m3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("CompleteViaMessages: %v", err)
+	}
+	if resp.Usage.PromptTokens != 11 || resp.Usage.CompletionTokens != 3 {
+		t.Errorf("usage = %+v, want 11 prompt and 3 completion", resp.Usage)
+	}
+	if resp.Usage.PromptTokensDetails.CachedTokens != 7 {
+		t.Errorf("cached = %d, want 7", resp.Usage.PromptTokensDetails.CachedTokens)
+	}
+	if resp.Usage.TotalTokens != 14 {
+		t.Errorf("total = %d, want 14; the API reports no total of its own", resp.Usage.TotalTokens)
+	}
+}
+
+// Chat streams the answer a token at a time, and the deltas arrive under
+// different event names on this API.
+func TestStreamingDeltasAndUsage(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// The SSE event name matters here, unlike on the Responses stream: the
+		// SDK's decoder dispatches on it and drops an event it does not know.
+		for _, event := range [][2]string{
+			{"message_start", `{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"minimax-m3","content":[],"usage":{"input_tokens":9,"output_tokens":0}}}`},
+			{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}`},
+			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}`},
+			{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+			{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":9,"output_tokens":2,"cache_read_input_tokens":4}}`},
+			{"message_stop", `{"type":"message_stop"}`},
+		} {
+			_, _ = w.Write([]byte("event: " + event[0] + "\ndata: " + event[1] + "\n\n"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	client := NewMessages("k", srv.URL, time.Second)
+
+	var seen []string
+	text, usage, err := CompleteStreamingViaMessages(context.Background(), client, nil, srv.URL,
+		openai.ChatCompletionNewParams{
+			Model:    shared.ChatModel("minimax-m3"),
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+		},
+		func(delta string) { seen = append(seen, delta) },
+	)
+	if err != nil {
+		t.Fatalf("CompleteStreamingViaMessages: %v", err)
+	}
+	if text != "Hello" {
+		t.Errorf("text = %q, want %q", text, "Hello")
+	}
+	if strings.Join(seen, "|") != "Hel|lo" {
+		t.Errorf("deltas = %v, want them handed over as they arrived", seen)
+	}
+	// message_delta is cumulative and has the last word.
+	if usage.PromptTokens != 9 || usage.CompletionTokens != 2 || usage.PromptTokensDetails.CachedTokens != 4 {
+		t.Errorf("usage = %+v, want 9/2/4 from message_delta", usage)
+	}
+}

--- a/backend/migrations/1730000024_local_ocr_sdks.go
+++ b/backend/migrations/1730000024_local_ocr_sdks.go
@@ -45,13 +45,18 @@ func init() {
 	})
 }
 
-// priorSDKs is ValidSDKs without the sidecars: the list as it stood before
-// either of them existed. Derived so it cannot go stale against ValidSDKs the
-// way a written-out literal would.
+// priorSDKs is the SDK list as it stood before either sidecar existed.
+//
+// Written out, unlike the up-migration's aiprovider.ValidSDKs. A
+// down-migration's target is a historical fact, not a view of the current code,
+// and deriving it is what went wrong here before: it was "every SDK that
+// requires an API key", which quietly grew an entry the moment a keyed SDK was
+// added after the sidecars.
 func priorSDKs() []string {
-	return slices.DeleteFunc(slices.Clone(aiprovider.ValidSDKs), func(sdk string) bool {
-		return !aiprovider.RequiresAPIKey(sdk)
-	})
+	return []string{
+		aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter,
+		aiprovider.SDKGoogleVision, aiprovider.SDKMistral,
+	}
 }
 
 func setProviderSDKValues(app core.App, values []string) error {

--- a/backend/migrations/1730000026_opencode_provider.go
+++ b/backend/migrations/1730000026_opencode_provider.go
@@ -1,0 +1,83 @@
+package migrations
+
+import (
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+// Widens ai_providers.sdk to include opencode, and moves the rows that already
+// reach OpenCode Go onto it.
+//
+// The widening is the same reasoning as 1730000024 and 1730000025:
+// EnsureCollection builds the select field from ValidSDKs but returns an
+// existing collection untouched, which is every install past its first boot.
+//
+// The rows are the part specific to this SDK. Before it existed the only way to
+// reach OpenCode was an openai or openrouter row with base_url pointing at it,
+// and that is what .env.example shipped, so most installs have one. The header
+// OpenCode requires used to be sent to any host under opencode.ai; it is now
+// sent because the SDK says so, and a row left behind would stop carrying it --
+// which is what gets a request refused outright. Its models would also lose
+// their endpoint routing, and the /messages ones stop working entirely.
+func init() {
+	m.Register(func(app core.App) error {
+		// Values before rows: a row cannot be saved with an sdk the select
+		// field does not list yet.
+		if err := setProviderSDKValues(app, aiprovider.ValidSDKs); err != nil {
+			return err
+		}
+		return moveOpenCodeRows(app, openCodeCapableSDKs(), aiprovider.SDKOpenCode)
+	}, func(app core.App) error {
+		// Rows before values, as in 1730000024: a record whose sdk is no longer
+		// in Values fails validation on its next save. Back to openai, which is
+		// the SDK .env.example named and the one every such row had.
+		if err := moveOpenCodeRows(app, []string{aiprovider.SDKOpenCode}, aiprovider.SDKOpenAI); err != nil {
+			return err
+		}
+		return setProviderSDKValues(app, sdksWithoutOpenCode())
+	})
+}
+
+// openCodeCapableSDKs are the SDKs a row could have used to reach OpenCode: an
+// OpenAI-compatible client pointed at a base URL. Mistral is not one -- its
+// provider takes a different request shape -- and neither are the keyless
+// sidecars.
+func openCodeCapableSDKs() []string {
+	return []string{aiprovider.SDKOpenAI, aiprovider.SDKOpenRouter}
+}
+
+// moveOpenCodeRows rewrites the sdk of every provider row in from whose
+// base_url addresses OpenCode.
+//
+// Best-effort per row: one row that will not save is not a reason to strand the
+// install between two migrations, and the alias and credential are untouched
+// either way.
+func moveOpenCodeRows(app core.App, from []string, to string) error {
+	for _, sdk := range from {
+		records, err := app.FindAllRecords(aiprovider.CollectionName, dbx.HashExp{"sdk": sdk})
+		if err != nil {
+			continue
+		}
+		for _, record := range records {
+			if !aiprovider.IsOpenCodeURL(record.GetString("base_url")) {
+				continue
+			}
+			record.Set("sdk", to)
+			_ = app.Save(record)
+		}
+	}
+	return nil
+}
+
+func sdksWithoutOpenCode() []string {
+	out := make([]string, 0, len(aiprovider.ValidSDKs))
+	for _, sdk := range aiprovider.ValidSDKs {
+		if sdk != aiprovider.SDKOpenCode {
+			out = append(out, sdk)
+		}
+	}
+	return out
+}

--- a/backend/migrations/1730000026_opencode_provider.go
+++ b/backend/migrations/1730000026_opencode_provider.go
@@ -62,7 +62,10 @@ func moveOpenCodeRows(app core.App, from []string, to string) error {
 			continue
 		}
 		for _, record := range records {
-			if !aiprovider.IsOpenCodeURL(record.GetString("base_url")) {
+			// The same rule the environment reads, so a row and the variable
+			// that seeded it cannot disagree about what an openai SDK on an
+			// opencode.ai base URL means.
+			if aiprovider.NormalizeOpenCodeSDK(sdk, record.GetString("base_url")) != aiprovider.SDKOpenCode {
 				continue
 			}
 			record.Set("sdk", to)

--- a/backend/migrations/opencode_provider_test.go
+++ b/backend/migrations/opencode_provider_test.go
@@ -1,0 +1,117 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+func saveProvider(t *testing.T, app core.App, sdk, alias, baseURL string) *core.Record {
+	t.Helper()
+	collection, err := app.FindCollectionByNameOrId(aiprovider.CollectionName)
+	if err != nil {
+		t.Fatalf("providers collection: %v", err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("sdk", sdk)
+	record.Set("alias", alias)
+	record.Set("base_url", baseURL)
+	record.Set("api_key", "test-key")
+	if err := app.Save(record); err != nil {
+		t.Fatalf("save a %s provider: %v", sdk, err)
+	}
+	return record
+}
+
+// The rows this migration exists for: before SDKOpenCode the only way to reach
+// OpenCode was an openai row with a base URL, which is what .env.example
+// shipped. Left behind, such a row stops sending the x-opencode-session header
+// -- which gets requests refused -- and loses its endpoint routing.
+func TestOpenCodeRowsAreMovedOntoTheSDK(t *testing.T) {
+	app := bootMigratedApp(t)
+
+	moved := saveProvider(t, app, aiprovider.SDKOpenAI, "Zen", "https://opencode.ai/zen/go/v1")
+	viaRouter := saveProvider(t, app, aiprovider.SDKOpenRouter, "Zen via OpenRouter", "https://api.opencode.ai/zen/go/v1")
+	// Left alone: a real OpenAI row, and one whose path merely mentions the name.
+	kept := saveProvider(t, app, aiprovider.SDKOpenAI, "OpenAI", "https://api.openai.com/v1")
+	lookalike := saveProvider(t, app, aiprovider.SDKOpenAI, "Lookalike", "https://gateway.example.com/opencode.ai/v1")
+
+	if err := moveOpenCodeRows(app, openCodeCapableSDKs(), aiprovider.SDKOpenCode); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	for _, tc := range []struct {
+		record *core.Record
+		want   string
+	}{
+		{moved, aiprovider.SDKOpenCode},
+		{viaRouter, aiprovider.SDKOpenCode},
+		{kept, aiprovider.SDKOpenAI},
+		{lookalike, aiprovider.SDKOpenAI},
+	} {
+		reloaded, err := app.FindRecordById(aiprovider.CollectionName, tc.record.Id)
+		if err != nil {
+			t.Fatalf("reload %s: %v", tc.record.GetString("alias"), err)
+		}
+		if got := reloaded.GetString("sdk"); got != tc.want {
+			t.Errorf("%s: sdk = %q, want %q", tc.record.GetString("alias"), got, tc.want)
+		}
+		// The credential and the alias are the operator's; only the SDK moves.
+		if reloaded.GetString("api_key") != "test-key" {
+			t.Errorf("%s: the API key did not survive the move", tc.record.GetString("alias"))
+		}
+	}
+}
+
+// Managed instances re-run migrations on every boot, so both halves have to be
+// no-ops once applied -- and the up half has to be safe on an install that
+// already had an opencode row.
+func TestTheOpenCodeMigrationIsIdempotent(t *testing.T) {
+	app := bootMigratedApp(t)
+	record := saveProvider(t, app, aiprovider.SDKOpenAI, "Zen", "https://opencode.ai/zen/go/v1")
+
+	for i := 0; i < 2; i++ {
+		if err := setProviderSDKValues(app, aiprovider.ValidSDKs); err != nil {
+			t.Fatalf("widen (pass %d): %v", i, err)
+		}
+		if err := moveOpenCodeRows(app, openCodeCapableSDKs(), aiprovider.SDKOpenCode); err != nil {
+			t.Fatalf("move (pass %d): %v", i, err)
+		}
+	}
+
+	reloaded, err := app.FindRecordById(aiprovider.CollectionName, record.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.GetString("sdk"); got != aiprovider.SDKOpenCode {
+		t.Fatalf("sdk = %q, want %q", got, aiprovider.SDKOpenCode)
+	}
+}
+
+// The down half puts the rows back before narrowing the field, or their next
+// save would fail the collection's own select validation.
+func TestTheOpenCodeMigrationReversesInTheRightOrder(t *testing.T) {
+	app := bootMigratedApp(t)
+	record := saveProvider(t, app, aiprovider.SDKOpenCode, "Zen", "https://opencode.ai/zen/go/v1")
+
+	if err := moveOpenCodeRows(app, []string{aiprovider.SDKOpenCode}, aiprovider.SDKOpenAI); err != nil {
+		t.Fatalf("move back: %v", err)
+	}
+	if err := setProviderSDKValues(app, sdksWithoutOpenCode()); err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+
+	reloaded, err := app.FindRecordById(aiprovider.CollectionName, record.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.GetString("sdk"); got != aiprovider.SDKOpenAI {
+		t.Fatalf("sdk = %q, want %q", got, aiprovider.SDKOpenAI)
+	}
+	// And it still saves, which is the whole reason for the order.
+	if err := app.Save(reloaded); err != nil {
+		t.Fatalf("save after narrowing: %v", err)
+	}
+}

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -329,11 +329,14 @@ size, memory, GPU variants and the per-page cost — is in
   SDK carries the table. On any other SDK every model goes to
   `/chat/completions`, and two thirds of the catalogue is not there.
 
-  An install that predates the SDK is moved onto it on the first boot after the
-  upgrade — a provider whose base URL addresses `opencode.ai` has its SDK
-  rewritten — so this only bites a row created by hand afterwards. The same
-  applies to the `x-opencode-session` header, which Opencode requires and which
-  only the `opencode` SDK sends.
+  An install that predates the SDK needs no edit: `AI_SDK=openai` with a base
+  URL addressing `opencode.ai` is *read* as `AI_SDK=opencode`, and the provider
+  row it seeded is moved onto that SDK by migration `1730000026`. Both halves
+  matter — a managed instance re-applies its environment on every boot, so the
+  row alone would be moved straight back. So this only bites a row created by
+  hand afterwards, or one pointed at Opencode through a URL that hides the
+  host. The same applies to the `x-opencode-session` header, which Opencode
+  requires and which only the `opencode` SDK sends.
 
   The routing, for reference. A model Lemmary has not heard of goes to
   `/chat/completions`, which is the endpoint whose refusal names the problem:

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -12,6 +12,7 @@ to use.
 
 | Provider | Language model | OCR | Embeddings |
 | --- | --- | --- | --- |
+| **Opencode Go** — `opencode` | ✅ **a catalogue of models on one subscription** | ✅ models that accept files/images | ❌ |
 | **`mistral`** | ✅ chat completions | ✅ dedicated Document OCR API | ✅ `mistral-embed` |
 | `openai` | ✅ | ✅ models that accept files/images | ✅ |
 | `openrouter` | ✅ many vendors on one key | ✅ models advertising `file` input | ✅ |
@@ -30,8 +31,26 @@ purpose-built document endpoint rather than a general model asked to read a
 scan, and its catalogue advertises per-model capabilities, so the Settings model
 pickers show the right models instead of the whole catalogue.
 
+**Or start with Opencode Go**, if a subscription suits you better than metered
+keys: `AI_SDK=opencode` and a key is the whole configuration, and it covers
+extraction, chat, Deep Search and OCR across a catalogue of models from several
+vendors. It does not embed — see the bullet below — so Deep Search matches
+keywords until you add a second provider for that.
+
 The alternatives are worth naming:
 
+- **Opencode Go** — one subscription across a catalogue of models (GLM, Kimi,
+  DeepSeek, Qwen, MiniMax, Grok and more). Unlike every other SDK here it does
+  not serve one API: each model lives on `/chat/completions`, `/responses` or
+  Anthropic's `/messages`, and which one is a property of the model that the
+  catalogue does not report — so Lemmary carries the table and speaks all three.
+  That is also why it is its own SDK rather than `openai` with a base URL: on
+  any other SDK every model goes to `/chat/completions`, where two thirds of the
+  catalogue is not served, and the `x-opencode-session` header it requires would
+  not be sent. Embeddings are refused, as for a ChatGPT seat: the gateway has no
+  `/embeddings` and the catalogue has no embedding model, so pair it with
+  `AI_EMBEDDING_SDK=local` or a metered key if you want meaning-based retrieval.
+  Its SDK value is `opencode`.
 - **`openai`** — pick this when you already have a key, or to point
   `AI_BASE_URL` at an OpenAI-compatible gateway or a self-hosted endpoint. Its
   `/v1/models` describes nothing, so the model pickers show the full catalogue
@@ -111,15 +130,15 @@ after that.
 | --- | --- | --- |
 | `AI_MANAGED` | `0` | Whether the operator owns AI configuration. See the table above. |
 | `AI_CHATGPT_LOGIN` | `0` | Whether **Settings** offers the ChatGPT subscription SDK (`chatgpt`), which bills a ChatGPT subscription instead of a metered key. Off unless set, and refused together with `AI_MANAGED=1`. It is not an `AI_SDK` value: the provider is added and signed in to from Settings, because its credential is minted rather than typed. See [ChatGPT sign-in](/chatgpt_login). |
-| `AI_SDK` | `openai` | The language model's SDK: `openai`, `openrouter` or `mistral`. `google_vision`, `docling` (Local OCR) and `local` (Local Embeddings) are refused — none of them can serve extraction. `chatgpt` too: it has no key to seed from the environment. |
+| `AI_SDK` | `openai` | The language model's SDK: `opencode`, `openai`, `openrouter` or `mistral`. `google_vision`, `docling` (Local OCR) and `local` (Local Embeddings) are refused — none of them can serve extraction. `chatgpt` too: it has no key to seed from the environment. |
 | `AI_API_KEY` | empty | Its credential. **One key is usually the whole configuration**: with this and nothing else the app creates one provider and routes extraction, chat, Deep Search *and* OCR to it. |
 | `AI_MODEL` | `gpt-5.6-luna` | The model for extraction, chat and Deep Search. Be sure it supports the result language set in **Settings**. |
-| `AI_BASE_URL` | the SDK's own endpoint | An OpenAI-compatible base URL, for a gateway or a self-hosted endpoint. |
-| `OCR_SDK` | unset (OCR runs on the `AI_SDK` provider) | A separate provider for OCR: `openai`, `openrouter`, `mistral`, `google_vision` or `docling` (Local OCR). `local` (Local Embeddings) is refused — it serves embeddings only. `chatgpt` reads documents but is refused here too: it is signed in to from Settings rather than given a key, so the environment has nothing to seed it with. Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. |
+| `AI_BASE_URL` | the SDK's own endpoint | An OpenAI-compatible base URL, for a gateway or a self-hosted endpoint. Leave it unset for `opencode`, whose own endpoint is `https://opencode.ai/zen/go/v1`. |
+| `OCR_SDK` | unset (OCR runs on the `AI_SDK` provider) | A separate provider for OCR: `opencode`, `openai`, `openrouter`, `mistral`, `google_vision` or `docling` (Local OCR). `local` (Local Embeddings) is refused — it serves embeddings only. `chatgpt` reads documents but is refused here too: it is signed in to from Settings rather than given a key, so the environment has nothing to seed it with. Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. |
 | `OCR_API_KEY` | `AI_API_KEY` when the SDKs match | Its credential. Required for an OCR SDK that differs from `AI_SDK` — except Local OCR (`docling`), which has no account behind it. Optional there, and only if you started the sidecar with `DOCLING_SERVE_API_KEY`. |
 | `OCR_BASE_URL` | `AI_BASE_URL` when the SDKs match, else the SDK's own endpoint | Where that provider lives. For Local OCR (`docling`) the default is the compose service name, `http://docling:5001`, so `OCR_SDK=docling` alone is a complete configuration under the overlay. |
 | `OCR_MODEL` | `AI_MODEL` when the SDKs match | Its model. Not required for `google_vision` or Local OCR (`docling`), which read a document without one; for Local OCR it optionally names the OCR engine instead. See [Choosing an engine](/local_ocr#choosing-an-engine). |
-| `AI_EMBEDDING_MODEL` | unset (Deep Search matches keywords only) | An embedding model — on the `AI_SDK` provider, or on the `AI_EMBEDDING_SDK` one when that is set — so Deep Search can also find documents by meaning. Operator-owned under `AI_MANAGED=1`; removing it there turns the feature off. See [what embeddings cost](#what-embeddings-cost). |
+| `AI_EMBEDDING_MODEL` | unset (Deep Search matches keywords only) | An embedding model — on the `AI_SDK` provider, or on the `AI_EMBEDDING_SDK` one when that is set — so Deep Search can also find documents by meaning. Under `AI_SDK=opencode` it requires `AI_EMBEDDING_SDK`: Opencode serves no `/embeddings`, so there is no provider to fall back to, and naming a model without one is refused at boot. Operator-owned under `AI_MANAGED=1`; removing it there turns the feature off. See [what embeddings cost](#what-embeddings-cost). |
 | `AI_SEARCH_HELPER_MODEL` | unset (the Search model does this work) | A cheaper model on the `AI_SDK` provider for Deep Search's bulk per-document work: distilling long reads into notes and surveying many documents for one question. Operator-owned under `AI_MANAGED=1`. See [How Research covers a topic](/setup#how-research-covers-a-topic). |
 
 ### The embedding provider
@@ -138,7 +157,7 @@ which has always been how a second provider for one job is described.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `AI_EMBEDDING_SDK` | unset (embeddings run on the `AI_SDK` provider) | A separate provider for embeddings: `openai`, `openrouter`, `mistral` or `local` (Local Embeddings). Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. `google_vision` and `docling` (Local OCR) are refused — neither has an `/embeddings` endpoint. |
+| `AI_EMBEDDING_SDK` | unset (embeddings run on the `AI_SDK` provider) | A separate provider for embeddings: `openai`, `openrouter`, `mistral` or `local` (Local Embeddings). Naming the same SDK as `AI_SDK` reuses that key and endpoint and only changes the model. `google_vision`, `docling` (Local OCR), `opencode` and `chatgpt` are refused — none of them has an `/embeddings` endpoint. Required rather than optional when `AI_SDK` is one of the last two and `AI_EMBEDDING_MODEL` is set. |
 | `AI_EMBEDDING_API_KEY` | `AI_API_KEY` when the SDKs match | Its credential. Required for an SDK that differs from `AI_SDK`, **except Local Embeddings (`local`)**, which takes none. |
 | `AI_EMBEDDING_BASE_URL` | the SDK's own endpoint, or `AI_BASE_URL` when the SDKs match | Where that provider lives. For Local Embeddings (`local`) this defaults to `http://embeddings:80/v1`, the compose overlay's service. |
 
@@ -303,20 +322,37 @@ size, memory, GPU variants and the per-page cost — is in
   [Local OCR](/local_ocr#what-it-costs).
 - **AI extraction fails** — check that an extraction model is bound and that it
   is a chat model, not an embedding or OCR model.
-- **A model in the picker answers every request with a 500** — some models are
-  served only by the OpenAI *Responses* API, and their gateway returns a bare
-  500 on `/chat/completions` even for a one-word prompt. OpenCode Zen routes
-  `gpt-5.6-luna`, `grok-4.6` and the `muse-spark` models that way. Lemmary
-  discovers this by itself, and nothing needs configuring: a refused request is
-  translated and sent again to `/responses`, so it still succeeds, and once the
-  model is known to live there every later request goes straight to it. The log
-  line is `chat completions refused this model; retrying on the Responses API`.
-  A 401 or 403 settles it at once; a 500 takes two, because a 500 is also what
-  any provider returns when it is simply having a bad minute, and one hiccup
-  should not reroute a model for the life of the process. An endpoint that has
-  already answered for a model is never rerouted at all. What is learned is
-  remembered per provider, so the same model name behind two providers is
-  discovered separately.
+- **An `opencode` model answers every request with a 500 or a 404** — check that
+  the SDK really is `opencode` and not `openai` with `AI_BASE_URL` pointed at it.
+  Opencode Go serves each model on one of three endpoints, and which one is a
+  property of the model that its catalogue does not report, so the `opencode`
+  SDK carries the table. On any other SDK every model goes to
+  `/chat/completions`, and two thirds of the catalogue is not there.
+
+  An install that predates the SDK is moved onto it on the first boot after the
+  upgrade — a provider whose base URL addresses `opencode.ai` has its SDK
+  rewritten — so this only bites a row created by hand afterwards. The same
+  applies to the `x-opencode-session` header, which Opencode requires and which
+  only the `opencode` SDK sends.
+
+  The routing, for reference. A model Lemmary has not heard of goes to
+  `/chat/completions`, which is the endpoint whose refusal names the problem:
+
+  | Endpoint | Models |
+  | --- | --- |
+  | `/chat/completions` | `glm-*`, `kimi-*`, `longcat-*`, `deepseek-*`, `mimo-*`, `hy*`, `omen-*` |
+  | `/responses` | `grok-*`, `gpt-5.6-luna`, `muse-spark-*` |
+  | `/messages` (Anthropic's API) | `minimax-*`, `qwen*` |
+
+- **A `gpt-5`-family model refuses a Deep Search request** — those models set
+  `reasoning_effort` themselves and then reject the request because function
+  tools are present. Lemmary handles it without configuration: the request is
+  translated to the *Responses* API, which keeps both the tools and the
+  reasoning, and falls back to `reasoning_effort=none` only if that endpoint
+  cannot serve it either. The log line is `model rejected reasoning_effort with
+  function tools; retrying on the Responses API`. What is learned is remembered
+  per provider, so the same model name behind two providers is discovered
+  separately.
 - **A managed instance will not start** — the log names the missing or invalid
   variable in the provider block; nothing inside the instance can repair it.
 - **Local Embeddings embeds nothing** — `docker compose logs embeddings`. On a

--- a/frontend/src/lib/api/providers.test.ts
+++ b/frontend/src/lib/api/providers.test.ts
@@ -35,12 +35,16 @@ describe('SDK capabilities', () => {
       expect(isLLMProvider(sdk)).toBe(true)
       expect(canEmbedProvider(sdk)).toBe(true)
     }
+    // opencode chats but serves no /embeddings, so it is an LLM SDK that is
+    // not an embedding one. Mirrors aiprovider.CanEmbed.
+    expect(isLLMProvider('opencode')).toBe(true)
+    expect(canEmbedProvider('opencode')).toBe(false)
   })
 
   it('asks for a key everywhere but the two sidecars', () => {
     expect(requiresAPIKey('local')).toBe(false)
     expect(requiresAPIKey('docling')).toBe(false)
-    for (const sdk of ['openai', 'openrouter', 'mistral', 'google_vision']) {
+    for (const sdk of ['openai', 'openrouter', 'mistral', 'opencode', 'google_vision']) {
       expect(requiresAPIKey(sdk)).toBe(true)
     }
     // Default-true like the Go side, so an unknown SDK still asks.
@@ -170,7 +174,7 @@ describe('the ChatGPT subscription SDK', () => {
   it('signs in instead of taking a key', () => {
     expect(requiresSignIn('chatgpt')).toBe(true)
     expect(requiresAPIKey('chatgpt')).toBe(false)
-    for (const sdk of ['openai', 'openrouter', 'mistral', 'google_vision', 'local', 'docling']) {
+    for (const sdk of ['openai', 'openrouter', 'mistral', 'opencode', 'google_vision', 'local', 'docling']) {
       expect(requiresSignIn(sdk)).toBe(false)
     }
   })

--- a/frontend/src/lib/api/providers.ts
+++ b/frontend/src/lib/api/providers.ts
@@ -5,6 +5,7 @@ export type ProviderSDK =
   | 'openrouter'
   | 'google_vision'
   | 'mistral'
+  | 'opencode'
   | 'chatgpt'
   | 'local'
   | 'docling'
@@ -47,6 +48,7 @@ export const SDK_DEFAULT_BASE: Record<ProviderSDK, string> = {
   openai: 'https://api.openai.com/v1',
   openrouter: 'https://openrouter.ai/api/v1',
   mistral: 'https://api.mistral.ai/v1',
+  opencode: 'https://opencode.ai/zen/go/v1',
   google_vision: '',
   // Not a /v1 root: the Codex backend serves one endpoint, and the middleware
   // behind this SDK rewrites the SDK's /chat/completions into it.
@@ -61,6 +63,7 @@ export const SDK_OPTIONS: { value: ProviderSDK; label: string }[] = [
   { value: 'openai', label: 'OpenAI' },
   { value: 'openrouter', label: 'OpenRouter' },
   { value: 'mistral', label: 'Mistral' },
+  { value: 'opencode', label: 'Opencode Go' },
   { value: 'google_vision', label: 'Google Cloud Vision' },
   { value: 'chatgpt', label: 'ChatGPT subscription' },
   { value: 'local', label: 'Local Embeddings (huggingface/text-embeddings-inference)' },
@@ -87,7 +90,13 @@ export function sdkAliasDefault(sdk: ProviderSDK | string) {
 }
 
 export function isLLMProvider(sdk: string) {
-  return sdk === 'openai' || sdk === 'openrouter' || sdk === 'mistral' || sdk === 'chatgpt'
+  return (
+    sdk === 'openai' ||
+    sdk === 'openrouter' ||
+    sdk === 'mistral' ||
+    sdk === 'opencode' ||
+    sdk === 'chatgpt'
+  )
 }
 
 /**
@@ -119,9 +128,9 @@ export function providerConfigured(
  * aiprovider.CanEmbed.
  */
 export function canEmbedProvider(sdk: string) {
-  // chatgpt is the second SDK to force these apart: it chats without embedding,
-  // because the Codex backend serves no /embeddings at all.
-  return (isLLMProvider(sdk) && sdk !== 'chatgpt') || sdk === 'local'
+  // chatgpt and opencode force these apart in the other direction: both chat
+  // without embedding, because neither endpoint serves /embeddings at all.
+  return (isLLMProvider(sdk) && sdk !== 'chatgpt' && sdk !== 'opencode') || sdk === 'local'
 }
 
 /**


### PR DESCRIPTION
Opencode Go is the provider this project recommends and its `gpt-5.6-luna` is `DefaultExtractModel`, yet it had no SDK id. You reached it with `AI_SDK=openai` and a base URL — which is what `.env.example` shipped, uncommented, contradicting its own comment. Two things Opencode needs were therefore guessed at rather than known, and a third could not be reached at all.

This adds the `opencode` SDK, which wraps two Go SDKs rather than one: `openai-go` for `/chat/completions` and `/responses`, `anthropic-sdk-go` for `/messages`. `internal/opencode` carries the routing table and the Messages translation; `internal/ai` does the routing.

## Routing

The endpoint is a property of the model, and `/v1/models` does not say — it answers `{id, object, created, owned_by}` and nothing else. So the table is static, by prefix rather than by the ~28 exact ids, and a model this build has never heard of goes to `/chat/completions`, the endpoint whose refusal names the problem.

| Endpoint | Models |
| --- | --- |
| `/chat/completions` | `glm-*`, `kimi-*`, `longcat-*`, `deepseek-*`, `mimo-*`, `hy*`, `omen-*` |
| `/responses` | `grok-*`, `gpt-5.6-luna`, `muse-spark-*` |
| `/messages` (Anthropic) | `minimax-*`, `qwen*` |

## What this replaces

**Error-shape discovery.** `classifyEndpointError` read a 500 as "maybe the wrong endpoint" and believed it on the second occurrence, backed by two `sync.Map`s of per-endpoint notes. That cost a rejected request per model per process — and could not reach `/messages` at all: a request in the wrong *shape* does not fail in a way any status code distinguishes. All of it is deleted. What remains in `responses.go` is the translation, still needed for OpenAI's own gpt-5 family, which refuses function tools alongside its server-side `reasoning_effort`.

**Hostname sniffing.** The `x-opencode-session` header — which Opencode requires, not prefers — was sent to any host under `opencode.ai`. That gate is why `RewriteHostMiddleware` existed: a second middleware whose only job was letting a test reach `httptest` with the host gate open. `SessionHost` and `RewriteHostMiddleware` are both gone; every client constructor installs `SessionMiddleware` only for this SDK.

**A duplicated client.** `ocr.LLMProvider` built an `openai.Client` of its own so it could call the package-level `ai.CompleteChat`. It now holds an `*ai.OpenAIClient`, and `CompleteChat` became the method `Complete` — so which endpoint a model is on, and which SDK speaks to it, has one owner instead of two.

## Upgrade path

Migration `1730000026` widens `ai_providers.sdk` and moves the rows that already reach Opencode. A provider whose `base_url` addresses `opencode.ai` stops carrying the session header the moment the gate becomes the SDK, and Opencode refuses requests that arrive without one — so leaving those rows behind would break working installs on upgrade. Values before rows on the way up, rows before values on the way down: a record whose `sdk` is not in the select field's `Values` fails validation on its next save.

## It does not embed

The gateway serves no `/embeddings` and the catalogue has no embedding model, so `CanEmbed` refuses it as it does `chatgpt`. Settings, the model pickers and `HasEmbedding` already asked `CanEmbed`, so they needed nothing — but it makes `AI_EMBEDDING_MODEL` alone ("embed on the `AI_SDK` provider") unavailable here. `config.parseEmbedding` now refuses that at boot and names the way out, rather than letting the binding read as configured while every document's embed step fails. Deep Search falls back to keyword retrieval, which is a working state.

## Deliberate choices in the Messages translation

- `max_tokens` is **required** by the Messages API and set by no caller in this codebase, so the translation has to invent one. Marked at the constant with its upgrade path.
- `response_format: json_object` has no equivalent — Anthropic's structured output wants a full schema, and these callers send none. It is dropped, exactly as the chat-completions path already drops it when a provider objects: every prompt already says "Return one JSON object" and every parser is lenient.

## Not verified against a real subscription

Whether `/messages` accepts the image and document blocks LLM OCR sends, and whether it takes `x-api-key`, `Authorization`, or either — documented shapes, undocumented auth, so both credentials are sent. Check there first if OCR on a `minimax` or `qwen` model returns empty or invented text.

## Unrelated fix, included

`priorSDKs()` in migration `1730000024` derived a *historical* SDK list from a live predicate ("every SDK that requires an API key"). A down-migration's target is a fact about the past, so it grew an entry the moment a keyed SDK shipped after the sidecars — and grew this one too, which is how it was noticed. Written out.

## Verification

`go build`, `go vet` and `go test ./...` green (with and without `-tags vectors`); frontend 198/198 and `tsc --noEmit` clean. New tests cover the routing table against every model id the docs list, the Messages translation (system hoisting, tool round trip, OCR image/PDF blocks, streaming, the session header, usage), the `NewOpenAIClient` wiring for all three endpoints, the migration in both directions, and the new env refusal.

Not exercised against a live Opencode subscription — see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
