### PR TITLE
Let a chat or a reprocess job run on a model other than the one in Settings

### DIFF
--- a/backend/internal/aiprovider/binding.go
+++ b/backend/internal/aiprovider/binding.go
@@ -1,0 +1,121 @@
+package aiprovider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Binding names a provider row and a model, as a per-request or per-job
+// replacement for one of the configured bindings in app_settings.
+//
+// A zero Binding means "use what Settings says", which is what every caller
+// sent before overrides existed -- so an absent field and the old behaviour are
+// the same thing, at every layer down to the stored job.
+type Binding struct {
+	ProviderID string `json:"provider_id"`
+	Model      string `json:"model"`
+}
+
+// Empty reports a binding that overrides nothing.
+//
+// Keyed on the provider id alone: a model with no provider is not half an
+// override, it is a request the resolver has to refuse. Treating it as empty
+// would silently run the configured model instead of the one that was asked
+// for, which is the one failure mode a picker must not have.
+func (b Binding) Empty() bool {
+	return strings.TrimSpace(b.ProviderID) == ""
+}
+
+// Normalized trims both fields, so a stored binding and one straight off the
+// wire compare equal.
+func (b Binding) Normalized() Binding {
+	return Binding{
+		ProviderID: strings.TrimSpace(b.ProviderID),
+		Model:      strings.TrimSpace(b.Model),
+	}
+}
+
+// Resolve loads the row a binding names and refuses one that cannot serve
+// purpose. It returns a nil provider for an empty binding, which is not an
+// error -- that is the "use Settings" case every caller starts from.
+//
+// This is the trust boundary: ProviderID arrives from a browser, on endpoints
+// any signed-in user may call, and it decides which of the operator's
+// credentials a request spends. Both halves are checked -- that the row is
+// configured, and that its SDK can do this job -- because either one wrong is
+// a request that fails deep inside a provider call with a message nobody can
+// act on.
+//
+// The model is not checked against the catalogue. Settings has always offered a
+// "Custom model id" field for exactly the model a provider added last week, so
+// a name absent from /v1/models is legitimate; a wrong one surfaces as a
+// provider error on the first call, as it does for the configured bindings.
+func Resolve(app core.App, b Binding, purpose ModelPurpose) (*Provider, string, error) {
+	b = b.Normalized()
+	if b.Empty() {
+		if b.Model != "" {
+			return nil, "", fmt.Errorf("a model override needs a provider")
+		}
+		return nil, "", nil
+	}
+
+	p, err := FindByID(app, b.ProviderID)
+	if err != nil || p == nil {
+		return nil, "", fmt.Errorf("unknown provider %q", b.ProviderID)
+	}
+	if !p.Configured() {
+		return nil, "", fmt.Errorf("provider %q is not configured", p.Alias)
+	}
+	if !ServesPurpose(p.SDK, purpose) {
+		return nil, "", fmt.Errorf("provider %q cannot serve %s requests; want one of %v",
+			p.Alias, purpose, PurposeSDKs(purpose))
+	}
+	if b.Model == "" && needsModel(p.SDK, purpose) {
+		return nil, "", fmt.Errorf("provider %q needs a model", p.Alias)
+	}
+	return p, b.Model, nil
+}
+
+// needsModel reports whether a binding on this SDK has to name one.
+//
+// Almost always yes: a client built with an empty model sends an empty model,
+// and what comes back is a provider error naming a field the user never saw.
+// The configured model is not a sensible fallback either -- it belongs to a
+// different provider, which need not serve it at all.
+//
+// The exception is the OCR binding on the two SDKs that read a document without
+// being told a model: Google Vision has none to give, and for the local sidecar
+// the field names an optional OCR engine rather than a model. Blank there is
+// the correct configuration, which is what RequiresOCRModel already encodes.
+func needsModel(sdk string, purpose ModelPurpose) bool {
+	if purpose == PurposeOCR {
+		return RequiresOCRModel(sdk)
+	}
+	return true
+}
+
+// ServesPurpose is the capability question the three predicates answer,
+// dispatched by purpose rather than asked by name.
+//
+// It exists so a caller holding a ModelPurpose -- the models endpoint, the
+// provider picker, Resolve -- does not switch on it itself. The frontend twin
+// is providerServesPurpose in lib/api/providers.ts.
+func ServesPurpose(sdk string, purpose ModelPurpose) bool {
+	switch purpose {
+	case PurposeOCR:
+		return CanOCR(sdk)
+	case PurposeEmbedding:
+		return CanEmbed(sdk)
+	default:
+		return IsLLM(sdk)
+	}
+}
+
+// PurposeSDKs names every SDK a purpose accepts, for the error messages that
+// have to list them. Derived through sdksWhere like LLMSDKs and its siblings,
+// so it cannot drift from the predicates.
+func PurposeSDKs(purpose ModelPurpose) []string {
+	return sdksWhere(func(sdk string) bool { return ServesPurpose(sdk, purpose) })
+}

--- a/backend/internal/aiprovider/binding_test.go
+++ b/backend/internal/aiprovider/binding_test.go
@@ -1,0 +1,239 @@
+package aiprovider
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func TestBindingEmpty(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		binding Binding
+		want    bool
+	}{
+		"zero":               {Binding{}, true},
+		"whitespace only":    {Binding{ProviderID: "  "}, true},
+		"provider":           {Binding{ProviderID: "p1"}, false},
+		"provider and model": {Binding{ProviderID: "p1", Model: "gpt-6-astra"}, false},
+		// Empty asks only whether a provider was named, which is what its
+		// callers -- the per-binding build guards in config.WithOverrides --
+		// need. A model with no provider reads as empty here and is refused by
+		// Resolve; config.Overrides.Empty is the one that must not use this
+		// answer, because it short-circuits before Resolve runs.
+		"model only": {Binding{Model: "gpt-6-astra"}, true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.binding.Empty(); got != tc.want {
+				t.Fatalf("Empty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBindingNormalized(t *testing.T) {
+	t.Parallel()
+	got := Binding{ProviderID: "  p1 ", Model: "\tgpt-6-astra\n"}.Normalized()
+	if got != (Binding{ProviderID: "p1", Model: "gpt-6-astra"}) {
+		t.Fatalf("Normalized() = %+v", got)
+	}
+}
+
+func TestServesPurpose(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		sdk     string
+		purpose ModelPurpose
+		want    bool
+	}{
+		"openai chats":                {SDKOpenAI, PurposeLLM, true},
+		"openai reads documents":      {SDKOpenAI, PurposeOCR, true},
+		"openai embeds":               {SDKOpenAI, PurposeEmbedding, true},
+		"chatgpt chats":               {SDKChatGPT, PurposeLLM, true},
+		"chatgpt cannot embed":        {SDKChatGPT, PurposeEmbedding, false},
+		"google vision only reads":    {SDKGoogleVision, PurposeOCR, true},
+		"google vision cannot chat":   {SDKGoogleVision, PurposeLLM, false},
+		"docling only reads":          {SDKDocling, PurposeOCR, true},
+		"docling cannot embed":        {SDKDocling, PurposeEmbedding, false},
+		"local embeddings only embed": {SDKLocalEmbeddings, PurposeEmbedding, true},
+		"local cannot chat":           {SDKLocalEmbeddings, PurposeLLM, false},
+		"local cannot read":           {SDKLocalEmbeddings, PurposeOCR, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := ServesPurpose(tc.sdk, tc.purpose); got != tc.want {
+				t.Fatalf("ServesPurpose(%q, %q) = %v, want %v", tc.sdk, tc.purpose, got, tc.want)
+			}
+		})
+	}
+}
+
+// The lists an error message is built from have to agree with the predicate it
+// is explaining, which is why they are derived rather than written out.
+func TestPurposeSDKsMatchTheDerivedLists(t *testing.T) {
+	t.Parallel()
+	if got, want := PurposeSDKs(PurposeLLM), LLMSDKs(); !slices.Equal(got, want) {
+		t.Fatalf("PurposeSDKs(llm) = %v, want %v", got, want)
+	}
+	if got, want := PurposeSDKs(PurposeOCR), OCRSDKs(); !slices.Equal(got, want) {
+		t.Fatalf("PurposeSDKs(ocr) = %v, want %v", got, want)
+	}
+	if got, want := PurposeSDKs(PurposeEmbedding), EmbeddingSDKs(); !slices.Equal(got, want) {
+		t.Fatalf("PurposeSDKs(embedding) = %v, want %v", got, want)
+	}
+}
+
+func bootAppForBinding(t *testing.T) *pocketbase.PocketBase {
+	t.Helper()
+	app := pocketbase.NewWithConfig(pocketbase.Config{
+		DefaultDataDir:  t.TempDir(),
+		HideStartBanner: true,
+	})
+	if err := app.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = app.ResetBootstrapState() })
+	if _, err := EnsureCollection(app); err != nil {
+		t.Fatalf("ensure %s: %v", CollectionName, err)
+	}
+	return app
+}
+
+func saveProvider(t *testing.T, app core.App, sdk, alias, apiKey, baseURL string) string {
+	t.Helper()
+	collection, err := app.FindCollectionByNameOrId(CollectionName)
+	if err != nil {
+		t.Fatalf("%s collection: %v", CollectionName, err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("sdk", sdk)
+	record.Set("alias", alias)
+	record.Set("api_key", apiKey)
+	record.Set("base_url", baseURL)
+	if err := app.Save(record); err != nil {
+		t.Fatalf("save provider %q: %v", alias, err)
+	}
+	return record.Id
+}
+
+// Resolve is the trust boundary: the provider id arrives from a browser, on
+// endpoints any signed-in user may call, and it decides which of the operator's
+// credentials a request spends.
+func TestResolve(t *testing.T) {
+	app := bootAppForBinding(t)
+
+	openAI := saveProvider(t, app, SDKOpenAI, "OpenAI", "sk-test", "https://api.openai.com/v1")
+	keyless := saveProvider(t, app, SDKOpenAI, "OpenAI unconfigured", "", "https://api.openai.com/v1")
+	// A sidecar is configured by address alone, with no key to check.
+	sidecar := saveProvider(t, app, SDKLocalEmbeddings, "Local embeddings", "", "http://embeddings:80/v1")
+	defaulted := saveProvider(t, app, SDKDocling, "Docling on its default address", "", "")
+
+	cases := map[string]struct {
+		binding Binding
+		purpose ModelPurpose
+		wantErr bool
+	}{
+		"empty binding is not an error": {
+			binding: Binding{},
+			purpose: PurposeLLM,
+		},
+		"a capable configured provider": {
+			binding: Binding{ProviderID: openAI, Model: "gpt-6-astra"},
+			purpose: PurposeLLM,
+		},
+		// The model is not checked against the catalogue: Settings has always
+		// had a "Custom model id" field for the model a provider added last
+		// week, and a wrong name surfaces as a provider error on first use.
+		"a model absent from any catalogue": {
+			binding: Binding{ProviderID: openAI, Model: "gpt-nonesuch-9"},
+			purpose: PurposeLLM,
+		},
+		"an unknown provider id": {
+			binding: Binding{ProviderID: "nosuchprovider", Model: "gpt-6-astra"},
+			purpose: PurposeLLM,
+			wantErr: true,
+		},
+		"a provider with no credential": {
+			binding: Binding{ProviderID: keyless, Model: "gpt-6-astra"},
+			purpose: PurposeLLM,
+			wantErr: true,
+		},
+		// Configured, keyless, and still wrong for this binding: the SDK that
+		// embeds without chatting is the one a capability check has to catch,
+		// because a key check never would.
+		"a configured sidecar bound to chat": {
+			binding: Binding{ProviderID: sidecar, Model: "bge-m3"},
+			purpose: PurposeLLM,
+			wantErr: true,
+		},
+		"the same sidecar bound to embedding": {
+			binding: Binding{ProviderID: sidecar, Model: "bge-m3"},
+			purpose: PurposeEmbedding,
+		},
+		// A sidecar row saved with a blank address is still configured:
+		// FromRecord normalizes it to DefaultBaseURL, which is the compose
+		// service name. So there is no "unreachable sidecar" to refuse here --
+		// an address that answers nothing is a request error, not a binding one.
+		"a sidecar left on its default address": {
+			binding: Binding{ProviderID: defaulted, Model: "rapidocr"},
+			purpose: PurposeOCR,
+		},
+		"a model with no provider": {
+			binding: Binding{Model: "gpt-6-astra"},
+			purpose: PurposeLLM,
+			wantErr: true,
+		},
+		// The other half-filled pair. An empty model reaches the provider as an
+		// empty model, and the configured one is no fallback: it belongs to a
+		// different provider, which need not serve it at all.
+		"a provider with no model": {
+			binding: Binding{ProviderID: openAI},
+			purpose: PurposeLLM,
+			wantErr: true,
+		},
+		"an embedding provider with no model": {
+			binding: Binding{ProviderID: sidecar},
+			purpose: PurposeEmbedding,
+			wantErr: true,
+		},
+		// The exception: these two read a document without being told a model,
+		// so blank is the correct configuration rather than a missing field.
+		"an OCR SDK that needs no model": {
+			binding: Binding{ProviderID: defaulted},
+			purpose: PurposeOCR,
+		},
+		"an OCR SDK that does need one": {
+			binding: Binding{ProviderID: openAI},
+			purpose: PurposeOCR,
+			wantErr: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p, model, err := Resolve(app, tc.binding, tc.purpose)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Resolve() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if tc.binding.Empty() {
+				if p != nil {
+					t.Fatalf("Resolve() of an empty binding returned provider %+v", p)
+				}
+				return
+			}
+			if p == nil {
+				t.Fatal("Resolve() returned no provider and no error")
+			}
+			if model != tc.binding.Normalized().Model {
+				t.Fatalf("model = %q, want %q", model, tc.binding.Model)
+			}
+		})
+	}
+}

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tools/hook"
+	"lemmary/backend/internal/aiprovider"
 	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/fulltext"
 	"lemmary/backend/internal/limits"
@@ -61,12 +62,13 @@ func Register(
 			g.GET("/chats/{id}", bindAuth(handleGetChat(app)))
 			g.PATCH("/chats/{id}", bindAuth(handlePatchChat(app)))
 			g.DELETE("/chats/{id}", bindAuth(handleDeleteChat(app)))
-			g.GET("/ocr/providers", bindAuth(handlePickableProviders(app, rt)))
+			// The OCR test page sends no purpose and means OCR.
+			g.GET("/ocr/providers", bindAuth(handlePickableProviders(app, rt, aiprovider.PurposeOCR)))
 			// The same list for any purpose, for the model pickers on a chat and
 			// on a reprocess job. Auth rather than admin: an override is a
 			// per-user choice among providers an admin already configured, and
 			// this answer carries no credential -- see pickableProvider.
-			g.GET("/ai/providers", bindAuth(handlePickableProviders(app, rt)))
+			g.GET("/ai/providers", bindAuth(handlePickableProviders(app, rt, aiprovider.PurposeLLM)))
 			// Without a route-level limit the multipart parse consumes the whole
 			// request under PocketBase's 32MB default before the handler's own
 			// 10MB check can reject it.

--- a/backend/internal/appapi/appapi.go
+++ b/backend/internal/appapi/appapi.go
@@ -48,7 +48,7 @@ func Register(
 			g.GET("/documents/export", bindAuth(handleExportDocuments(app)))
 			g.GET("/documents/search", bindAuth(handleDocumentSearch(app, idx)))
 			g.GET("/documents/timeline", bindAuth(handleDocumentsTimeline(app)))
-			g.POST("/documents/reprocess-failed", bindAuth(handlePostReprocessFailed(app)))
+			g.POST("/documents/reprocess-failed", bindAuth(handlePostReprocessFailed(app, rt)))
 			g.POST("/search", bindAuth(handleDeepSearch(app, rt, idx))).
 				Bind(apis.BodyLimit(chatMaxBodyBytes))
 			g.POST("/search/stream", bindAuth(handleSearchStream(app, rt, idx))).
@@ -61,7 +61,12 @@ func Register(
 			g.GET("/chats/{id}", bindAuth(handleGetChat(app)))
 			g.PATCH("/chats/{id}", bindAuth(handlePatchChat(app)))
 			g.DELETE("/chats/{id}", bindAuth(handleDeleteChat(app)))
-			g.GET("/ocr/providers", bindAuth(handleOCRProviders(app, rt)))
+			g.GET("/ocr/providers", bindAuth(handlePickableProviders(app, rt)))
+			// The same list for any purpose, for the model pickers on a chat and
+			// on a reprocess job. Auth rather than admin: an override is a
+			// per-user choice among providers an admin already configured, and
+			// this answer carries no credential -- see pickableProvider.
+			g.GET("/ai/providers", bindAuth(handlePickableProviders(app, rt)))
 			// Without a route-level limit the multipart parse consumes the whole
 			// request under PocketBase's 32MB default before the handler's own
 			// 10MB check can reject it.
@@ -76,7 +81,10 @@ func Register(
 			g.POST("/providers", bindAdmin(handleCreateProvider(app, rt)))
 			g.PATCH("/providers/{id}", bindAdmin(handlePatchProvider(app, rt)))
 			g.DELETE("/providers/{id}", bindAdmin(handleDeleteProvider(app, rt)))
-			g.GET("/providers/{id}/models", bindAdmin(handleListProviderModels(app)))
+			// Auth rather than admin, unlike the rest of /providers: a model picker
+			// is useless without the catalogue, and the answer is model ids and an
+			// SDK name -- no key, no account, no base URL.
+			g.GET("/providers/{id}/models", bindAuth(handleListProviderModels(app)))
 			// Device-code sign-in for the chatgpt SDK. Two calls rather than
 			// one blocking handler: the browser owns the polling interval.
 			g.POST("/providers/{id}/chatgpt/device", bindAdmin(handleChatGPTDeviceStart(app, rt)))

--- a/backend/internal/appapi/chat.go
+++ b/backend/internal/appapi/chat.go
@@ -26,6 +26,55 @@ const tooManySessionsMessage = "You have reached the maximum number of saved cha
 type chatRequest struct {
 	SessionID string `json:"session_id"`
 	Content   string `json:"content"`
+	// The provider and model to open the conversation on, instead of the chat
+	// binding in Settings. Read only when SessionID is empty: see
+	// conversationBinding.
+	ProviderID string `json:"provider_id"`
+	Model      string `json:"model"`
+}
+
+// conversationBinding decides which provider and model a turn runs on.
+//
+// An existing conversation runs on the one stored with it, and what the request
+// carries is ignored. The transcript replayed below was produced by that model,
+// and answering the next question with another one reads that work back as if
+// it were its own -- the same argument the search mode conflict makes a few
+// lines further down in search.go.
+//
+// Ignored rather than refused, unlike a mode mismatch. There the client is
+// choosing, and a disagreement means the two have drifted; here it is echoing
+// the binding it loaded with the session, and a stale echo is not a mistake
+// worth failing a question over.
+func conversationBinding(session *core.Record, requested aiprovider.Binding) aiprovider.Binding {
+	if session != nil {
+		return chat.BindingOf(session)
+	}
+	return requested.Normalized()
+}
+
+// recordedBinding is the binding a conversation is opened with: the override
+// when one was chosen, and otherwise the configured pair spelled out.
+//
+// Spelling it out is the point. A conversation that stored nothing followed
+// Settings for the rest of its life, so changing the chat model moved every
+// old conversation onto the new one -- mid-transcript, with the answers above
+// produced by a model that was no longer answering. That is the same
+// inconsistency the pinning rule exists to prevent; it was simply invisible
+// because the binding was never written down.
+//
+// Both halves or neither: a provider with no model is refused by
+// aiprovider.Resolve, so stamping half a pair on a part-configured instance
+// would turn a chat that used to work into a 400. Nothing stored means "follow
+// Settings", which is what those instances did before.
+func recordedBinding(requested aiprovider.Binding, providerID, model string) aiprovider.Binding {
+	if !requested.Empty() {
+		return requested.Normalized()
+	}
+	configured := aiprovider.Binding{ProviderID: providerID, Model: model}.Normalized()
+	if configured.Empty() || configured.Model == "" {
+		return aiprovider.Binding{}
+	}
+	return configured
 }
 
 type chatResponse struct {
@@ -167,11 +216,6 @@ func handleDocumentChat(app core.App, rt *config.Runtime) func(*core.RequestEven
 			return writeError(e, http.StatusBadRequest, err.Error())
 		}
 
-		chatter := rt.Snapshot().Chatter
-		if chatter == nil {
-			return writeError(e, http.StatusServiceUnavailable, "AI chat is not configured; update Settings.")
-		}
-
 		ownerID, err := resolveOwnerUserID(app, e)
 		if err != nil {
 			return writeOwnerError(e, err)
@@ -182,6 +226,22 @@ func handleDocumentChat(app core.App, rt *config.Runtime) func(*core.RequestEven
 			return writeChatSessionError(e, app, err)
 		}
 		messages := append(history, ai.ChatMessage{Role: chat.RoleUser, Content: content})
+
+		// Resolved after the session is loaded, because a continued
+		// conversation's stored binding is what decides, not the request's.
+		cfg := rt.Snapshot().Cfg
+		binding := conversationBinding(session, recordedBinding(
+			aiprovider.Binding{ProviderID: req.ProviderID, Model: req.Model},
+			cfg.ChatProviderID, cfg.ChatModel,
+		))
+		snap, err := rt.WithOverrides(app, config.Overrides{Chat: binding})
+		if err != nil {
+			return writeError(e, http.StatusBadRequest, err.Error())
+		}
+		chatter := snap.Chatter
+		if chatter == nil {
+			return writeError(e, http.StatusServiceUnavailable, "AI chat is not configured; update Settings.")
+		}
 
 		// The conversation exists before the question is asked, so the id the
 		// provider is given as a cache key is the id the chat keeps. opened
@@ -194,6 +254,7 @@ func handleDocumentChat(app core.App, rt *config.Runtime) func(*core.RequestEven
 				UserID:       ownerID,
 				Kind:         chat.KindDocument,
 				DocumentID:   documentID,
+				Binding:      binding,
 				FirstMessage: content,
 			})
 			if err != nil {

--- a/backend/internal/appapi/chat.go
+++ b/backend/internal/appapi/chat.go
@@ -67,7 +67,11 @@ func conversationBinding(session *core.Record, requested aiprovider.Binding) aip
 // would turn a chat that used to work into a 400. Nothing stored means "follow
 // Settings", which is what those instances did before.
 func recordedBinding(requested aiprovider.Binding, providerID, model string) aiprovider.Binding {
-	if !requested.Empty() {
+	// Against the zero value, not Binding.Empty, for the same reason
+	// config.Overrides.Empty is: Empty is keyed on the provider id, so a model
+	// with no provider would read as no override and quietly run the configured
+	// one. Resolve refuses that pair, and can only do so if it sees it.
+	if requested.Normalized() != (aiprovider.Binding{}) {
 		return requested.Normalized()
 	}
 	configured := aiprovider.Binding{ProviderID: providerID, Model: model}.Normalized()
@@ -75,6 +79,36 @@ func recordedBinding(requested aiprovider.Binding, providerID, model string) aip
 		return aiprovider.Binding{}
 	}
 	return configured
+}
+
+// conversationSnapshot turns the binding a turn runs on into the clients that
+// run it.
+//
+// An unusable binding this request picked is a bad request: answering on a
+// different model is the substitution the picker exists to prevent. One the
+// conversation carries falls back to Settings instead -- the provider row can
+// be deleted long after the transcript, which is why chat_sessions.provider is
+// text and not a relation, and refusing it would leave every pinned chat unable
+// to take another turn once its provider is rotated out. The stale pair stays
+// on the record, so the picker still names the gone provider: a chat naming the
+// wrong model beats one that cannot be continued.
+func conversationSnapshot(
+	app core.App,
+	rt *config.Runtime,
+	o config.Overrides,
+	session *core.Record,
+	requested aiprovider.Binding,
+) (config.Snapshot, error) {
+	snap, err := rt.WithOverrides(app, o)
+	if err == nil {
+		return snap, nil
+	}
+	if session == nil && requested.Normalized() != (aiprovider.Binding{}) {
+		return snap, err
+	}
+	app.Logger().Warn("conversation binding no longer resolves; continuing on the configured model",
+		slog.Any("error", err))
+	return rt.Snapshot(), nil
 }
 
 type chatResponse struct {
@@ -230,11 +264,9 @@ func handleDocumentChat(app core.App, rt *config.Runtime) func(*core.RequestEven
 		// Resolved after the session is loaded, because a continued
 		// conversation's stored binding is what decides, not the request's.
 		cfg := rt.Snapshot().Cfg
-		binding := conversationBinding(session, recordedBinding(
-			aiprovider.Binding{ProviderID: req.ProviderID, Model: req.Model},
-			cfg.ChatProviderID, cfg.ChatModel,
-		))
-		snap, err := rt.WithOverrides(app, config.Overrides{Chat: binding})
+		requested := aiprovider.Binding{ProviderID: req.ProviderID, Model: req.Model}
+		binding := conversationBinding(session, recordedBinding(requested, cfg.ChatProviderID, cfg.ChatModel))
+		snap, err := conversationSnapshot(app, rt, config.Overrides{Chat: binding}, session, requested)
 		if err != nil {
 			return writeError(e, http.StatusBadRequest, err.Error())
 		}

--- a/backend/internal/appapi/ocr.go
+++ b/backend/internal/appapi/ocr.go
@@ -63,14 +63,20 @@ type ocrTestResponse struct {
 // It grew out of the OCR-test page's own list, which is why it is here rather
 // than in providers.go: that page needed a non-admin answer to "which providers
 // could do this", and so does every provider/model override -- on a chat, on a
-// reprocess job. The same handler serves the old /ocr/providers path, where the
-// purpose defaults to ocr.
+// reprocess job.
+//
+// fallback is what an unqualified request means, per route: ParseModelPurpose
+// reads anything it does not recognise as the language model, which is wrong
+// for the /ocr/providers path the OCR test page still calls with no purpose.
 //
 // The configured binding for the purpose is sorted first, so the picker opens
 // on what Settings would have used anyway.
-func handlePickableProviders(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
+func handlePickableProviders(app core.App, rt *config.Runtime, fallback aiprovider.ModelPurpose) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
-		purpose := aiprovider.ParseModelPurpose(e.Request.URL.Query().Get("for"))
+		purpose := fallback
+		if raw := strings.TrimSpace(e.Request.URL.Query().Get("for")); raw != "" {
+			purpose = aiprovider.ParseModelPurpose(raw)
+		}
 		// Which configured pair to report, when the capability alone does not
 		// say. Defaults to the one the purpose implies.
 		bindingName := e.Request.URL.Query().Get("binding")

--- a/backend/internal/appapi/ocr.go
+++ b/backend/internal/appapi/ocr.go
@@ -18,8 +18,36 @@ import (
 
 const ocrTestMaxFileBytes = 10 * 1024 * 1024
 
-type ocrProvidersResponse struct {
-	Providers []ocr.ProviderInfo `json:"providers"`
+// pickableProvider is a configured provider as a picker sees it: enough to name
+// a row in a dropdown, and nothing else.
+//
+// Deliberately not providerResponse, which carries api_key_set, the signed-in
+// ChatGPT account address and its plan. This list is readable by any signed-in
+// user, because any of them may override the model on their own chat or
+// reprocess job; what the operator pays with is not part of that.
+type pickableProvider struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	SDK  string `json:"sdk"`
+}
+
+// configuredBinding is what Settings would use for a purpose, so a picker can
+// name the model that answers when nobody overrides anything.
+//
+// The provider's alias rides along because the id alone is not something to put
+// in front of a user, and a caller showing the default has no list to look it
+// up in -- an unconfigured binding sends nothing at all.
+type configuredBinding struct {
+	ProviderID   string `json:"provider_id,omitempty"`
+	ProviderName string `json:"provider_name,omitempty"`
+	Model        string `json:"model,omitempty"`
+}
+
+type pickableProvidersResponse struct {
+	Providers []pickableProvider `json:"providers"`
+	// Configured is the binding in Settings for the requested purpose. Empty
+	// when nothing is bound, which is what an instance mid-setup looks like.
+	Configured configuredBinding `json:"configured"`
 }
 
 type ocrTestResponse struct {
@@ -29,27 +57,45 @@ type ocrTestResponse struct {
 	Duration  string `json:"duration"`
 }
 
-func handleOCRProviders(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
+// handlePickableProviders lists the configured providers that can serve a
+// purpose, for a model picker outside Settings.
+//
+// It grew out of the OCR-test page's own list, which is why it is here rather
+// than in providers.go: that page needed a non-admin answer to "which providers
+// could do this", and so does every provider/model override -- on a chat, on a
+// reprocess job. The same handler serves the old /ocr/providers path, where the
+// purpose defaults to ocr.
+//
+// The configured binding for the purpose is sorted first, so the picker opens
+// on what Settings would have used anyway.
+func handlePickableProviders(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
+		purpose := aiprovider.ParseModelPurpose(e.Request.URL.Query().Get("for"))
+		// Which configured pair to report, when the capability alone does not
+		// say. Defaults to the one the purpose implies.
+		bindingName := e.Request.URL.Query().Get("binding")
 		providers, err := aiprovider.List(app)
 		if err != nil {
-			return writeError(e, 500, "Failed to list OCR providers.")
+			return writeError(e, 500, "Failed to list providers.")
 		}
-		preferred := rt.Snapshot().Cfg.OCRProviderID
-		out := make([]ocr.ProviderInfo, 0, len(providers))
-		var first *ocr.ProviderInfo
-		rest := make([]ocr.ProviderInfo, 0, len(providers))
+		cfg := rt.Snapshot().Cfg
+		preferredID, preferredModel := preferredBinding(cfg, purpose, bindingName)
+		configured := configuredBinding{ProviderID: preferredID, Model: preferredModel}
+		out := make([]pickableProvider, 0, len(providers))
+		var first *pickableProvider
+		rest := make([]pickableProvider, 0, len(providers))
 		for _, p := range providers {
 			// A local sidecar has an address instead of a key; skipping on the
 			// key alone would hide it from the very page an operator opens
-			// first to check the container is working. CanOCR is the other
-			// half: the local embeddings sidecar is configured and keyless too,
-			// and cannot read a document at all.
-			if !p.Configured() || !aiprovider.CanOCR(p.SDK) {
+			// first to check the container is working. ServesPurpose is the
+			// other half: the local embeddings sidecar is configured and
+			// keyless too, and cannot read a document at all.
+			if !p.Configured() || !aiprovider.ServesPurpose(p.SDK, purpose) {
 				continue
 			}
-			info := ocr.ProviderInfo{ID: p.ID, Name: p.Alias, SDK: p.SDK}
-			if p.ID == preferred {
+			info := pickableProvider{ID: p.ID, Name: p.Alias, SDK: p.SDK}
+			if p.ID == preferredID {
+				configured.ProviderName = p.Alias
 				copy := info
 				first = &copy
 				continue
@@ -60,7 +106,34 @@ func handleOCRProviders(app core.App, rt *config.Runtime) func(*core.RequestEven
 			out = append(out, *first)
 		}
 		out = append(out, rest...)
-		return writeJSON(e, 200, ocrProvidersResponse{Providers: out})
+		return writeJSON(e, 200, pickableProvidersResponse{Providers: out, Configured: configured})
+	}
+}
+
+// preferredBinding is the configured provider and model a picker opens on, and
+// what it reports as answering when nobody overrides anything.
+//
+// name breaks the tie the capability cannot. Chat, search and extraction are
+// all language models, so the purpose alone cannot tell them apart -- and
+// telling Deep Search that the chat model answers it would be wrong on any
+// instance that bound the two separately. Unnamed, the LLM purpose answers with
+// chat: it is the only LLM picker a non-admin reaches without naming one.
+func preferredBinding(cfg config.Config, purpose aiprovider.ModelPurpose, name string) (providerID, model string) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "search":
+		return cfg.SearchProviderID, cfg.SearchModel
+	case "extract":
+		return cfg.ExtractProviderID, cfg.ExtractModel
+	case "chat":
+		return cfg.ChatProviderID, cfg.ChatModel
+	}
+	switch purpose {
+	case aiprovider.PurposeOCR:
+		return cfg.OCRProviderID, cfg.OCRModel
+	case aiprovider.PurposeEmbedding:
+		return cfg.EmbeddingProviderID, cfg.EmbeddingModel
+	default:
+		return cfg.ChatProviderID, cfg.ChatModel
 	}
 }
 

--- a/backend/internal/appapi/overrides_test.go
+++ b/backend/internal/appapi/overrides_test.go
@@ -153,6 +153,15 @@ func TestRecordedBinding(t *testing.T) {
 		"nothing configured records nothing": {
 			want: aiprovider.Binding{},
 		},
+		// Passed through rather than read as "no override", which Binding.Empty
+		// would: substituting the configured model here would run one the
+		// request did not ask for. Resolve refuses this pair.
+		"a model with no provider is not an absent override": {
+			requested: aiprovider.Binding{Model: "gpt-6-astra"},
+			provider:  "configured",
+			model:     "configured-model",
+			want:      aiprovider.Binding{Model: "gpt-6-astra"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/appapi/overrides_test.go
+++ b/backend/internal/appapi/overrides_test.go
@@ -1,0 +1,165 @@
+package appapi
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/chat"
+	"lemmary/backend/internal/config"
+)
+
+// sessionForTest is a chat_sessions record carrying a stored binding, without a
+// database behind it -- conversationBinding only reads two fields.
+func sessionForTest(providerID, model string) *core.Record {
+	collection := core.NewBaseCollection(chat.SessionsCollection)
+	collection.Fields.Add(
+		&core.TextField{Name: "provider", Max: 15},
+		&core.TextField{Name: "model", Max: 200},
+	)
+	record := core.NewRecord(collection)
+	record.Set("provider", providerID)
+	record.Set("model", model)
+	return record
+}
+
+// A conversation runs on the binding stored with it, and what the request
+// carries is ignored.
+//
+// The transcript replayed to the model was produced by that model, and
+// answering the next question with another one reads that work back as if it
+// were its own -- the same argument the search mode conflict makes, except
+// ignored rather than refused: the client is echoing the binding it loaded, not
+// choosing one.
+func TestConversationBinding(t *testing.T) {
+	t.Parallel()
+	requested := aiprovider.Binding{ProviderID: "requested", Model: "gpt-6-astra"}
+
+	cases := map[string]struct {
+		session *core.Record
+		want    aiprovider.Binding
+	}{
+		"a new conversation takes the request's binding": {
+			session: nil,
+			want:    requested,
+		},
+		"an existing conversation keeps its own": {
+			session: sessionForTest("stored", "gpt-5.6-sol"),
+			want:    aiprovider.Binding{ProviderID: "stored", Model: "gpt-5.6-sol"},
+		},
+		// The case that matters most: a chat opened on the configured model
+		// stays on it, even when a stale picker sends something else.
+		"an existing conversation with no binding stays unbound": {
+			session: sessionForTest("", ""),
+			want:    aiprovider.Binding{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := conversationBinding(tc.session, requested); got != tc.want {
+				t.Fatalf("conversationBinding() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConversationBindingNormalizesTheRequest(t *testing.T) {
+	t.Parallel()
+	got := conversationBinding(nil, aiprovider.Binding{ProviderID: " p1 ", Model: " gpt-6-astra "})
+	if got != (aiprovider.Binding{ProviderID: "p1", Model: "gpt-6-astra"}) {
+		t.Fatalf("conversationBinding() = %+v", got)
+	}
+}
+
+// The picker opens on the binding Settings would have used anyway, and reports
+// it as the model that answers when nobody overrides anything. Each purpose
+// reads a different pair of fields; a missing case would name the OCR model in
+// a chat.
+func TestPreferredBinding(t *testing.T) {
+	t.Parallel()
+	cfg := config.Config{
+		OCRProviderID:       "ocr",
+		OCRModel:            "ocr-model",
+		ExtractProviderID:   "extract",
+		ExtractModel:        "extract-model",
+		ChatProviderID:      "chat",
+		ChatModel:           "chat-model",
+		SearchProviderID:    "search",
+		SearchModel:         "search-model",
+		EmbeddingProviderID: "embedding",
+		EmbeddingModel:      "embedding-model",
+	}
+	cases := []struct {
+		purpose aiprovider.ModelPurpose
+		name    string
+		want    [2]string
+	}{
+		{aiprovider.PurposeOCR, "", [2]string{"ocr", "ocr-model"}},
+		{aiprovider.PurposeEmbedding, "", [2]string{"embedding", "embedding-model"}},
+		// Unnamed, the LLM purpose answers with chat: it is the only LLM picker
+		// a non-admin reaches without naming one.
+		{aiprovider.PurposeLLM, "", [2]string{"chat", "chat-model"}},
+		// Named, because the capability cannot tell three language-model
+		// bindings apart -- and telling Deep Search the chat model answers it
+		// is wrong on any instance that bound the two separately.
+		{aiprovider.PurposeLLM, "search", [2]string{"search", "search-model"}},
+		{aiprovider.PurposeLLM, "extract", [2]string{"extract", "extract-model"}},
+		{aiprovider.PurposeLLM, "chat", [2]string{"chat", "chat-model"}},
+		// An unrecognised name falls back to the purpose rather than answering
+		// with nothing.
+		{aiprovider.PurposeLLM, "sideways", [2]string{"chat", "chat-model"}},
+	}
+	for _, tc := range cases {
+		id, model := preferredBinding(cfg, tc.purpose, tc.name)
+		if id != tc.want[0] || model != tc.want[1] {
+			t.Fatalf("preferredBinding(%q, %q) = %q/%q, want %q/%q",
+				tc.purpose, tc.name, id, model, tc.want[0], tc.want[1])
+		}
+	}
+}
+
+// A conversation records the model it runs on, so changing Settings later
+// cannot move it mid-transcript.
+func TestRecordedBinding(t *testing.T) {
+	t.Parallel()
+	override := aiprovider.Binding{ProviderID: "chosen", Model: "chosen-model"}
+
+	cases := map[string]struct {
+		requested aiprovider.Binding
+		provider  string
+		model     string
+		want      aiprovider.Binding
+	}{
+		"an override is recorded as chosen": {
+			requested: override,
+			provider:  "configured",
+			model:     "configured-model",
+			want:      override,
+		},
+		"no override records the configured pair": {
+			provider: "configured",
+			model:    "configured-model",
+			want:     aiprovider.Binding{ProviderID: "configured", Model: "configured-model"},
+		},
+		// Half a pair is refused by aiprovider.Resolve, so recording one would
+		// turn a chat that used to work into a bad request. Nothing recorded
+		// means "follow Settings", which is what those instances did before.
+		"a provider with no configured model records nothing": {
+			provider: "configured",
+			want:     aiprovider.Binding{},
+		},
+		"nothing configured records nothing": {
+			want: aiprovider.Binding{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := recordedBinding(tc.requested, tc.provider, tc.model); got != tc.want {
+				t.Fatalf("recordedBinding() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/appapi/reprocess.go
+++ b/backend/internal/appapi/reprocess.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 
+	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/reprocess"
 )
 
@@ -16,9 +17,16 @@ type reprocessFailedRequest struct {
 	Limit       int      `json:"limit"`
 	Mode        string   `json:"mode"`
 	DocumentIDs []string `json:"document_ids"`
+	// Overrides are the provider and model to run this batch on, instead of the
+	// bindings in Settings. Optional, like every other field here.
+	//
+	// Only ocr, extract and embedding are read: they are the three bindings the
+	// pipeline uses. A chat or search override would be stored and never
+	// looked at, so it is refused rather than silently ignored.
+	Overrides config.Overrides `json:"overrides"`
 }
 
-func handlePostReprocessFailed(app core.App) func(*core.RequestEvent) error {
+func handlePostReprocessFailed(app core.App, rt *config.Runtime) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
 		var req reprocessFailedRequest
 		// Every field is optional, so an empty body is a valid "one default
@@ -32,6 +40,19 @@ func handlePostReprocessFailed(app core.App) func(*core.RequestEvent) error {
 			return writeError(e, http.StatusBadRequest, err.Error())
 		}
 
+		// Refused here rather than dropped, so a client sending a binding the
+		// pipeline cannot use learns that instead of watching a batch run on
+		// the configured model.
+		if !req.Overrides.Chat.Empty() || !req.Overrides.Search.Empty() {
+			return writeError(e, http.StatusBadRequest, "A reprocess job can only override the ocr, extract and embedding bindings.")
+		}
+		// Validated up front as well as in the create hook: the hook refuses
+		// one job, and a bad provider id would otherwise be discovered on the
+		// first document of a batch after the rest had already been queued.
+		if err := req.Overrides.Validate(app, rt.Snapshot().Cfg); err != nil {
+			return writeError(e, http.StatusBadRequest, err.Error())
+		}
+
 		ownerID, err := resolveOwnerUserID(app, e)
 		if err != nil {
 			return writeOwnerError(e, err)
@@ -42,6 +63,7 @@ func handlePostReprocessFailed(app core.App) func(*core.RequestEvent) error {
 			DocumentIDs: req.DocumentIDs,
 			Limit:       req.Limit,
 			Mode:        mode,
+			Overrides:   req.Overrides,
 		})
 		if err != nil {
 			app.Logger().Error("reprocess batch failed", slog.Any("error", err))

--- a/backend/internal/appapi/search.go
+++ b/backend/internal/appapi/search.go
@@ -207,11 +207,9 @@ func prepareSearchTurn(app core.App, rt *config.Runtime, idx *fulltext.Index, e 
 	// coincide on most instances, but an instance that bound them separately did
 	// so deliberately.
 	cfg := rt.Snapshot().Cfg
-	binding := conversationBinding(session, recordedBinding(
-		aiprovider.Binding{ProviderID: req.ProviderID, Model: req.Model},
-		cfg.SearchProviderID, cfg.SearchModel,
-	))
-	snap, err := rt.WithOverrides(app, config.Overrides{Search: binding})
+	requested := aiprovider.Binding{ProviderID: req.ProviderID, Model: req.Model}
+	binding := conversationBinding(session, recordedBinding(requested, cfg.SearchProviderID, cfg.SearchModel))
+	snap, err := conversationSnapshot(app, rt, config.Overrides{Search: binding}, session, requested)
 	if err != nil {
 		return searchTurn{}, true, writeError(e, http.StatusBadRequest, err.Error())
 	}

--- a/backend/internal/appapi/search.go
+++ b/backend/internal/appapi/search.go
@@ -32,6 +32,11 @@ type searchRequest struct {
 	// stopped generates an id here and POSTs it to /search/cancel. Optional:
 	// omitting it costs the ability to cancel, nothing else.
 	RunID string `json:"run_id"`
+	// The provider and model to open the conversation on, instead of the search
+	// binding in Settings. Read only when SessionID is empty, like Mode is
+	// fixed once a conversation exists -- see conversationBinding.
+	ProviderID string `json:"provider_id"`
+	Model      string `json:"model"`
 }
 
 type searchResponse struct {
@@ -158,11 +163,6 @@ func prepareSearchTurn(app core.App, rt *config.Runtime, idx *fulltext.Index, e 
 		return searchTurn{}, true, writeError(e, http.StatusBadRequest, err.Error())
 	}
 
-	agent := rt.Snapshot().SearchAgent
-	if agent == nil {
-		return searchTurn{}, true, writeError(e, http.StatusServiceUnavailable, "AI search is not configured; update Settings.")
-	}
-
 	// Two different questions, deliberately answered differently.
 	//
 	// ownerID is whose sidebar this conversation belongs in, so a superuser
@@ -201,6 +201,25 @@ func prepareSearchTurn(app core.App, rt *config.Runtime, idx *fulltext.Index, e 
 		}
 	}
 
+	// After the session, so a continued conversation runs on the binding stored
+	// with it rather than on whatever the request echoed back.
+	// The search binding, not the chat one: applyBindingFallbacks makes them
+	// coincide on most instances, but an instance that bound them separately did
+	// so deliberately.
+	cfg := rt.Snapshot().Cfg
+	binding := conversationBinding(session, recordedBinding(
+		aiprovider.Binding{ProviderID: req.ProviderID, Model: req.Model},
+		cfg.SearchProviderID, cfg.SearchModel,
+	))
+	snap, err := rt.WithOverrides(app, config.Overrides{Search: binding})
+	if err != nil {
+		return searchTurn{}, true, writeError(e, http.StatusBadRequest, err.Error())
+	}
+	agent := snap.SearchAgent
+	if agent == nil {
+		return searchTurn{}, true, writeError(e, http.StatusServiceUnavailable, "AI search is not configured; update Settings.")
+	}
+
 	tools, err := buildAgentTools(app, rt, idx, searchUserID)
 	if err != nil {
 		app.Logger().Error("search list tags failed", slog.Any("error", err))
@@ -229,6 +248,7 @@ func prepareSearchTurn(app core.App, rt *config.Runtime, idx *fulltext.Index, e 
 			UserID:       ownerID,
 			Kind:         chat.KindSearch,
 			Mode:         mode,
+			Binding:      binding,
 			FirstMessage: content,
 		})
 		if err != nil {

--- a/backend/internal/chat/collection.go
+++ b/backend/internal/chat/collection.go
@@ -95,6 +95,19 @@ func ensureSessions(app core.App) (*core.Collection, error) {
 			MaxSelect: 1,
 			Values:    []string{ModeSearch, ModeResearch},
 		},
+		// The provider and model this conversation runs on, when it was opened
+		// on something other than the configured binding. Empty means the
+		// Settings binding, which is every session created before overrides
+		// existed.
+		//
+		// A text field rather than a relation to ai_providers, deliberately.
+		// An optional relation would either cascade-delete transcripts with the
+		// provider row or silently unset the id -- and a transcript is worth
+		// keeping after its provider is gone, readable and continuable on the
+		// configured model. A stale id resolves to nothing and falls back the
+		// same way an empty one does.
+		&core.TextField{Name: "provider", Max: 15},
+		&core.TextField{Name: "model", Max: 200},
 		// Not Required: a NumberField's Required means non-zero, and a session
 		// legitimately holds 0 between its creation and its first turn inside
 		// AppendTurn's transaction.

--- a/backend/internal/chat/session.go
+++ b/backend/internal/chat/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/types"
 
 	"lemmary/backend/internal/ai"
+	"lemmary/backend/internal/aiprovider"
 	"lemmary/backend/internal/strutil"
 )
 
@@ -276,6 +277,12 @@ type SessionInfo struct {
 	Title string `json:"title"`
 	// Mode is the search mode the last turn ran in ("" for document chats).
 	Mode string `json:"mode,omitempty"`
+	// Provider and Model are the binding the conversation runs on, empty when
+	// it runs on the one in Settings. Sent so reopening a chat restores the
+	// picker on the choice its transcript was produced with -- the same reason
+	// Mode is here.
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
 	// Document is set for KindDocument sessions; DocumentTitle is filled by the
 	// handler, which is the layer that may read the documents collection.
 	Document      string `json:"document,omitempty"`
@@ -307,12 +314,30 @@ func ToSessionInfo(record *core.Record) SessionInfo {
 		Kind:          record.GetString("kind"),
 		Title:         record.GetString("title"),
 		Mode:          record.GetString("mode"),
+		Provider:      record.GetString("provider"),
+		Model:         record.GetString("model"),
 		Document:      record.GetString("document"),
 		MessageCount:  record.GetInt("message_count"),
 		LastMessageAt: lastMessageAt,
 		Created:       record.GetDateTime("created").String(),
 		Updated:       record.GetDateTime("updated").String(),
 	}
+}
+
+// BindingOf reads the provider and model a conversation is pinned to.
+//
+// The only reader of those two fields, so that "a session with no override runs
+// on Settings" is one line rather than a nil check at each of the two chat
+// handlers. A nil record answers the same as an unpinned one, which is what a
+// conversation that does not exist yet needs.
+func BindingOf(record *core.Record) aiprovider.Binding {
+	if record == nil {
+		return aiprovider.Binding{}
+	}
+	return aiprovider.Binding{
+		ProviderID: record.GetString("provider"),
+		Model:      record.GetString("model"),
+	}.Normalized()
 }
 
 // ToMessageInfo projects a message record for the API.

--- a/backend/internal/chat/store.go
+++ b/backend/internal/chat/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/types"
 
 	"lemmary/backend/internal/ai"
+	"lemmary/backend/internal/aiprovider"
 )
 
 // SessionQuery selects a slice of one account's sessions. An empty Kind or
@@ -29,6 +30,9 @@ type NewSession struct {
 	// Mode is the search mode the conversation runs in, and is fixed for its
 	// lifetime. Empty for document chats.
 	Mode string
+	// Binding is the provider and model the conversation runs on, fixed for its
+	// lifetime for the same reason Mode is. Empty means the Settings binding.
+	Binding aiprovider.Binding
 	// FirstMessage is the question that started the conversation; the title is
 	// derived from it.
 	FirstMessage string
@@ -252,6 +256,10 @@ func CreateSession(app core.App, spec NewSession) (*core.Record, error) {
 		}
 		if spec.Mode != "" {
 			session.Set("mode", spec.Mode)
+		}
+		if binding := spec.Binding.Normalized(); !binding.Empty() {
+			session.Set("provider", binding.ProviderID)
+			session.Set("model", binding.Model)
 		}
 		session.Set("title", DeriveTitle(spec.FirstMessage))
 		session.Set("message_count", 0)

--- a/backend/internal/chat/store_test.go
+++ b/backend/internal/chat/store_test.go
@@ -1,0 +1,134 @@
+package chat_test
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+
+	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/chat"
+	// Registers the migrations that create users and documents, which
+	// chat_sessions relates to. Importing them is also why this file is an
+	// external test package: internal/chat cannot import migrations, which
+	// import it back to define the collections.
+	_ "lemmary/backend/migrations"
+)
+
+func bootAppForStore(t *testing.T) *pocketbase.PocketBase {
+	t.Helper()
+	app := pocketbase.NewWithConfig(pocketbase.Config{
+		DefaultDataDir:  t.TempDir(),
+		HideStartBanner: true,
+	})
+	if err := app.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = app.ResetBootstrapState() })
+	if err := app.RunAppMigrations(); err != nil {
+		t.Fatalf("run app migrations: %v", err)
+	}
+	return app
+}
+
+func makeUser(t *testing.T, app core.App, email string) string {
+	t.Helper()
+	users, err := app.FindCollectionByNameOrId(chat.UsersCollectionName)
+	if err != nil {
+		t.Fatalf("users collection: %v", err)
+	}
+	user := core.NewRecord(users)
+	user.Set("email", email)
+	user.SetPassword("test-password-123")
+	if err := app.Save(user); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+	return user.Id
+}
+
+// The binding is fixed for a conversation, so it has to survive the write and
+// come back out: without the round trip, every turn after the first would
+// silently fall back to the model in Settings.
+func TestCreateSessionStoresAndReturnsItsBinding(t *testing.T) {
+	app := bootAppForStore(t)
+	userID := makeUser(t, app, "binding@example.test")
+
+	want := aiprovider.Binding{ProviderID: "provider1234567", Model: "gpt-6-astra"}
+	session, err := chat.CreateSession(app, chat.NewSession{
+		UserID:       userID,
+		Kind:         chat.KindSearch,
+		Mode:         chat.ModeResearch,
+		Binding:      want,
+		FirstMessage: "how much did I spend on the car in 2024?",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Re-read rather than trusting the in-memory record: the columns are what a
+	// later turn reads the binding back out of.
+	stored, err := app.FindRecordById(chat.SessionsCollection, session.Id)
+	if err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	if got := chat.BindingOf(stored); got != want {
+		t.Fatalf("BindingOf() = %+v, want %+v", got, want)
+	}
+	// Sent to the client too, so reopening the chat restores the picker.
+	if info := chat.ToSessionInfo(stored); info.Provider != want.ProviderID || info.Model != want.Model {
+		t.Fatalf("SessionInfo binding = %q/%q, want %q/%q",
+			info.Provider, info.Model, want.ProviderID, want.Model)
+	}
+}
+
+// A chat opened on the configured model must store nothing, so it reads back as
+// "use Settings" -- which is every session that existed before overrides did.
+func TestCreateSessionLeavesTheBindingUnsetWhenThereIsNone(t *testing.T) {
+	app := bootAppForStore(t)
+	userID := makeUser(t, app, "nobinding@example.test")
+
+	session, err := chat.CreateSession(app, chat.NewSession{
+		UserID:       userID,
+		Kind:         chat.KindSearch,
+		Mode:         chat.ModeSearch,
+		FirstMessage: "plumber invoice",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if got := chat.BindingOf(session); !got.Empty() {
+		t.Fatalf("BindingOf() = %+v, want empty", got)
+	}
+	if info := chat.ToSessionInfo(session); info.Provider != "" || info.Model != "" {
+		t.Fatalf("SessionInfo carried a binding: %q/%q", info.Provider, info.Model)
+	}
+}
+
+// A model with no provider is refused by the API, so it must not become a
+// stored half-binding either -- BindingOf would hand it back and the next
+// turn would be refused for a choice nobody made.
+func TestCreateSessionDropsAModelWithNoProvider(t *testing.T) {
+	app := bootAppForStore(t)
+	userID := makeUser(t, app, "halfbinding@example.test")
+
+	session, err := chat.CreateSession(app, chat.NewSession{
+		UserID:       userID,
+		Kind:         chat.KindSearch,
+		Mode:         chat.ModeSearch,
+		Binding:      aiprovider.Binding{Model: "gpt-6-astra"},
+		FirstMessage: "plumber invoice",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if got := chat.BindingOf(session); !got.Empty() {
+		t.Fatalf("BindingOf() = %+v, want empty", got)
+	}
+}
+
+func TestBindingOfNilRecord(t *testing.T) {
+	t.Parallel()
+	if got := chat.BindingOf(nil); !got.Empty() {
+		t.Fatalf("BindingOf(nil) = %+v, want empty", got)
+	}
+}

--- a/backend/internal/config/override.go
+++ b/backend/internal/config/override.go
@@ -1,0 +1,277 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/pocketbase/pocketbase/core"
+	"lemmary/backend/internal/ai"
+	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/ocr"
+)
+
+// Overrides names the bindings that replace the configured ones for the length
+// of one request or one job. An empty field keeps the configured client.
+//
+// One struct rather than a method per binding: five near-identical
+// "OverrideChatter"/"OverrideExtractor" entry points would each have to repeat
+// the credential handling and the nil-provider fallback, and a caller wanting
+// two of them at once (a reprocess job overriding OCR and extraction) would
+// build two snapshots and pick fields out of both.
+//
+// The json tags are load-bearing: this is also the stored shape of a
+// processing job's `overrides` column, so a job carries the same document the
+// API accepts and there is no second struct to keep in step with this one. A
+// job never sets Chat or Search; the fields are inert there rather than
+// forbidden, which costs nothing and keeps one type.
+type Overrides struct {
+	Chat      aiprovider.Binding `json:"chat,omitzero"`
+	Search    aiprovider.Binding `json:"search,omitzero"`
+	Extract   aiprovider.Binding `json:"extract,omitzero"`
+	OCR       aiprovider.Binding `json:"ocr,omitzero"`
+	Embedding aiprovider.Binding `json:"embedding,omitzero"`
+}
+
+// Empty reports overrides that change nothing, so a caller can skip the rebuild
+// entirely and hand on the published snapshot.
+//
+// Compared against the zero value rather than asking each Binding.Empty().
+// That reads the same but is not: Binding.Empty is keyed on the provider id, so
+// a binding carrying a model and no provider is "empty" to it -- and this is
+// the short-circuit before Validate, so such a binding would be dropped and the
+// request would quietly run the configured model instead of the one it named.
+// Anything at all set here has to reach Validate, which is where a half-filled
+// binding is refused.
+func (o Overrides) Empty() bool {
+	return o == Overrides{}
+}
+
+// BoundOverride is one field of Overrides with the capability it has to serve,
+// and the name it is called by in an error message.
+type BoundOverride struct {
+	Name    string
+	Binding aiprovider.Binding
+	Purpose aiprovider.ModelPurpose
+}
+
+// Purposes pairs each binding with the capability it has to serve.
+//
+// It is the one list of the five fields, so a binding cannot be added to the
+// struct and forgotten by the validator -- which would accept an override and
+// then silently run the configured model. Fixed order, so the same bad request
+// always names the same field first.
+func (o Overrides) Purposes() []BoundOverride {
+	return []BoundOverride{
+		{"ocr", o.OCR, aiprovider.PurposeOCR},
+		{"extract", o.Extract, aiprovider.PurposeLLM},
+		{"chat", o.Chat, aiprovider.PurposeLLM},
+		{"search", o.Search, aiprovider.PurposeLLM},
+		{"embedding", o.Embedding, aiprovider.PurposeEmbedding},
+	}
+}
+
+// Validate resolves every non-empty binding without building anything, so a
+// request or a record write can be refused before any work is queued.
+func (o Overrides) Validate(app core.App, cfg Config) error {
+	for _, item := range o.Purposes() {
+		if _, _, err := aiprovider.Resolve(app, item.Binding, item.Purpose); err != nil {
+			return fmt.Errorf("%s override: %w", item.Name, err)
+		}
+	}
+	return o.validateEmbeddingModel(cfg)
+}
+
+// validateEmbeddingModel refuses an embedding override naming a model other
+// than the one the retrieval index was built for.
+//
+// Not a stylistic restriction, and the reason it is checked here rather than
+// left to the embedder: a chunk row records the model and dimension count it
+// was produced with, and the index only reads rows matching the configured spec
+// -- embed.SpecFrom, and matchesSpec in internal/embed/source.go. Embedding a
+// document on a different model therefore spends the provider call, writes the
+// rows, reports success, and drops that document out of dense retrieval,
+// because nothing will ever read them. There is no way to make that outcome
+// visible afterwards, so it is refused up front.
+//
+// The configured model is allowed, and is the case worth having: re-running the
+// embed step for a document whose vectors are missing or stale.
+func (o Overrides) validateEmbeddingModel(cfg Config) error {
+	binding := o.Embedding.Normalized()
+	if binding.Empty() {
+		return nil
+	}
+	configured := strings.TrimSpace(cfg.EmbeddingModel)
+	if binding.Model == configured {
+		return nil
+	}
+	if configured == "" {
+		return fmt.Errorf("embedding override: no embedding model is configured, so there is no index for these vectors to join; bind one in Settings first")
+	}
+	return fmt.Errorf("embedding override: the retrieval index holds %q vectors, so vectors from %q would be written and never read; re-embed on %q, or change the model in Settings and reindex",
+		configured, binding.Model, configured)
+}
+
+// WithOverrides returns the published snapshot with the named clients rebuilt
+// on the bindings the caller supplied.
+//
+// It goes through the same builders apply does, which is the point: the
+// overridden clients get the same ChatGPT token middleware, the same OpenCode
+// session header and the same timeouts as the configured ones, and there is no
+// second construction path to drift from the first.
+//
+// Rebuilding is cheap -- the ai constructors only assemble an openai-go client,
+// with no network call -- so this runs per request on the chat surfaces. The one
+// exception is a google_vision OCR client, which opens a gRPC connection; that
+// binding is reached only from the worker, once per job.
+func (r *Runtime) WithOverrides(app core.App, o Overrides) (Snapshot, error) {
+	snap := r.Snapshot()
+	if o.Empty() {
+		return snap, nil
+	}
+	if err := o.Validate(app, snap.Cfg); err != nil {
+		return snap, err
+	}
+
+	logger := app.Logger()
+	aiLogger := logger.With("component", "ai")
+
+	// Resolved again rather than carried out of Validate: the loop there is a
+	// yes/no over five bindings, and threading five (provider, model) pairs out
+	// of it would make the shape of that answer depend on this caller.
+	resolve := func(b aiprovider.Binding, purpose aiprovider.ModelPurpose) (*aiprovider.Provider, string) {
+		p, model, _ := aiprovider.Resolve(app, b, purpose)
+		return p, model
+	}
+
+	if !o.OCR.Empty() {
+		p, model := resolve(o.OCR, aiprovider.PurposeOCR)
+		built, err := buildOCR(app, snap.Cfg, p, model, logger.With("component", "ocr"))
+		if err != nil {
+			return snap, fmt.Errorf("ocr override: %w", err)
+		}
+		snap.OCR = built
+	}
+	if !o.Extract.Empty() {
+		p, model := resolve(o.Extract, aiprovider.PurposeLLM)
+		// The splitter moves with the extractor because it is defined as the
+		// extraction provider's second client; leaving it on the configured
+		// binding would make Snapshot.Splitter's own doc comment false.
+		snap.AI, snap.Splitter = buildExtractPair(app, snap.Cfg, p, model, aiLogger)
+	}
+	if !o.Chat.Empty() {
+		p, model := resolve(o.Chat, aiprovider.PurposeLLM)
+		snap.Chatter = buildChatter(app, snap.Cfg, p, model, aiLogger)
+	}
+	if !o.Search.Empty() {
+		p, model := resolve(o.Search, aiprovider.PurposeLLM)
+		// SearchHelper deliberately stays put. It is a separate binding because
+		// it does many cheap per-document calls where the research model does a
+		// few expensive ones, and moving the bulk work onto whatever model was
+		// picked for the conversation is not what picking it asked for.
+		snap.SearchAgent = buildSearchAgent(app, snap.Cfg, p, model, aiLogger)
+	}
+	if !o.Embedding.Empty() {
+		p, model := resolve(o.Embedding, aiprovider.PurposeEmbedding)
+		snap.Embedder = buildEmbedder(app, snap.Cfg, p, model, aiLogger)
+	}
+	return snap, nil
+}
+
+// buildOCR builds the OCR client for a provider row, or nil when there is none.
+//
+// The row is copied before its key is replaced: the caller's Provider may be
+// the one hanging off Config, and a chatgpt row's placeholder key written back
+// there would be published in the next snapshot as though it were real.
+func buildOCR(app core.App, cfg Config, p *aiprovider.Provider, model string, logger *slog.Logger) (ocr.Provider, error) {
+	if p == nil {
+		return nil, nil
+	}
+	row := *p
+	key, opts := providerCredential(app, p, logger)
+	row.APIKey = key
+	return ocr.NewFromAIProvider(row, model, cfg.OCRTimeout, logger, opts...)
+}
+
+// buildExtractPair builds the extractor and the splitter together.
+//
+// One credential for both, which is why they are one function: asking twice
+// would put two middlewares over one ChatGPT token source, each refreshing
+// against the other. The splitter is always the extraction provider's client,
+// so there is no caller that wants one without the other.
+func buildExtractPair(app core.App, cfg Config, p *aiprovider.Provider, model string, logger *slog.Logger) (ai.Extractor, ai.Splitter) {
+	if !usableLLM(p) {
+		return nil, nil
+	}
+	key, opts := providerCredential(app, p, logger)
+	extractor := ai.NewExtractor(
+		p.SDK,
+		key,
+		model,
+		p.BaseURL,
+		cfg.ExtractionPromptVer,
+		cfg.ProcessingResultLanguage,
+		cfg.OpenAITimeout,
+		logger,
+		opts...,
+	)
+	splitter := ai.NewSplitter(
+		p.SDK,
+		key,
+		model,
+		p.BaseURL,
+		cfg.OpenAITimeout,
+		logger,
+		opts...,
+	)
+	return extractor, splitter
+}
+
+func buildChatter(app core.App, cfg Config, p *aiprovider.Provider, model string, logger *slog.Logger) ai.Chatter {
+	if !usableLLM(p) {
+		return nil
+	}
+	key, opts := providerCredential(app, p, logger)
+	return ai.NewChatter(p.SDK, key, model, p.BaseURL, cfg.OpenAITimeout, logger, opts...)
+}
+
+func buildSearchAgent(app core.App, cfg Config, p *aiprovider.Provider, model string, logger *slog.Logger) ai.SearchAgent {
+	if !usableLLM(p) {
+		return nil
+	}
+	key, opts := providerCredential(app, p, logger)
+	return ai.NewSearchAgent(
+		p.SDK,
+		key,
+		model,
+		p.BaseURL,
+		cfg.OpenAITimeout,
+		cfg.DeepSearchLanguages,
+		cfg.ProcessingResultLanguage,
+		logger,
+		opts...,
+	)
+}
+
+func buildHelper(app core.App, cfg Config, p *aiprovider.Provider, model string, logger *slog.Logger) ai.Helper {
+	if !usableLLM(p) {
+		return nil
+	}
+	key, opts := providerCredential(app, p, logger)
+	return ai.NewHelper(p.SDK, key, model, p.BaseURL, cfg.OpenAITimeout, logger, opts...)
+}
+
+// buildEmbedder builds the embedding client, or nil when the provider cannot
+// embed.
+//
+// EmbeddingDims comes from the configuration rather than the binding: it is the
+// width the chunk index was built for, and an embedder asked for a different
+// one writes rows that index discards. An override here is only ever useful for
+// re-embedding on the model already bound -- see the guard in worker.
+func buildEmbedder(app core.App, cfg Config, p *aiprovider.Provider, model string, logger *slog.Logger) ai.Embedder {
+	if p == nil || !p.Configured() || !aiprovider.CanEmbed(p.SDK) || model == "" {
+		return nil
+	}
+	key, _ := providerCredential(app, p, logger)
+	return ai.NewEmbedder(p.SDK, key, model, p.BaseURL, cfg.EmbeddingDims, cfg.OpenAITimeout, logger)
+}

--- a/backend/internal/config/override_test.go
+++ b/backend/internal/config/override_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"lemmary/backend/internal/aiprovider"
+)
+
+func TestOverridesEmpty(t *testing.T) {
+	t.Parallel()
+	if !(Overrides{}).Empty() {
+		t.Fatal("the zero Overrides overrides nothing")
+	}
+	// A model with no provider is not empty: it is a request Validate has to
+	// refuse. Reading it as empty would run the configured model instead of the
+	// one that was asked for, silently.
+	partial := Overrides{Chat: aiprovider.Binding{Model: "gpt-6-astra"}}
+	if partial.Empty() {
+		t.Fatal("a model with no provider must not read as no override")
+	}
+	full := Overrides{Chat: aiprovider.Binding{ProviderID: "p1", Model: "gpt-6-astra"}}
+	if full.Empty() {
+		t.Fatal("a populated binding must not read as no override")
+	}
+}
+
+// Every binding has to be reachable: an override dropped by a missing case in
+// Purposes would run on the configured model with nothing to show it had been
+// ignored.
+func TestOverridesPurposesCoversEveryBinding(t *testing.T) {
+	t.Parallel()
+	o := Overrides{
+		Chat:      aiprovider.Binding{ProviderID: "chat"},
+		Search:    aiprovider.Binding{ProviderID: "search"},
+		Extract:   aiprovider.Binding{ProviderID: "extract"},
+		OCR:       aiprovider.Binding{ProviderID: "ocr"},
+		Embedding: aiprovider.Binding{ProviderID: "embedding"},
+	}
+	seen := map[string]aiprovider.ModelPurpose{}
+	for _, item := range o.Purposes() {
+		seen[item.Binding.ProviderID] = item.Purpose
+	}
+	want := map[string]aiprovider.ModelPurpose{
+		"chat":      aiprovider.PurposeLLM,
+		"search":    aiprovider.PurposeLLM,
+		"extract":   aiprovider.PurposeLLM,
+		"ocr":       aiprovider.PurposeOCR,
+		"embedding": aiprovider.PurposeEmbedding,
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("Purposes() covered %d bindings, want %d: %+v", len(seen), len(want), seen)
+	}
+	for name, purpose := range want {
+		if seen[name] != purpose {
+			t.Fatalf("%s binding validated as %q, want %q", name, seen[name], purpose)
+		}
+	}
+}
+
+// The guard that keeps a re-embed from spending a provider call on vectors
+// nothing will ever read: a chunk row records its model, and the index only
+// reads rows matching the configured spec.
+func TestValidateEmbeddingModel(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		configured string
+		override   aiprovider.Binding
+		wantErr    bool
+	}{
+		"no override is fine": {
+			configured: "text-embedding-3-small",
+		},
+		"the configured model is a legitimate re-embed": {
+			configured: "text-embedding-3-small",
+			override:   aiprovider.Binding{ProviderID: "p1", Model: "text-embedding-3-small"},
+		},
+		"whitespace does not make it a different model": {
+			configured: "text-embedding-3-small",
+			override:   aiprovider.Binding{ProviderID: "p1", Model: "  text-embedding-3-small  "},
+		},
+		"another model writes rows the index discards": {
+			configured: "text-embedding-3-small",
+			override:   aiprovider.Binding{ProviderID: "p1", Model: "text-embedding-3-large"},
+			wantErr:    true,
+		},
+		"no index at all": {
+			configured: "",
+			override:   aiprovider.Binding{ProviderID: "p1", Model: "text-embedding-3-small"},
+			wantErr:    true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			o := Overrides{Embedding: tc.override}
+			err := o.validateEmbeddingModel(Config{EmbeddingModel: tc.configured})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateEmbeddingModel() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			// The message has to name the model to re-embed on; an admin cannot
+			// act on "wrong model".
+			if err != nil && tc.configured != "" && !strings.Contains(err.Error(), tc.configured) {
+				t.Fatalf("error does not name the configured model: %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/config/runtime.go
+++ b/backend/internal/config/runtime.go
@@ -151,110 +151,21 @@ func (r *Runtime) apply(app core.App, cfg Config) {
 	ocrLogger := logger.With("component", "ocr")
 	aiLogger := logger.With("component", "ai")
 
-	var ocrProvider ocr.Provider
-	if cfg.OCRProvider != nil {
-		// The same credential treatment the AI clients get: a chatgpt row has
-		// a minted token rather than a key, and the row itself carries neither.
-		p := *cfg.OCRProvider
-		key, opts := providerCredential(app, cfg.OCRProvider, ocrLogger)
-		p.APIKey = key
-		built, err := ocr.NewFromAIProvider(p, cfg.OCRModel, cfg.OCRTimeout, ocrLogger, opts...)
-		if err != nil {
-			logger.Warn("OCR provider unavailable after settings reload", slog.Any("error", err))
-		} else {
-			ocrProvider = built
-		}
+	// Every client is built by the same function an override goes through, in
+	// override.go. That is what keeps a per-request or per-job client identical
+	// in every respect but its model to the one Settings produces -- the
+	// credential handling, the middleware and the timeouts are not restated
+	// here to be forgotten there.
+	ocrProvider, err := buildOCR(app, cfg, cfg.OCRProvider, cfg.OCRModel, ocrLogger)
+	if err != nil {
+		logger.Warn("OCR provider unavailable after settings reload", slog.Any("error", err))
+		ocrProvider = nil
 	}
-
-	// One credential for the extraction provider, shared by the two clients
-	// built on it: asking twice would put two middlewares over one token
-	// source, and the splitter is always the extractor's provider.
-	extractKey, extractOpts := providerCredential(app, cfg.ExtractProvider, aiLogger)
-
-	var extractor ai.Extractor
-	if usableLLM(cfg.ExtractProvider) {
-		extractor = ai.NewExtractor(
-			cfg.ExtractProvider.SDK,
-			extractKey,
-			cfg.ExtractModel,
-			cfg.ExtractProvider.BaseURL,
-			cfg.ExtractionPromptVer,
-			cfg.ProcessingResultLanguage,
-			cfg.OpenAITimeout,
-			aiLogger,
-			extractOpts...,
-		)
-	}
-
-	var chatter ai.Chatter
-	if usableLLM(cfg.ChatProvider) {
-		key, opts := providerCredential(app, cfg.ChatProvider, aiLogger)
-		chatter = ai.NewChatter(
-			cfg.ChatProvider.SDK,
-			key,
-			cfg.ChatModel,
-			cfg.ChatProvider.BaseURL,
-			cfg.OpenAITimeout,
-			aiLogger,
-			opts...,
-		)
-	}
-
-	var splitter ai.Splitter
-	if usableLLM(cfg.ExtractProvider) {
-		splitter = ai.NewSplitter(
-			cfg.ExtractProvider.SDK,
-			extractKey,
-			cfg.ExtractModel,
-			cfg.ExtractProvider.BaseURL,
-			cfg.OpenAITimeout,
-			aiLogger,
-			extractOpts...,
-		)
-	}
-
-	var embedder ai.Embedder
-	if HasEmbedding(cfg) {
-		embedder = ai.NewEmbedder(
-			cfg.EmbeddingProvider.SDK,
-			cfg.EmbeddingProvider.APIKey,
-			cfg.EmbeddingModel,
-			cfg.EmbeddingProvider.BaseURL,
-			cfg.EmbeddingDims,
-			cfg.OpenAITimeout,
-			aiLogger,
-		)
-	}
-
-	var searchAgent ai.SearchAgent
-	if usableLLM(cfg.SearchProvider) {
-		key, opts := providerCredential(app, cfg.SearchProvider, aiLogger)
-		searchAgent = ai.NewSearchAgent(
-			cfg.SearchProvider.SDK,
-			key,
-			cfg.SearchModel,
-			cfg.SearchProvider.BaseURL,
-			cfg.OpenAITimeout,
-			cfg.DeepSearchLanguages,
-			cfg.ProcessingResultLanguage,
-			aiLogger,
-			opts...,
-		)
-	}
-
-	var searchHelper ai.Helper
-	if usableLLM(cfg.SearchHelperProvider) {
-		key, opts := providerCredential(app, cfg.SearchHelperProvider, aiLogger)
-		searchHelper = ai.NewHelper(
-			cfg.SearchHelperProvider.SDK,
-			key,
-			cfg.SearchHelperModel,
-			cfg.SearchHelperProvider.BaseURL,
-			cfg.OpenAITimeout,
-			aiLogger,
-			opts...,
-		)
-	}
+	extractor, splitter := buildExtractPair(app, cfg, cfg.ExtractProvider, cfg.ExtractModel, aiLogger)
+	chatter := buildChatter(app, cfg, cfg.ChatProvider, cfg.ChatModel, aiLogger)
+	embedder := buildEmbedder(app, cfg, cfg.EmbeddingProvider, cfg.EmbeddingModel, aiLogger)
+	searchAgent := buildSearchAgent(app, cfg, cfg.SearchProvider, cfg.SearchModel, aiLogger)
+	searchHelper := buildHelper(app, cfg, cfg.SearchHelperProvider, cfg.SearchHelperModel, aiLogger)
 
 	snap := Snapshot{
 		Cfg:          cfg,

--- a/backend/internal/ocr/provider.go
+++ b/backend/internal/ocr/provider.go
@@ -31,12 +31,6 @@ type LimitedConcurrency interface {
 	MaxConcurrency() int
 }
 
-type ProviderInfo struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	SDK  string `json:"sdk"`
-}
-
 // NewFromAIProvider builds the OCR provider a row describes.
 //
 // extra carries request options the caller had to build for it -- today only

--- a/backend/internal/reprocess/reprocess.go
+++ b/backend/internal/reprocess/reprocess.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
 
+	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/models"
 	"lemmary/backend/internal/worker"
 )
@@ -60,6 +61,12 @@ type Request struct {
 	DocumentIDs []string
 	Limit       int
 	Mode        Mode
+	// Overrides are the provider and model this batch runs on, instead of the
+	// bindings in Settings. Stored on each job rather than resolved here: the
+	// worker may not reach a queued job for minutes, and a batch queued to try
+	// a different extractor must not quietly run on whatever Settings holds by
+	// then. Zero means the configured bindings.
+	Overrides config.Overrides
 }
 
 // Result reports what a batch did. Remaining counts documents still failed
@@ -115,7 +122,7 @@ func RunBatch(app core.App, req Request) (Result, error) {
 	result := Result{Skipped: skipped}
 	for _, document := range documents {
 		steps, forceSteps := StepsFor(document, mode)
-		if err := queueOne(app, document, steps, forceSteps); err != nil {
+		if err := queueOne(app, document, steps, forceSteps, req.Overrides); err != nil {
 			return result, fmt.Errorf("queue document %s: %w", document.Id, err)
 		}
 		result.Queued++
@@ -142,13 +149,13 @@ func RunBatch(app core.App, req Request) (Result, error) {
 // which would set the document to processing, so the job must not become visible
 // before the pending write lands. A rollback also means a failed create cannot
 // leave the document stranded at pending with no job to move it.
-func queueOne(app core.App, document *core.Record, steps, forceSteps []string) error {
+func queueOne(app core.App, document *core.Record, steps, forceSteps []string, overrides config.Overrides) error {
 	return app.RunInTransaction(func(txApp core.App) error {
 		document.Set("processing_status", models.DocStatusPending)
 		if err := txApp.Save(document); err != nil {
 			return err
 		}
-		_, err := worker.Enqueue(txApp, document.Id, steps, forceSteps)
+		_, err := worker.Enqueue(txApp, document.Id, steps, forceSteps, overrides)
 		return err
 	})
 }

--- a/backend/internal/worker/enqueue_guard_test.go
+++ b/backend/internal/worker/enqueue_guard_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tools/filesystem"
 
+	"lemmary/backend/internal/config"
 	"lemmary/backend/internal/models"
 	// Registers the migrations that create processing_jobs; without them
 	// RunAppMigrations builds an empty schema.
@@ -90,7 +91,7 @@ func TestEnqueueRefusesASecondJobWhileEmbedIsStillRunning(t *testing.T) {
 
 	live := makeJob(t, app, documentID, models.JobStatusCompleted, "")
 
-	got, err := createProcessingJob(app, documentID, []string{models.StepEmbed}, nil)
+	got, err := createProcessingJob(app, documentID, []string{models.StepEmbed}, nil, config.Overrides{})
 	if err != nil {
 		t.Fatalf("createProcessingJob: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestEnqueueGuardBoundaries(t *testing.T) {
 			documentID := makeDocumentForEnqueue(t, app)
 			existing := makeJob(t, app, documentID, tc.status, tc.finishedAt)
 
-			got, err := createProcessingJob(app, documentID, []string{models.StepEmbed}, nil)
+			got, err := createProcessingJob(app, documentID, []string{models.StepEmbed}, nil, config.Overrides{})
 			if err != nil {
 				t.Fatalf("createProcessingJob: %v", err)
 			}

--- a/backend/internal/worker/job_overrides.go
+++ b/backend/internal/worker/job_overrides.go
@@ -1,0 +1,82 @@
+package worker
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/core"
+	"lemmary/backend/internal/config"
+)
+
+// jobOverridesField is the column a job's provider/model choices live in.
+const jobOverridesField = "overrides"
+
+// parseJobOverrides reads a job's provider and model choices.
+//
+// A job with nothing stored, or with something unreadable stored, runs on the
+// configured bindings -- the same answer parseForceSteps gives, and for the
+// same reason: the overrides are a refinement of a job that is otherwise
+// perfectly runnable, and refusing to run it over a malformed refinement would
+// strand a document. Anything a browser could put there has already been
+// refused by the create hook.
+func parseJobOverrides(job *core.Record) config.Overrides {
+	var out config.Overrides
+	raw := job.Get(jobOverridesField)
+	if raw == nil {
+		return out
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return out
+	}
+	// A JSONField round-trips an empty column as the four bytes "null", which
+	// unmarshals into the zero value anyway; decoding it is cheaper than
+	// special-casing it.
+	if err := json.Unmarshal(data, &out); err != nil {
+		return config.Overrides{}
+	}
+	return out
+}
+
+// setJobOverrides writes the choices onto a new job, leaving the column unset
+// when there are none. Unset rather than "{}" so a job queued without a picker
+// touched is byte-identical to every job created before overrides existed.
+func setJobOverrides(job *core.Record, overrides config.Overrides) {
+	if overrides.Empty() {
+		return
+	}
+	job.Set(jobOverridesField, overrides)
+}
+
+// effectiveSnapshot is the configuration this job actually runs under: the
+// published snapshot, with whatever the job overrides rebuilt on its own
+// bindings.
+//
+// A job with no overrides gets the published snapshot unchanged and builds
+// nothing, which is every job an unmodified reprocess queues.
+func (p *Processor) effectiveSnapshot(job *core.Record) (config.Snapshot, error) {
+	overrides := parseJobOverrides(job)
+	if overrides.Empty() {
+		return p.rt.Snapshot(), nil
+	}
+	return p.rt.WithOverrides(p.app, overrides)
+}
+
+// validateJobOverrides refuses a job whose overrides name a provider that does
+// not exist or cannot do the work.
+//
+// It runs in the processing_jobs create hook rather than in the reprocess
+// handler because that collection is writable by its owner: the single-document
+// reprocess form creates a job straight through the collection API
+// (frontend/src/lib/api/documents.ts), so a check in the custom endpoint would
+// guard one of the two ways a job is made. This is the point both paths cross.
+func validateJobOverrides(app core.App, cfg config.Config, job *core.Record) error {
+	overrides := parseJobOverrides(job)
+	if overrides.Empty() {
+		return nil
+	}
+	// Chat and search are not refused here, only unused. This hook guards what
+	// a job may run on; the reprocess endpoint is where a client that sent an
+	// inapplicable binding is told so, because it is the layer that knows the
+	// request was a reprocess rather than an upload.
+	return overrides.Validate(app, cfg)
+}

--- a/backend/internal/worker/job_overrides_test.go
+++ b/backend/internal/worker/job_overrides_test.go
@@ -1,0 +1,200 @@
+package worker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"lemmary/backend/internal/aiprovider"
+	"lemmary/backend/internal/config"
+	"lemmary/backend/internal/models"
+)
+
+func makeProviderForOverrides(t *testing.T, app core.App, sdk, apiKey, baseURL string) string {
+	t.Helper()
+	collection, err := app.FindCollectionByNameOrId(aiprovider.CollectionName)
+	if err != nil {
+		t.Fatalf("%s collection: %v", aiprovider.CollectionName, err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("sdk", sdk)
+	// Unique per row: the collection has a unique index on alias.
+	record.Set("alias", sdk+" "+apiKey+baseURL)
+	record.Set("base_url", baseURL)
+	record.Set("api_key", apiKey)
+	if err := app.Save(record); err != nil {
+		t.Fatalf("save provider: %v", err)
+	}
+	return record.Id
+}
+
+// jobWithOverrides is a job record carrying overrides but never saved -- what
+// the create hook is handed before the write lands.
+func jobWithOverrides(t *testing.T, app core.App, overrides config.Overrides) *core.Record {
+	t.Helper()
+	collection, err := app.FindCollectionByNameOrId("processing_jobs")
+	if err != nil {
+		t.Fatalf("processing_jobs collection: %v", err)
+	}
+	job := core.NewRecord(collection)
+	job.Set("steps", []string{models.StepExtractMetadata})
+	setJobOverrides(job, overrides)
+	return job
+}
+
+// A job queued with no picker touched must look exactly like one queued before
+// overrides existed: an unset column, not a stored "{}".
+func TestEnqueueLeavesOverridesUnsetWhenThereAreNone(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	documentID := makeDocumentForEnqueue(t, app)
+
+	job, err := Enqueue(app, documentID, []string{models.StepEmbed}, nil, config.Overrides{})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if raw := strings.TrimSpace(job.GetString(jobOverridesField)); raw != "" && raw != "null" {
+		t.Fatalf("overrides = %q, want unset", raw)
+	}
+	if got := parseJobOverrides(job); !got.Empty() {
+		t.Fatalf("parseJobOverrides() = %+v, want empty", got)
+	}
+}
+
+// The choice has to survive the queue: the worker may not reach a job for
+// minutes, and a batch queued to try a different extractor must not quietly run
+// on whatever Settings holds by then.
+func TestEnqueueStoresOverridesOnTheJob(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	documentID := makeDocumentForEnqueue(t, app)
+	provider := makeProviderForOverrides(t, app, aiprovider.SDKOpenAI, "sk-test", "https://api.openai.com/v1")
+
+	want := aiprovider.Binding{ProviderID: provider, Model: "gpt-6-astra"}
+	job, err := Enqueue(app, documentID, []string{models.StepExtractMetadata}, nil, config.Overrides{Extract: want})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	// Re-read rather than trusting the in-memory record: the round trip through
+	// the JSON column is the part that can lose the value.
+	stored, err := app.FindRecordById("processing_jobs", job.Id)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	got := parseJobOverrides(stored)
+	if got.Extract != want {
+		t.Fatalf("extract override = %+v, want %+v", got.Extract, want)
+	}
+	if !got.OCR.Empty() || !got.Embedding.Empty() {
+		t.Fatalf("unset bindings came back populated: %+v", got)
+	}
+}
+
+// A job whose overrides column holds something unreadable still runs, on the
+// configured bindings -- the same answer parseForceSteps gives. The overrides
+// are a refinement of an otherwise runnable job, and stranding a document over
+// a malformed refinement is the worse failure.
+func TestParseJobOverridesToleratesGarbage(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	job := jobWithOverrides(t, app, config.Overrides{})
+	job.Set(jobOverridesField, `"not an object"`)
+
+	if got := parseJobOverrides(job); !got.Empty() {
+		t.Fatalf("parseJobOverrides() = %+v, want empty", got)
+	}
+}
+
+// The trust boundary. processing_jobs is writable by the document's owner --
+// the single-document reprocess form creates a job straight through the
+// collection API -- so a browser can name any provider row for any binding.
+func TestValidateJobOverridesRefusesABindingTheProviderCannotServe(t *testing.T) {
+	cases := map[string]struct {
+		sdk       string
+		baseURL   string
+		overrides func(providerID string) config.Overrides
+	}{
+		// The embeddings sidecar embeds without chatting: bound to extraction it
+		// would fail on every document.
+		"local embeddings cannot extract": {
+			sdk:     aiprovider.SDKLocalEmbeddings,
+			baseURL: "http://embeddings:80/v1",
+			overrides: func(id string) config.Overrides {
+				return config.Overrides{Extract: aiprovider.Binding{ProviderID: id, Model: "bge-m3"}}
+			},
+		},
+		// And the reverse: docling reads documents and cannot produce a vector.
+		"docling cannot embed": {
+			sdk:     aiprovider.SDKDocling,
+			baseURL: "http://docling:5001",
+			overrides: func(id string) config.Overrides {
+				return config.Overrides{Embedding: aiprovider.Binding{ProviderID: id, Model: "rapidocr"}}
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			app := bootAppForEnqueue(t)
+			provider := makeProviderForOverrides(t, app, tc.sdk, "", tc.baseURL)
+			overrides := tc.overrides(provider)
+
+			err := validateJobOverrides(app, config.Config{}, jobWithOverrides(t, app, overrides))
+			if err == nil {
+				t.Fatal("accepted an override whose provider cannot serve its binding")
+			}
+		})
+	}
+}
+
+func TestValidateJobOverridesRefusesAnUnknownProvider(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	job := jobWithOverrides(t, app, config.Overrides{
+		Extract: aiprovider.Binding{ProviderID: "nosuchprovider", Model: "gpt-6-astra"},
+	})
+
+	if err := validateJobOverrides(app, config.Config{}, job); err == nil {
+		t.Fatal("accepted an override naming a provider that does not exist")
+	}
+}
+
+func TestValidateJobOverridesAcceptsAUsableExtractProvider(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	provider := makeProviderForOverrides(t, app, aiprovider.SDKOpenAI, "sk-test", "https://api.openai.com/v1")
+	job := jobWithOverrides(t, app, config.Overrides{
+		Extract: aiprovider.Binding{ProviderID: provider, Model: "gpt-6-astra"},
+	})
+
+	if err := validateJobOverrides(app, config.Config{}, job); err != nil {
+		t.Fatalf("validateJobOverrides: %v", err)
+	}
+}
+
+// A job with nothing stored must not be made to resolve anything, so an
+// instance with no providers at all still processes its uploads.
+func TestValidateJobOverridesPassesWithNoOverrides(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	if err := validateJobOverrides(app, config.Config{}, jobWithOverrides(t, app, config.Overrides{})); err != nil {
+		t.Fatalf("validateJobOverrides: %v", err)
+	}
+}
+
+// The embedding guard, end to end through the hook's entry point: the same
+// model is a legitimate fix-up re-embed, a different one writes vectors the
+// chunk index will never read.
+func TestValidateJobOverridesEmbeddingModelMustMatchTheIndex(t *testing.T) {
+	app := bootAppForEnqueue(t)
+	provider := makeProviderForOverrides(t, app, aiprovider.SDKOpenAI, "sk-test", "https://api.openai.com/v1")
+	cfg := config.Config{EmbeddingModel: "text-embedding-3-small"}
+
+	same := jobWithOverrides(t, app, config.Overrides{
+		Embedding: aiprovider.Binding{ProviderID: provider, Model: "text-embedding-3-small"},
+	})
+	if err := validateJobOverrides(app, cfg, same); err != nil {
+		t.Fatalf("refused a re-embed on the configured model: %v", err)
+	}
+
+	other := jobWithOverrides(t, app, config.Overrides{
+		Embedding: aiprovider.Binding{ProviderID: provider, Model: "text-embedding-3-large"},
+	})
+	if err := validateJobOverrides(app, cfg, other); err == nil {
+		t.Fatal("accepted an embedding override the chunk index cannot read")
+	}
+}

--- a/backend/internal/worker/processor.go
+++ b/backend/internal/worker/processor.go
@@ -126,7 +126,7 @@ func (p *Processor) registerHooks() {
 		}
 
 		steps := createStepsFor(record)
-		_, err := createProcessingJob(e.App, record.Id, steps, nil)
+		_, err := createProcessingJob(e.App, record.Id, steps, nil, config.Overrides{})
 		return err
 	})
 
@@ -141,6 +141,14 @@ func (p *Processor) registerHooks() {
 		}
 		if len(steps) == 0 {
 			record.Set("steps", models.FullPipelineSteps)
+		}
+		// The trust boundary for the provider/model choices: this collection is
+		// writable by the document's owner, so `overrides` arrives from a
+		// browser on the single-document reprocess path as well as through the
+		// custom endpoint. Refused as a bad request, which is what the direct
+		// collection write surfaces to the form that made it.
+		if err := validateJobOverrides(e.App, p.rt.Snapshot().Cfg, record); err != nil {
+			return router.NewBadRequestError(err.Error(), nil)
 		}
 		return e.Next()
 	})
@@ -162,12 +170,13 @@ func (p *Processor) registerHooks() {
 
 // Enqueue creates a pending job for documentID so the worker picks it up on the
 // next drain. It is the entry point for callers outside this package (bulk
-// reprocess); forceSteps may be nil.
-func Enqueue(app core.App, documentID string, steps []string, forceSteps []string) (*core.Record, error) {
-	return createProcessingJob(app, documentID, steps, forceSteps)
+// reprocess); forceSteps may be nil and overrides may be zero, which means the
+// job runs on the bindings in Settings.
+func Enqueue(app core.App, documentID string, steps []string, forceSteps []string, overrides config.Overrides) (*core.Record, error) {
+	return createProcessingJob(app, documentID, steps, forceSteps, overrides)
 }
 
-func createProcessingJob(app core.App, documentID string, steps []string, forceSteps []string) (*core.Record, error) {
+func createProcessingJob(app core.App, documentID string, steps []string, forceSteps []string, overrides config.Overrides) (*core.Record, error) {
 	// Ensure-queued semantics: a document with an active job must not get a
 	// second one — concurrent reprocess requests would otherwise run OCR and
 	// AI extraction twice for the same document.
@@ -213,6 +222,7 @@ func createProcessingJob(app core.App, documentID string, steps []string, forceS
 	if len(forceSteps) > 0 {
 		job.Set("force_steps", forceSteps)
 	}
+	setJobOverrides(job, overrides)
 
 	if err := app.Save(job); err != nil {
 		return nil, err
@@ -244,7 +254,39 @@ func (p *Processor) drainPending() {
 			return
 		}
 
-		snap := p.rt.Snapshot()
+		// Checked before anything else touches the job, so every path below
+		// that leaves it runnable is caught here rather than spinning. It used
+		// to sit lower, which was safe only because both paths above it
+		// returned; the override paths do not.
+		if job.Id == lastJobID {
+			// The previous iteration returned without moving the job out of the
+			// runnable set, so picking it up again would spin. Hand it back to
+			// the cron instead.
+			p.app.Logger().Error("job made no progress; deferring to next cron tick", "job", job.Id)
+			return
+		}
+		lastJobID = job.Id
+
+		// The job's own bindings are applied before readiness is judged, not
+		// after. A job queued with an OCR or extraction override may be the one
+		// job that *can* run on an instance whose configured provider is gone,
+		// and asking providersReady about the configured snapshot would defer it
+		// forever over a binding it does not use.
+		snap, err := p.effectiveSnapshot(job)
+		if err != nil {
+			// Stored overrides that no longer resolve -- a provider deleted
+			// between queueing and draining. Failed rather than deferred: the
+			// job asked for a provider that no longer exists, and no amount of
+			// waiting brings it back. The document lands on "failed", where a
+			// plain reprocess can pick it up again without the override.
+			//
+			// Return value dropped deliberately: failJob hands back the error it
+			// was given whether or not the write succeeded, so testing it would
+			// log the same error twice under a message about the write. failJob
+			// logs "job failed" with the cause itself.
+			_ = failJob(p.app, job, nil, err)
+			continue
+		}
 		if err := providersReady(snap); err != nil {
 			// Leave the job pending so it runs once Settings are complete. Returning
 			// (rather than retrying inline) is what keeps this from becoming a hot
@@ -256,14 +298,6 @@ func (p *Processor) drainPending() {
 			)
 			return
 		}
-
-		if job.Id == lastJobID {
-			// runJob returned without moving the job out of the runnable set, so
-			// picking it up again would spin. Hand it back to the cron instead.
-			p.app.Logger().Error("job made no progress; deferring to next cron tick", "job", job.Id)
-			return
-		}
-		lastJobID = job.Id
 
 		if err := p.runJob(job.Id, snap); err != nil {
 			p.app.Logger().Error("job error", "job", job.Id, slog.Any("error", err))

--- a/backend/migrations/1730000027_chat_session_binding.go
+++ b/backend/migrations/1730000027_chat_session_binding.go
@@ -1,0 +1,43 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// The provider and model a conversation runs on, so a chat can be opened on
+// something other than the global chat/search binding in Settings.
+//
+// Fixed for the conversation's lifetime, like mode beside it: a transcript
+// produced by one model must not be replayed to another as though the answers
+// in it were its own. Empty means the Settings binding, which is every session
+// that already exists -- so this migration changes no behaviour by itself.
+//
+// Text rather than a relation to ai_providers: see the field comment in
+// internal/chat/collection.go, which is the definition a fresh install uses.
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("chat_sessions")
+		if err != nil {
+			return err
+		}
+		if collection.Fields.GetByName("provider") == nil {
+			collection.Fields.Add(&core.TextField{Name: "provider", Max: 15})
+		}
+		if collection.Fields.GetByName("model") == nil {
+			collection.Fields.Add(&core.TextField{Name: "model", Max: 200})
+		}
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("chat_sessions")
+		if err != nil {
+			return nil
+		}
+		for _, name := range []string{"provider", "model"} {
+			if f := collection.Fields.GetByName(name); f != nil {
+				collection.Fields.RemoveById(f.GetId())
+			}
+		}
+		return app.Save(collection)
+	})
+}

--- a/backend/migrations/1730000028_job_overrides.go
+++ b/backend/migrations/1730000028_job_overrides.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// The provider and model a reprocess job runs on, when it was queued on
+// something other than the configured bindings.
+//
+// One JSON column rather than six text ones. The shape is
+//
+//	{"ocr":{"provider_id":"...","model":"..."},
+//	 "extract":{...},"embedding":{...}}
+//
+// which is worth a column of its own precisely because the set of bindings
+// keeps growing: app_settings has taken four separate migrations to reach six
+// pairs, and a job carrying the overrides as a document needs none of them.
+//
+// Empty or absent means the Settings bindings, which is every job that already
+// exists and every job queued without a picker touched -- so this changes no
+// behaviour by itself. The column is validated in the processing_jobs create
+// hook rather than in the reprocess handler, because the single-document
+// reprocess form writes a job straight through the collection API.
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("processing_jobs")
+		if err != nil {
+			return err
+		}
+		if collection.Fields.GetByName("overrides") == nil {
+			collection.Fields.Add(&core.JSONField{Name: "overrides", MaxSize: 2000})
+		}
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("processing_jobs")
+		if err != nil {
+			return nil
+		}
+		if f := collection.Fields.GetByName("overrides"); f != nil {
+			collection.Fields.RemoveById(f.GetId())
+		}
+		return app.Save(collection)
+	})
+}

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -216,6 +216,49 @@ only file-capable models where the provider says which those are (OpenRouter's
 `file` input, Mistral's `ocr` capability); other SDKs show the full catalogue
 with a warning. Any list can be typed past with the **Custom model id** field.
 
+## Overriding a model for one chat or one job
+
+The bindings above are the defaults. A single chat or a single reprocess job can
+run on a different provider and model without touching them — useful for
+retrying one stubborn document on a stronger extractor, or asking a cheap
+question of a cheap model. Any signed-in user can do this; the choice is among
+the providers an admin has already configured, so it can spend the operator's
+credentials but never add a new one.
+
+- **Ask AI** and **Deep Search** offer *Use a different chat/search model*
+  under the composer, which also names the model in use when nothing is
+  overridden. The choice is fixed for the conversation, like the Search/Research
+  mode beside it: the transcript replayed on each turn was produced by one
+  model, and answering the next question with another reads that work back as if
+  it were its own. Start a new chat to switch. Deep Search's **helper** model is
+  not moved by this — it is a separate binding because it does many cheap
+  per-document calls where the search model does a few expensive ones.
+
+  **A conversation records the model it opened on, whether or not anyone picked
+  it.** So changing the chat or search binding in Settings applies to new chats
+  and leaves existing ones where they are, rather than moving every open
+  transcript onto a model that did not write it. Conversations from before this
+  shipped have nothing recorded and do still follow Settings.
+- **Reprocess** — on a document's own page, on the document list's bulk bar, and
+  in **Management → Failed processing** — offers OCR, extraction and embedding.
+  The choice is stored on each queued job, so a batch queued to try a different
+  extractor runs on it however long the queue takes, rather than on whatever
+  Settings holds by the time the worker gets there. The step history
+  (**Processing job → step runs**) records the provider and model that actually
+  ran.
+- Left untouched, every picker sends nothing and the job or chat runs exactly as
+  it did before — the same request, byte for byte.
+
+**The embedding override must name the model already bound in Settings.** A
+chunk row records the model and dimension count it was produced with, and the
+retrieval index only reads the rows matching the configured one, so vectors from
+any other model would be paid for, written, and never read — a document silently
+dropping out of dense search. The server refuses that rather than letting it
+look like success. Re-embedding on the *configured* model is the case worth
+having: a fix-up for a document whose vectors are missing or stale. To change
+the model itself, change it in Settings, which re-embeds everything (see [What
+embeddings cost](#what-embeddings-cost)).
+
 ## What embeddings cost
 
 Turning `AI_EMBEDDING_MODEL` on is a commitment to embed the whole archive, not

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -238,7 +238,10 @@ credentials but never add a new one.
   it.** So changing the chat or search binding in Settings applies to new chats
   and leaves existing ones where they are, rather than moving every open
   transcript onto a model that did not write it. Conversations from before this
-  shipped have nothing recorded and do still follow Settings.
+  shipped have nothing recorded and do still follow Settings. If the provider a
+  conversation is pinned to is later deleted, the chat keeps working: the next
+  turn falls back to the binding in Settings, so rotating a provider does not
+  leave open chats stuck.
 - **Reprocess** — on a document's own page, on the document list's bulk bar, and
   in **Management → Failed processing** — offers OCR, extraction and embedding.
   The choice is stored on each queued job, so a batch queued to try a different

--- a/frontend/src/components/BindingOverride.tsx
+++ b/frontend/src/components/BindingOverride.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useRef } from 'react'
+import {
+  asPickerProvider,
+  bindingModelLabel,
+  listPickableProviders,
+  EMPTY_BINDING,
+  type ModelPurpose,
+  type ProviderBinding,
+} from '../lib/api/providers'
+import type { JobOverrides } from '../lib/api/documents'
+import type { ProcessingStep } from '../lib/processing'
+import { useAsync } from '../hooks/useAsync'
+import { ProviderModelFields } from './ProviderModelFields'
+import { fieldHintClassName } from './ui'
+
+type BindingOverrideProps = {
+  /** Names the binding being overridden, e.g. "Chat" or "Extraction". */
+  label: string
+  purpose: ModelPurpose
+  /**
+   * The chosen binding, or undefined for "use the configured model".
+   *
+   * Undefined is the off state rather than an empty binding, because an empty
+   * one is a real intermediate state: the picker is open and no provider has
+   * been chosen yet. Collapsing the two would make the checkbox unable to open.
+   */
+  value: ProviderBinding | undefined
+  onChange: (binding: ProviderBinding | undefined) => void
+  /** Short explanation of what this binding is used for. */
+  help?: string
+  /**
+   * Locks the choice open on its current value. For a conversation that already
+   * has turns: the binding is fixed once a transcript exists, so the picker has
+   * to show what it is running on without offering to change it.
+   */
+  locked?: boolean
+  /** What the locked state says in place of the picker. */
+  lockedHint?: string
+  /**
+   * Names the model that answers when nothing is overridden.
+   *
+   * For the chat surfaces, where "which model am I talking to?" is a fair
+   * question whether or not anyone touched the picker. Off for the reprocess
+   * forms, where it would cost a request per binding on every page load to
+   * answer something the step history already records after the fact.
+   */
+  showConfigured?: boolean
+  /**
+   * Names which configured binding to report as the default, when the purpose
+   * alone cannot say -- "search" and "chat" are both `llm`. Passed through to
+   * the providers endpoint.
+   */
+  bindingName?: string
+}
+
+/**
+ * An optional provider/model choice for one chat or one reprocess job.
+ *
+ * Off by default, and off means the request carries no binding at all -- so a
+ * page whose checkbox is never ticked behaves exactly as it did before
+ * overrides existed. That default is the whole reason this wraps
+ * ProviderModelFields rather than using it directly: in Settings a binding
+ * always exists, and on these five surfaces it usually should not.
+ *
+ * The provider list comes from /api/app/ai/providers, which any signed-in user
+ * may read; ProviderModelFields fetches the model catalogue per provider.
+ */
+export function BindingOverride({
+  label,
+  purpose,
+  value,
+  onChange,
+  help,
+  locked = false,
+  lockedHint,
+  showConfigured = false,
+  bindingName,
+}: BindingOverrideProps) {
+  const open = value !== undefined
+
+  // The binding as it stands *within* the current event, not as of the last
+  // render.
+  //
+  // ProviderModelFields reports a provider change as two calls in one handler:
+  // onProviderChange(next), then onModelChange('') to drop the model that
+  // belonged to the old provider. Both run before React re-renders, so a
+  // handler that merged into the `value` prop would compute the second update
+  // from the pre-change binding -- and the model reset would put the empty
+  // provider back, leaving the picker stuck on "Select a provider" however many
+  // times it was clicked. Settings does not hit this: each of its two callbacks
+  // writes a different field of one settings object.
+  // Synced in an effect rather than assigned during render, which React
+  // forbids; the handlers below keep it current within an event themselves,
+  // which is the case that matters here.
+  const latest = useRef(value)
+  useEffect(() => {
+    latest.current = value
+  }, [value])
+
+  function update(next: ProviderBinding | undefined) {
+    latest.current = next
+    onChange(next)
+  }
+
+  const providersState = useAsync(async () => {
+    // Fetched when the picker is opened, and also when the caller wants the
+    // configured model named -- that answer comes from the same request. A page
+    // that shows neither pays for nothing: most visits to a reprocess form
+    // override no model at all.
+    if (!open && !showConfigured) return { providers: [], configured: {} }
+    return listPickableProviders(purpose, bindingName)
+  }, [open, showConfigured, purpose, bindingName])
+  const providers = (providersState.data?.providers ?? []).map(asPickerProvider)
+  const configured = providersState.data?.configured ?? {}
+
+  // The model this binding actually runs on: the override when there is one,
+  // the Settings binding when there is not.
+  const effectiveModel = value?.provider_id ? value.model : configured.model
+  const source = value?.provider_id ? '' : ' (from Settings)'
+
+  if (locked) {
+    if (!value?.provider_id && !showConfigured) return null
+    return (
+      <div className="flex flex-col gap-1">
+        <p className="text-xs text-ink-soft">
+          {label} model:{' '}
+          <span className="font-medium text-ink">{bindingModelLabel(effectiveModel)}</span>
+          {source}
+        </p>
+        {value?.provider_id && lockedHint && <p className={fieldHintClassName}>{lockedHint}</p>}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Which model answers, whether or not it was chosen here. Without it the
+          only way to know was to open Settings, which most accounts cannot. */}
+      {showConfigured && !open && (
+        <p className="text-xs text-ink-soft">
+          {label} model:{' '}
+          <span className="font-medium text-ink">{bindingModelLabel(configured.model)}</span>
+          {configured.provider_name ? ` (${configured.provider_name}, from Settings)` : ' (from Settings)'}
+        </p>
+      )}
+      <label className="flex items-center gap-2 text-sm text-ink-muted">
+        <input
+          type="checkbox"
+          checked={open}
+          onChange={(event) => update(event.target.checked ? { ...EMPTY_BINDING } : undefined)}
+          className="size-4 rounded-xs border-line-strong text-oxblood focus:ring-oxblood"
+        />
+        Use a different {label.toLowerCase()} model
+      </label>
+
+      {open && (
+        <>
+          <ProviderModelFields
+            label={label}
+            help={help}
+            providers={providers}
+            providerId={value.provider_id}
+            model={value.model}
+            purpose={purpose}
+            onProviderChange={(provider_id) => update({ provider_id, model: '' })}
+            onModelChange={(model) => update({ ...(latest.current ?? EMPTY_BINDING), model })}
+          />
+          {providersState.error && <p className="text-xs text-amber-700">{providersState.error}</p>}
+          {!providersState.loading && providers.length === 0 && !providersState.error && (
+            <p className="text-xs text-amber-800">
+              No configured provider can serve this binding. Add one in Settings.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The three pipeline steps that run on a model, and the job binding each one
+ * uses. The other three steps -- preview, duplicate detection, applying the
+ * metadata -- call no provider at all, so they have no model to override.
+ *
+ * One table, read by both shapes of the picker: grouped, for the pages that
+ * queue a batch by mode, and per step, for the form that ticks steps
+ * individually. Two copies would mean two versions of the embedding warning.
+ *
+ * Not exported: nothing outside needs it, and exporting a constant from a file
+ * that also exports components costs Fast Refresh.
+ */
+const JOB_BINDINGS = [
+  {
+    step: 'ocr',
+    key: 'ocr',
+    purpose: 'ocr',
+    label: 'OCR',
+    help: 'Reads the text out of the document.',
+  },
+  {
+    step: 'extract_metadata',
+    key: 'extract',
+    purpose: 'llm',
+    label: 'Extraction',
+    help: "Turns the document's text into its title, date, type and tags.",
+  },
+  {
+    step: 'embed',
+    key: 'embedding',
+    purpose: 'embedding',
+    label: 'Embedding',
+    help: 'Builds the retrieval vectors. Must name the model already bound in Settings — vectors from any other model are written and never read, because the search index only reads the configured one.',
+  },
+] as const satisfies readonly {
+  step: ProcessingStep
+  key: keyof JobOverrides
+  purpose: ModelPurpose
+  label: string
+  help: string
+}[]
+
+/**
+ * The model override for one pipeline step, or nothing for a step that calls no
+ * provider.
+ *
+ * Rendered beside the step it belongs to rather than in a block of its own: the
+ * question "which model?" only means anything once you have said you are
+ * re-running the step that uses one.
+ */
+export function StepBindingOverride({
+  step,
+  value,
+  onChange,
+}: {
+  step: ProcessingStep
+  value: JobOverrides
+  onChange: (overrides: JobOverrides) => void
+}) {
+  const binding = JOB_BINDINGS.find((item) => item.step === step)
+  if (!binding) return null
+  return (
+    <BindingOverride
+      label={binding.label}
+      purpose={binding.purpose}
+      value={value[binding.key]}
+      onChange={(next) => onChange({ ...value, [binding.key]: next })}
+      help={binding.help}
+    />
+  )
+}
+
+/**
+ * All three bindings in one block, for the pages that queue a reprocess by mode
+ * rather than by ticking steps: the bulk bar on the document list and the
+ * failed-processing panel.
+ *
+ * All three are offered whatever the mode is. "Auto" does not know which steps
+ * it will run until the server looks at each document, and a picker that
+ * appears and disappears as the mode dropdown moves is harder to reason about
+ * than one a job simply ignores.
+ */
+export function JobOverrideFields({
+  value,
+  onChange,
+}: {
+  value: JobOverrides
+  onChange: (overrides: JobOverrides) => void
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-t border-line pt-3">
+      {JOB_BINDINGS.map((binding) => (
+        <BindingOverride
+          key={binding.key}
+          label={binding.label}
+          purpose={binding.purpose}
+          value={value[binding.key]}
+          onChange={(next) => onChange({ ...value, [binding.key]: next })}
+          help={binding.help}
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/BindingOverride.tsx
+++ b/frontend/src/components/BindingOverride.tsx
@@ -7,7 +7,7 @@ import {
   type ModelPurpose,
   type ProviderBinding,
 } from '../lib/api/providers'
-import type { JobOverrides } from '../lib/api/documents'
+import { STEP_BINDINGS, type JobOverrides } from '../lib/api/documents'
 import type { ProcessingStep } from '../lib/processing'
 import { useAsync } from '../hooks/useAsync'
 import { ProviderModelFields } from './ProviderModelFields'
@@ -178,13 +178,9 @@ export function BindingOverride({
 }
 
 /**
- * The three pipeline steps that run on a model, and the job binding each one
- * uses. The other three steps -- preview, duplicate detection, applying the
- * metadata -- call no provider at all, so they have no model to override.
- *
- * One table, read by both shapes of the picker: grouped, for the pages that
- * queue a batch by mode, and per step, for the form that ticks steps
- * individually. Two copies would mean two versions of the embedding warning.
+ * How each overridable step is presented; STEP_BINDINGS says which binding it
+ * reads. One table, read by both shapes of the picker -- grouped, for the pages
+ * that queue by mode, and per step -- so there is one embedding warning.
  *
  * Not exported: nothing outside needs it, and exporting a constant from a file
  * that also exports components costs Fast Refresh.
@@ -192,28 +188,26 @@ export function BindingOverride({
 const JOB_BINDINGS = [
   {
     step: 'ocr',
-    key: 'ocr',
     purpose: 'ocr',
     label: 'OCR',
     help: 'Reads the text out of the document.',
   },
   {
     step: 'extract_metadata',
-    key: 'extract',
     purpose: 'llm',
     label: 'Extraction',
     help: "Turns the document's text into its title, date, type and tags.",
   },
   {
     step: 'embed',
-    key: 'embedding',
     purpose: 'embedding',
     label: 'Embedding',
     help: 'Builds the retrieval vectors. Must name the model already bound in Settings — vectors from any other model are written and never read, because the search index only reads the configured one.',
   },
 ] as const satisfies readonly {
-  step: ProcessingStep
-  key: keyof JobOverrides
+  // Narrower than ProcessingStep on purpose: a step with no binding cannot be
+  // listed here.
+  step: keyof typeof STEP_BINDINGS
   purpose: ModelPurpose
   label: string
   help: string
@@ -238,12 +232,13 @@ export function StepBindingOverride({
 }) {
   const binding = JOB_BINDINGS.find((item) => item.step === step)
   if (!binding) return null
+  const key = STEP_BINDINGS[binding.step]
   return (
     <BindingOverride
       label={binding.label}
       purpose={binding.purpose}
-      value={value[binding.key]}
-      onChange={(next) => onChange({ ...value, [binding.key]: next })}
+      value={value[key]}
+      onChange={(next) => onChange({ ...value, [key]: next })}
       help={binding.help}
     />
   )
@@ -270,11 +265,11 @@ export function JobOverrideFields({
     <div className="flex flex-col gap-3 border-t border-line pt-3">
       {JOB_BINDINGS.map((binding) => (
         <BindingOverride
-          key={binding.key}
+          key={binding.step}
           label={binding.label}
           purpose={binding.purpose}
-          value={value[binding.key]}
-          onChange={(next) => onChange({ ...value, [binding.key]: next })}
+          value={value[STEP_BINDINGS[binding.step]]}
+          onChange={(next) => onChange({ ...value, [STEP_BINDINGS[binding.step]]: next })}
           help={binding.help}
         />
       ))}

--- a/frontend/src/components/Combobox.tsx
+++ b/frontend/src/components/Combobox.tsx
@@ -25,6 +25,10 @@ type Props = {
   bgClassName?: string
 }
 
+// max-h-56 on the listbox, in pixels. Read to decide which way the list opens,
+// so the two have to move together.
+const listMaxHeightPx = 224
+
 const comboboxInputClassName =
   'w-full rounded-xs border border-line-strong py-2 pr-8 pl-3 text-sm text-ink outline-none placeholder:text-ink-faint focus:border-oxblood focus:ring-1 focus:ring-oxblood disabled:cursor-not-allowed disabled:opacity-50'
 
@@ -55,6 +59,12 @@ export function Combobox({
   // null means "showing the selection", a string means the user is typing.
   const [query, setQuery] = useState<string | null>(null)
   const [highlightedIndex, setHighlightedIndex] = useState(0)
+  // Which way the list opens. Downward is what every list does when there is
+  // room; near the foot of the viewport there is not, and a list that opens
+  // past the fold has to be scrolled to before it can be read. The chat pages
+  // put a picker directly under the composer, at the bottom of a tall panel,
+  // which is exactly where that happens.
+  const [dropUp, setDropUp] = useState(false)
 
   const selectedLabel = options.find((option) => option.value === value)?.label ?? ''
 
@@ -80,6 +90,15 @@ export function Combobox({
 
   function openList() {
     if (disabled || loading) return
+    // Measured on open rather than in a layout effect: the list has no box
+    // until it is open, and the input's does not move while it is. Upward only
+    // when there is genuinely less room below than above, so a list that fits
+    // still opens the ordinary way.
+    const rect = rootRef.current?.getBoundingClientRect()
+    if (rect) {
+      const below = window.innerHeight - rect.bottom
+      setDropUp(below < listMaxHeightPx && rect.top > below)
+    }
     setOpen(true)
     // Start on the current selection so Enter is a no-op rather than a surprise.
     const selectedIndex = options.findIndex((option) => option.value === value)
@@ -198,7 +217,9 @@ export function Combobox({
       {open && (
         <ul
           role="listbox"
-          className="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-xs border border-line bg-surface py-1 shadow-sm"
+          className={`absolute z-20 max-h-56 w-full overflow-auto rounded-xs border border-line bg-surface py-1 shadow-sm ${
+            dropUp ? 'bottom-full mb-1' : 'mt-1'
+          }`}
         >
           {filteredOptions.length === 0 ? (
             <li className="px-3 py-1.5 text-sm text-ink-faint">No matches</li>

--- a/frontend/src/components/ProviderModelFields.tsx
+++ b/frontend/src/components/ProviderModelFields.tsx
@@ -168,7 +168,12 @@ export function ProviderModelFields({
           }}
         />
       </div>
-      {!hideModel && (
+      {/* No provider, no model field. The catalogue is fetched per provider, so
+          with none chosen there is nothing to list -- and ModelSelect reads an
+          empty list as "this provider has no catalogue" and falls back to a
+          free-text box, which is how an unbound binding came to show a text
+          input where every bound one shows a dropdown. */}
+      {!hideModel && providerId && (
         <ModelSelect
           key={providerId || 'none'}
           label={label}

--- a/frontend/src/lib/api/ai.ts
+++ b/frontend/src/lib/api/ai.ts
@@ -1,4 +1,5 @@
 import { apiFetch, apiStream } from '../apiClient'
+import { bindingBody, type ProviderBinding } from './providers'
 import type { ChatMessageRecord, ChatSession, SearchDocumentHit } from './chats'
 
 export type { SearchDocumentHit } from './chats'
@@ -42,12 +43,22 @@ export async function chatWithDocument(input: {
   documentId: string
   sessionId?: string
   content: string
+  /**
+   * The provider and model to open the conversation on. Read by the server
+   * only when there is no session id yet: a conversation keeps the binding its
+   * transcript was produced with.
+   */
+  binding?: ProviderBinding
 }): Promise<ChatTurnResult> {
   const data = await apiFetch<RawTurnResponse>(
     `/api/app/documents/${encodeURIComponent(input.documentId)}/chat`,
     {
       method: 'POST',
-      body: { session_id: input.sessionId ?? '', content: input.content },
+      body: {
+        session_id: input.sessionId ?? '',
+        content: input.content,
+        ...bindingBody(input.binding),
+      },
       fallbackError: 'Failed to get AI response',
     },
   )
@@ -113,7 +124,14 @@ export type ResearchEvent =
  * `cancelSearchRun`.
  */
 export async function searchStream(
-  input: { sessionId?: string; content: string; mode: SearchMode; runId: string },
+  input: {
+    sessionId?: string
+    content: string
+    mode: SearchMode
+    runId: string
+    /** Read only when there is no session id yet; see `chatWithDocument`. */
+    binding?: ProviderBinding
+  },
   onEvent: (event: ResearchEvent) => void,
   signal?: AbortSignal,
 ) {
@@ -123,6 +141,7 @@ export async function searchStream(
       content: input.content,
       mode: input.mode,
       run_id: input.runId,
+      ...bindingBody(input.binding),
     },
     onEvent,
     signal,

--- a/frontend/src/lib/api/bindings.test.ts
+++ b/frontend/src/lib/api/bindings.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { asPickerProvider, bindingBody, bindingIsEmpty } from './providers'
-import { describeJobOverrides, jobOverridesBody } from './documents'
+import { describeJobOverrides, jobOverridesBody, overridesForSteps } from './documents'
 import { chatSessionBinding, type ChatSession } from './chats'
 
 describe('bindingBody', () => {
@@ -69,6 +69,29 @@ describe('describeJobOverrides', () => {
         ocr: { provider_id: 'p2', model: '' },
       }),
     ).toBe('extract: gpt-6-astra, ocr: provider default')
+  })
+})
+
+describe('overridesForSteps', () => {
+  const overrides = {
+    ocr: { provider_id: 'p1', model: 'mistral-ocr-latest' },
+    embedding: { provider_id: 'p2', model: 'text-embedding-3-small' },
+  }
+
+  // The bug this exists for: tick Embed, choose a model, untick Embed, submit.
+  // The picker unmounts but its state does not, and the create hook validates
+  // every binding on the job.
+  it('drops the bindings whose steps are not being queued', () => {
+    expect(overridesForSteps(overrides, ['ocr'])).toEqual({ ocr: overrides.ocr })
+  })
+
+  it('keeps the bindings whose steps are', () => {
+    expect(overridesForSteps(overrides, ['ocr', 'embed'])).toEqual(overrides)
+  })
+
+  it('is empty for steps that call no provider, and for no overrides', () => {
+    expect(overridesForSteps(overrides, ['preview', 'detect_duplicates'])).toEqual({})
+    expect(overridesForSteps(undefined, ['ocr'])).toEqual({})
   })
 })
 

--- a/frontend/src/lib/api/bindings.test.ts
+++ b/frontend/src/lib/api/bindings.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import { asPickerProvider, bindingBody, bindingIsEmpty } from './providers'
+import { describeJobOverrides, jobOverridesBody } from './documents'
+import { chatSessionBinding, type ChatSession } from './chats'
+
+describe('bindingBody', () => {
+  // The whole point of the "or nothing" shape: a page whose picker is never
+  // opened has to send exactly what it sent before overrides existed.
+  it('sends nothing when no provider was chosen', () => {
+    expect(bindingBody(undefined)).toEqual({})
+    expect(bindingBody({ provider_id: '', model: '' })).toEqual({})
+    expect(bindingBody({ provider_id: '   ', model: 'gpt-6-astra' })).toEqual({})
+  })
+
+  it('sends both halves, trimmed', () => {
+    expect(bindingBody({ provider_id: ' p1 ', model: ' gpt-6-astra ' })).toEqual({
+      provider_id: 'p1',
+      model: 'gpt-6-astra',
+    })
+  })
+
+  // A provider with no model is legitimate: the server falls back to the
+  // configured model for that provider rather than refusing the request.
+  it('sends a provider with no model', () => {
+    expect(bindingBody({ provider_id: 'p1', model: '' })).toEqual({
+      provider_id: 'p1',
+      model: '',
+    })
+  })
+})
+
+describe('bindingIsEmpty', () => {
+  it('keys on the provider, matching aiprovider.Binding.Empty', () => {
+    expect(bindingIsEmpty(undefined)).toBe(true)
+    expect(bindingIsEmpty({ provider_id: '', model: 'gpt-6-astra' })).toBe(true)
+    expect(bindingIsEmpty({ provider_id: 'p1', model: '' })).toBe(false)
+  })
+})
+
+describe('jobOverridesBody', () => {
+  it('sends nothing when no binding was chosen', () => {
+    expect(jobOverridesBody(undefined)).toEqual({})
+    expect(jobOverridesBody({})).toEqual({})
+    // An opened-but-unfilled picker is not a choice yet.
+    expect(jobOverridesBody({ extract: { provider_id: '', model: '' } })).toEqual({})
+  })
+
+  it('sends only the bindings that were chosen', () => {
+    expect(
+      jobOverridesBody({
+        ocr: { provider_id: 'p1', model: 'mistral-ocr-latest' },
+        extract: { provider_id: '', model: '' },
+      }),
+    ).toEqual({ overrides: { ocr: { provider_id: 'p1', model: 'mistral-ocr-latest' } } })
+  })
+})
+
+describe('describeJobOverrides', () => {
+  it('is empty when nothing was overridden', () => {
+    expect(describeJobOverrides(undefined)).toBe('')
+    expect(describeJobOverrides({ extract: { provider_id: '', model: 'x' } })).toBe('')
+  })
+
+  it('names each overridden binding and its model', () => {
+    expect(
+      describeJobOverrides({
+        extract: { provider_id: 'p1', model: 'gpt-6-astra' },
+        ocr: { provider_id: 'p2', model: '' },
+      }),
+    ).toBe('extract: gpt-6-astra, ocr: provider default')
+  })
+})
+
+describe('chatSessionBinding', () => {
+  const base: ChatSession = {
+    id: 's1',
+    kind: 'search',
+    title: 'A chat',
+    message_count: 2,
+    last_message_at: '2026-09-08 10:00:00.000Z',
+    created: '2026-09-08 10:00:00.000Z',
+    updated: '2026-09-08 10:00:00.000Z',
+  }
+
+  it('is undefined for a chat on the configured model', () => {
+    expect(chatSessionBinding(null)).toBeUndefined()
+    expect(chatSessionBinding(base)).toBeUndefined()
+  })
+
+  it('restores the pinned binding', () => {
+    expect(chatSessionBinding({ ...base, provider: 'p1', model: 'gpt-6-astra' })).toEqual({
+      provider_id: 'p1',
+      model: 'gpt-6-astra',
+    })
+  })
+
+  // The server refuses a model with no provider, so offering it back as a
+  // choice would only produce a request it will not accept.
+  it('ignores a model with no provider', () => {
+    expect(chatSessionBinding({ ...base, model: 'gpt-6-astra' })).toBeUndefined()
+  })
+})
+
+describe('asPickerProvider', () => {
+  // ProviderModelFields was written for Settings, where a provider is the full
+  // record. It reads only id, sdk and alias; the credential flags are true
+  // because /api/app/ai/providers only returns configured providers.
+  it('maps a pickable row onto the shape the picker wants', () => {
+    expect(asPickerProvider({ id: 'p1', name: 'My OpenAI', sdk: 'openai' })).toEqual({
+      id: 'p1',
+      sdk: 'openai',
+      alias: 'My OpenAI',
+      base_url: '',
+      api_key_set: true,
+      signed_in: true,
+    })
+  })
+})

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from '../apiClient'
+import type { ProviderBinding } from './providers'
 
 export type ChatSessionKind = 'search' | 'document'
 export type ChatRole = 'user' | 'assistant'
@@ -28,6 +29,14 @@ export type ChatSession = {
   title: string
   /** The mode the last search turn ran in; absent for document chats. Mirrors SearchMode. */
   mode?: 'search' | 'research'
+  /**
+   * The provider row and model this conversation is pinned to, absent when it
+   * runs on the binding in Settings. Fixed for the conversation's lifetime, so
+   * reopening a chat restores the picker on what its transcript was produced
+   * with.
+   */
+  provider?: string
+  model?: string
   /** Set only for kind === 'document'. */
   document?: string
   document_title?: string
@@ -115,6 +124,20 @@ export function deleteChatSession(id: string) {
 /** What the sidebar shows for a session whose title never resolved. */
 export function chatSessionTitle(session: ChatSession): string {
   return session.title.trim() || 'New chat'
+}
+
+/**
+ * The binding a conversation is pinned to, as the picker wants it, or undefined
+ * when it runs on the configured model.
+ *
+ * Undefined for a session with no provider even if it somehow carries a model:
+ * the server refuses that pair, so offering it back as a choice would only
+ * produce a request it will not accept.
+ */
+export function chatSessionBinding(session: ChatSession | null): ProviderBinding | undefined {
+  const providerId = session?.provider?.trim()
+  if (!providerId) return undefined
+  return { provider_id: providerId, model: session?.model?.trim() ?? '' }
 }
 
 /** Trims a PocketBase timestamp to its date for the sidebar. */

--- a/frontend/src/lib/api/documents.ts
+++ b/frontend/src/lib/api/documents.ts
@@ -179,7 +179,11 @@ export async function reprocessDocument(
     // provider ids are checked by the processing_jobs create hook, not here --
     // this collection is writable by the document's owner, so the server has
     // to be the one that refuses a binding it cannot serve.
-    ...jobOverridesBody(overrides),
+    //
+    // Narrowed to the steps being queued, here rather than at the caller: the
+    // hook validates every binding on the job, so an override left behind by a
+    // step that was ticked and then unticked would refuse the whole job.
+    ...jobOverridesBody(overridesForSteps(overrides, steps)),
   })
 }
 
@@ -228,6 +232,33 @@ export type JobOverrides = {
  * nothing for a binding with no provider, and a key whose value is `{}` would
  * be a binding the server has to refuse.
  */
+/**
+ * The pipeline steps that call a provider, and the job binding each one uses.
+ * The other three reach no provider. One table, so the pickers and the request
+ * cannot disagree about which binding a step reads.
+ */
+export const STEP_BINDINGS = {
+  ocr: 'ocr',
+  extract_metadata: 'extract',
+  embed: 'embedding',
+} as const satisfies Partial<Record<ProcessingStep, keyof JobOverrides>>
+
+/** The overrides among `overrides` that the given steps will actually read. */
+export function overridesForSteps(
+  overrides: JobOverrides | undefined,
+  steps: ProcessingStep[],
+): JobOverrides {
+  const out: JobOverrides = {}
+  for (const step of steps) {
+    const key = STEP_BINDINGS[step as keyof typeof STEP_BINDINGS]
+    const binding = key && overrides?.[key]
+    if (key && binding) {
+      out[key] = binding
+    }
+  }
+  return out
+}
+
 export function jobOverridesBody(overrides: JobOverrides | undefined) {
   if (!overrides) return {}
   const body: Record<string, ProviderBinding> = {}

--- a/frontend/src/lib/api/documents.ts
+++ b/frontend/src/lib/api/documents.ts
@@ -1,6 +1,7 @@
 import { pb, pbUrl } from '../pb'
 import { ensureAuth } from '../auth'
 import { apiFetch, errorDetail } from '../apiClient'
+import { bindingBody, type ProviderBinding } from './providers'
 import type { ProcessingStep, ReprocessMode } from '../processing'
 import type { TimelineMonth } from '../timeline'
 
@@ -163,6 +164,7 @@ export async function reprocessDocument(
   documentId: string,
   steps: ProcessingStep[],
   forceSteps?: ProcessingStep[],
+  overrides?: JobOverrides,
 ) {
   await ensureAuth()
   await pb.collection('documents').update(documentId, {
@@ -173,6 +175,11 @@ export async function reprocessDocument(
     status: 'pending',
     steps,
     ...(forceSteps?.length ? { force_steps: forceSteps } : {}),
+    // Written straight onto the record, like the rest of this call. The
+    // provider ids are checked by the processing_jobs create hook, not here --
+    // this collection is writable by the document's owner, so the server has
+    // to be the one that refuses a binding it cannot serve.
+    ...jobOverridesBody(overrides),
   })
 }
 
@@ -196,6 +203,59 @@ export type ReprocessResult = {
   remaining: number
 }
 
+/**
+ * The provider and model a reprocess job runs on, instead of the bindings in
+ * Settings. Mirrors config.Overrides, minus the two bindings a job never uses
+ * (chat and search), which the endpoint refuses outright.
+ *
+ * An embedding override must name the model already bound in Settings: a chunk
+ * row records the model it was produced with, and the retrieval index only
+ * reads rows matching the configured one. The server refuses anything else,
+ * because vectors nothing will ever read look exactly like success.
+ */
+export type JobOverrides = {
+  ocr?: ProviderBinding
+  extract?: ProviderBinding
+  embedding?: ProviderBinding
+}
+
+/**
+ * The request field for a set of job overrides, or nothing when none were
+ * chosen -- so a reprocess with every picker untouched sends exactly what it
+ * sent before overrides existed.
+ *
+ * Half-filled bindings are dropped rather than sent: `bindingBody` returns
+ * nothing for a binding with no provider, and a key whose value is `{}` would
+ * be a binding the server has to refuse.
+ */
+export function jobOverridesBody(overrides: JobOverrides | undefined) {
+  if (!overrides) return {}
+  const body: Record<string, ProviderBinding> = {}
+  for (const [name, binding] of Object.entries(overrides)) {
+    const fields = bindingBody(binding)
+    if ('provider_id' in fields) {
+      body[name] = fields as ProviderBinding
+    }
+  }
+  return Object.keys(body).length > 0 ? { overrides: body } : {}
+}
+
+/**
+ * One line naming the overridden bindings, for the confirm dialogs, or "" when
+ * there are none.
+ *
+ * Worth saying out loud: a batch reprocess commits provider spend, and which
+ * model it is about to be spent on is the thing the picker just changed.
+ */
+export function describeJobOverrides(overrides: JobOverrides | undefined): string {
+  // Read off the input rather than jobOverridesBody's output, whose shape is
+  // deliberately "the field or nothing" and so needs unwrapping to read back.
+  return Object.entries(overrides ?? {})
+    .filter(([, binding]) => binding?.provider_id.trim())
+    .map(([name, binding]) => `${name}: ${binding!.model.trim() || 'provider default'}`)
+    .join(', ')
+}
+
 function postReprocess(body: Record<string, unknown>) {
   return apiFetch<ReprocessResult>('/api/app/documents/reprocess-failed', {
     method: 'POST',
@@ -205,10 +265,15 @@ function postReprocess(body: Record<string, unknown>) {
 }
 
 /** Requeues up to `limit` of the caller's failed documents, oldest first. */
-export function reprocessFailedDocuments(opts: { limit?: number; mode?: ReprocessMode }) {
+export function reprocessFailedDocuments(opts: {
+  limit?: number
+  mode?: ReprocessMode
+  overrides?: JobOverrides
+}) {
   return postReprocess({
     ...(opts.limit ? { limit: opts.limit } : {}),
     mode: opts.mode ?? 'auto',
+    ...jobOverridesBody(opts.overrides),
   })
 }
 
@@ -216,8 +281,12 @@ export function reprocessFailedDocuments(opts: { limit?: number; mode?: Reproces
  * Requeues an explicit selection. Documents already queued are skipped, so a
  * stale selection cannot double-queue.
  */
-export function reprocessDocuments(documentIds: string[], mode: ReprocessMode = 'auto') {
-  return postReprocess({ document_ids: documentIds, mode })
+export function reprocessDocuments(
+  documentIds: string[],
+  mode: ReprocessMode = 'auto',
+  overrides?: JobOverrides,
+) {
+  return postReprocess({ document_ids: documentIds, mode, ...jobOverridesBody(overrides) })
 }
 
 export type DocumentSearchList = {

--- a/frontend/src/lib/api/providers.ts
+++ b/frontend/src/lib/api/providers.ts
@@ -32,6 +32,40 @@ export type AIProviderWrite = {
 
 export type ModelPurpose = 'ocr' | 'llm' | 'embedding'
 
+/**
+ * A provider and model chosen for one chat or one reprocess job, instead of the
+ * binding in Settings. Mirrors aiprovider.Binding.
+ *
+ * Both halves, in practice. The server refuses a model with no provider rather
+ * than running the configured one in its place, so `bindingBody` drops that
+ * half-filled pair instead of sending it; and it refuses a provider with no
+ * model, because an empty model reaches the provider as an empty model and the
+ * configured one belongs to a different provider. The single exception is the
+ * OCR binding on google_vision and docling, which read a document without being
+ * told a model -- see `usesOCRModel`.
+ */
+export type ProviderBinding = {
+  provider_id: string
+  model: string
+}
+
+export const EMPTY_BINDING: ProviderBinding = { provider_id: '', model: '' }
+
+export function bindingIsEmpty(binding: ProviderBinding | undefined) {
+  return !binding?.provider_id.trim()
+}
+
+/**
+ * The request fields for a binding, or nothing when none was chosen.
+ *
+ * Absent rather than empty strings, so a request from a page with the picker
+ * untouched is byte-identical to one sent before overrides existed.
+ */
+export function bindingBody(binding: ProviderBinding | undefined) {
+  if (bindingIsEmpty(binding)) return {}
+  return { provider_id: binding!.provider_id.trim(), model: binding!.model.trim() }
+}
+
 export type CatalogModel = {
   id: string
   name: string
@@ -338,6 +372,64 @@ export async function listOCRProviders() {
     fallbackError: 'Failed to load OCR providers',
   })
   return data.providers ?? []
+}
+
+/**
+ * The binding Settings uses for a purpose: what answers when nobody overrides
+ * anything. Empty on an instance where nothing is bound yet.
+ */
+export type ConfiguredBinding = {
+  provider_id?: string
+  provider_name?: string
+  model?: string
+}
+
+/**
+ * The configured providers that can serve a purpose, and the binding Settings
+ * would use, for a picker outside Settings.
+ *
+ * Readable by any signed-in user, unlike `listAIProviders`, which is admin-only
+ * because it carries the credential state. This answer is provider names, model
+ * ids and SDKs -- no key, no account, no base URL.
+ */
+export async function listPickableProviders(purpose: ModelPurpose, binding?: string) {
+  const query = new URLSearchParams({ for: purpose })
+  // Names which configured pair to report back. The capability cannot say:
+  // chat, search and extraction are all language models, and Deep Search must
+  // not be told the chat model is what answers it.
+  if (binding) query.set('binding', binding)
+  const data = await apiFetch<{ providers?: OCRProviderInfo[]; configured?: ConfiguredBinding }>(
+    `/api/app/ai/providers?${query.toString()}`,
+    { fallbackError: 'Failed to load providers' },
+  )
+  return { providers: data.providers ?? [], configured: data.configured ?? {} }
+}
+
+/** How a model is named in the UI when there is nothing bound to name. */
+export const UNBOUND_MODEL_LABEL = 'not configured'
+
+/** The model a binding runs on, for the one-line "which model" summaries. */
+export function bindingModelLabel(model: string | undefined) {
+  return model?.trim() || UNBOUND_MODEL_LABEL
+}
+
+/**
+ * Adapts a pickable row to what ProviderModelFields wants.
+ *
+ * That component was written for Settings, where a provider is the full record;
+ * it reads only `id`, `sdk` and `alias`. The credential flags are set true
+ * because this list is already filtered to configured providers -- the server
+ * would not have returned an unconfigured one.
+ */
+export function asPickerProvider(item: OCRProviderInfo): AIProvider {
+  return {
+    id: item.id,
+    sdk: item.sdk as ProviderSDK,
+    alias: item.name,
+    base_url: '',
+    api_key_set: true,
+    signed_in: true,
+  }
 }
 
 export type OCRTestResult = {

--- a/frontend/src/routes/document.$documentId.ask.tsx
+++ b/frontend/src/routes/document.$documentId.ask.tsx
@@ -5,6 +5,7 @@ import { ChatPanel } from '../components/ChatPanel'
 import { ChatTranscript } from '../components/ChatTranscript'
 import { ChatComposer } from '../components/ChatComposer'
 import { ChatSessionList } from '../components/ChatSessionList'
+import { BindingOverride } from '../components/BindingOverride'
 import { pb } from '../lib/pb'
 import { ensureAuth } from '../lib/auth'
 import { chatWithDocument } from '../lib/api/ai'
@@ -14,8 +15,10 @@ import {
   listChatSessions,
   mergeChatSession,
   renameChatSession,
+  chatSessionBinding,
   type ChatSession,
 } from '../lib/api/chats'
+import type { ProviderBinding } from '../lib/api/providers'
 import type { DocumentRecord } from '../lib/api/documents'
 import { useAsync } from '../hooks/useAsync'
 import { useChatSession } from '../hooks/useChatSession'
@@ -33,6 +36,10 @@ export function DocumentAskPage() {
   const [justSettled, setJustSettled] = useState<ChatSession | null>(null)
   const [railBusy, setRailBusy] = useState(false)
   const [railError, setRailError] = useState('')
+  // The model this page will open its next conversation on. Not reset by
+  // startNewChat: having picked a model once, the likely next thing is another
+  // question for the same one.
+  const [binding, setBinding] = useState<ProviderBinding | undefined>()
 
   const {
     data: document,
@@ -74,11 +81,29 @@ export function DocumentAskPage() {
       }
       return detail
     },
-    send: ({ sessionId: id, content }) => chatWithDocument({ documentId, sessionId: id, content }),
+    send: ({ sessionId: id, content }) =>
+      chatWithDocument({ documentId, sessionId: id, content, binding }),
     onSessionSettled,
   })
 
   const hasOcrText = Boolean(document?.ocr_text?.trim())
+  // A conversation keeps the binding its transcript was produced with -- the
+  // server ignores anything else a request carries -- so once one exists the
+  // picker reports it instead of offering to change it.
+  //
+  // Keyed on whether the URL names a conversation, not on whether one is
+  // loaded. Those differ in the two cases that matter, in opposite directions:
+  //
+  //   - Opening someone's existing chat, the session is briefly null while it
+  //     loads. Falling back to the local pick there is what showed the model
+  //     from the *previous* chat on a conversation that never used it, until
+  //     the page was reloaded.
+  //   - During the send that creates a conversation there is no id and no
+  //     session yet, and the local pick is genuinely what is answering, so
+  //     showing nothing would blank the row mid-answer.
+  const inConversation = Boolean(sessionId) || Boolean(chat.session)
+  const shownBinding = inConversation ? chatSessionBinding(chat.session) : binding
+  const bindingLocked = inConversation || chat.turns.length > 0
   const rows = mergeChatSession(sessions.data ?? [], justSettled)
 
   function openSession(session: ChatSession) {
@@ -228,6 +253,24 @@ export function DocumentAskPage() {
                   autoFocus
                 />
               </ChatPanel>
+            {/* Directly below the panel rather than inside it: ChatPanel is
+                overflow-hidden -- which is what makes the transcript scroll
+                instead of stretching the box -- and the model dropdown is
+                absolutely positioned, so inside the panel its list was clipped
+                at the panel's edge. border-t-0 butts this strip against the
+                panel's bottom border, so it still reads as part of it. */}
+              <div className="border border-t-0 border-line bg-surface px-4 py-3">
+                <BindingOverride
+                  label="Chat"
+                  purpose="llm"
+                  value={shownBinding}
+                  onChange={setBinding}
+                  locked={bindingLocked}
+                  lockedHint="Fixed for this conversation. Start a new chat to ask a different model."
+                  help="Answers questions about this document."
+                  showConfigured
+                />
+              </div>
             </div>
           </div>
         </>

--- a/frontend/src/routes/document.$documentId.tsx
+++ b/frontend/src/routes/document.$documentId.tsx
@@ -4,11 +4,14 @@ import { ClientResponseError } from 'pocketbase'
 import { pb } from '../lib/pb'
 import { ensureAuth } from '../lib/auth'
 import {
+  describeJobOverrides,
   openDocumentFile,
   reprocessDocument,
   saveDocumentMetadata,
   type DocumentRecord,
+  type JobOverrides,
 } from '../lib/api/documents'
+import { StepBindingOverride } from '../components/BindingOverride'
 import {
   defaultReprocessSteps,
   forceStepsForReprocess,
@@ -42,6 +45,7 @@ export function DocumentDetailPage() {
   const [reprocessing, setReprocessing] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [reprocessSteps, setReprocessSteps] = useState<ProcessingStep[]>([])
+  const [reprocessOverrides, setReprocessOverrides] = useState<JobOverrides>({})
   const [showProcessingJob, setShowProcessingJob] = useState(false)
   const [showPreview, setShowPreview] = useStoredFlag('lemmary.showPreview', true)
   const [error, setError] = useState('')
@@ -255,8 +259,11 @@ export function DocumentDetailPage() {
     }
 
     const stepLabels = reprocessSteps.map((step) => PROCESSING_STEP_LABELS[step]).join(', ')
+    const overrides = describeJobOverrides(reprocessOverrides)
     const confirmed = window.confirm(
-      `Re-run these steps?\n\n${stepLabels}\n\nExisting metadata may be overwritten.`,
+      `Re-run these steps?\n\n${stepLabels}\n` +
+        (overrides ? `\nModels: ${overrides}\n` : '') +
+        '\nExisting metadata may be overwritten.',
     )
     if (confirmed) {
       void onReprocess()
@@ -274,7 +281,12 @@ export function DocumentDetailPage() {
       setError('')
 
       const steps = orderedProcessingSteps(reprocessSteps)
-      await reprocessDocument(document.id, steps, forceStepsForReprocess(steps))
+      await reprocessDocument(
+        document.id,
+        steps,
+        forceStepsForReprocess(steps),
+        reprocessOverrides,
+      )
 
       // Confirmed as soon as the job exists, before the refresh below. Queueing
       // flips the document to pending, which wakes the realtime subscription,
@@ -584,33 +596,58 @@ export function DocumentDetailPage() {
                     const selectable = canSelectReprocessStep(step)
                     const checked = reprocessSteps.includes(step)
                     return (
-                      <label
+                      // A div wrapping a label, not one label around
+                      // everything: the model picker below is itself a
+                      // checkbox and a combobox, and nesting those inside the
+                      // step's label would make a click on either of them
+                      // toggle the step.
+                      <div
                         key={step}
-                        className={`flex items-start gap-2 rounded-xs border px-3 py-1.5 text-sm ${
+                        // A stable hook for the browser suite, which has to
+                        // assert that the model picker sits inside the block of
+                        // the step it belongs to. Same purpose as
+                        // data-timeline-period on the timeline rail.
+                        data-reprocess-step={step}
+                        className={`flex flex-col gap-2 rounded-xs border px-3 py-1.5 text-sm ${
                           selectable
                             ? 'border-line bg-bright text-ink-muted'
                             : 'border-line/50 bg-wash/50 text-ink-faint'
                         }`}
-                        title={
-                          step === 'extract_metadata' && !selectable
-                            ? 'OCR text required, or select OCR'
-                            : undefined
-                        }
                       >
-                        <input
-                          type="checkbox"
-                          className="mt-0.5"
-                          checked={checked}
-                          disabled={!selectable}
-                          onChange={() => toggleReprocessStep(step)}
-                        />
-                        <span>
-                          <span className="font-medium">{PROCESSING_STEP_LABELS[step]}</span>
-                          <span className="mt-0.5 block text-xs font-normal text-ink-soft">
-                            {PROCESSING_STEP_DESCRIPTIONS[step]}
+                        <label
+                          className="flex items-start gap-2"
+                          title={
+                            step === 'extract_metadata' && !selectable
+                              ? 'OCR text required, or select OCR'
+                              : undefined
+                          }
+                        >
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={checked}
+                            disabled={!selectable}
+                            onChange={() => toggleReprocessStep(step)}
+                          />
+                          <span>
+                            <span className="font-medium">{PROCESSING_STEP_LABELS[step]}</span>
+                            <span className="mt-0.5 block text-xs font-normal text-ink-soft">
+                              {PROCESSING_STEP_DESCRIPTIONS[step]}
+                            </span>
                           </span>
-                        </span>
-                      </label>
+                        </label>
+                        {/* Only for a step that is actually going to run:
+                            which model to use is not a question until you
+                            have said you are re-running the step that uses
+                            one. */}
+                        {checked && (
+                          <StepBindingOverride
+                            step={step}
+                            value={reprocessOverrides}
+                            onChange={setReprocessOverrides}
+                          />
+                        )}
+                      </div>
                     )
                   })}
                 </fieldset>

--- a/frontend/src/routes/document.$documentId.tsx
+++ b/frontend/src/routes/document.$documentId.tsx
@@ -6,6 +6,7 @@ import { ensureAuth } from '../lib/auth'
 import {
   describeJobOverrides,
   openDocumentFile,
+  overridesForSteps,
   reprocessDocument,
   saveDocumentMetadata,
   type DocumentRecord,
@@ -259,7 +260,9 @@ export function DocumentDetailPage() {
     }
 
     const stepLabels = reprocessSteps.map((step) => PROCESSING_STEP_LABELS[step]).join(', ')
-    const overrides = describeJobOverrides(reprocessOverrides)
+    // The same narrowing reprocessDocument does: a picker that was opened and
+    // then unticked must not name a model in the confirmation.
+    const overrides = describeJobOverrides(overridesForSteps(reprocessOverrides, reprocessSteps))
     const confirmed = window.confirm(
       `Re-run these steps?\n\n${stepLabels}\n` +
         (overrides ? `\nModels: ${overrides}\n` : '') +

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -5,13 +5,16 @@ import { pb } from '../lib/pb'
 import { ensureAuth } from '../lib/auth'
 import {
   buildDocumentFilter,
+  describeJobOverrides,
   fetchDocumentTimeline,
   reprocessDocuments,
   searchDocuments,
   type CorrespondentRecord,
   type DocumentRecord,
   type DocumentTypeRecord,
+  type JobOverrides,
 } from '../lib/api/documents'
+import { JobOverrideFields } from '../components/BindingOverride'
 import { activePeriod, periodRange } from '../lib/timeline'
 import {
   documentQuerySearch,
@@ -63,6 +66,7 @@ export function IndexPage() {
   const [error, setError] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [reprocessMode, setReprocessMode] = useState<ReprocessMode>('auto')
+  const [reprocessOverrides, setReprocessOverrides] = useState<JobOverrides>({})
   const [reprocessing, setReprocessing] = useState(false)
   const [message, setMessage] = useState('')
   // Bumped whenever the library changes, to re-count the timeline.
@@ -228,10 +232,12 @@ export function IndexPage() {
     const ids = selectedOnPage.map((document) => document.id)
     if (ids.length === 0) return
 
+    const overrides = describeJobOverrides(reprocessOverrides)
     const confirmed = window.confirm(
       `Reprocess ${ids.length === 1 ? 'this document' : `these ${ids.length} documents`}?\n\n` +
-        `Steps: ${REPROCESS_MODE_LABELS[reprocessMode]}\n\n` +
-        'Existing metadata may be overwritten.',
+        `Steps: ${REPROCESS_MODE_LABELS[reprocessMode]}\n` +
+        (overrides ? `Models: ${overrides}\n` : '') +
+        '\nExisting metadata may be overwritten.',
     )
     if (!confirmed) return
 
@@ -239,7 +245,7 @@ export function IndexPage() {
       setReprocessing(true)
       setError('')
       setMessage('')
-      const result = await reprocessDocuments(ids, reprocessMode)
+      const result = await reprocessDocuments(ids, reprocessMode, reprocessOverrides)
       setSelectedIds(new Set())
       setMessage(
         result.skipped > 0
@@ -417,6 +423,14 @@ export function IndexPage() {
                     <Button variant="secondary" onClick={() => setSelectedIds(new Set())}>
                       Clear
                     </Button>
+                  )}
+                  {selectedOnPage.length > 0 && (
+                    <div className="w-full">
+                      <JobOverrideFields
+                        value={reprocessOverrides}
+                        onChange={setReprocessOverrides}
+                      />
+                    </div>
                   )}
                 </div>
               )}

--- a/frontend/src/routes/management.tsx
+++ b/frontend/src/routes/management.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import { countFailedDocuments, reprocessFailedDocuments } from '../lib/api/documents'
+import {
+  countFailedDocuments,
+  describeJobOverrides,
+  reprocessFailedDocuments,
+  type JobOverrides,
+} from '../lib/api/documents'
+import { JobOverrideFields } from '../components/BindingOverride'
 import {
   getActiveJobCounts,
   getEmbeddingBackfillState,
@@ -71,6 +77,7 @@ export function ManagementPage() {
   const [reprocessing, setReprocessing] = useState(false)
   const [reprocessMode, setReprocessMode] = useState<ReprocessMode>('auto')
   const [reprocessBatch, setReprocessBatch] = useState<number>(100)
+  const [reprocessOverrides, setReprocessOverrides] = useState<JobOverrides>({})
   const [embedding, setEmbedding] = useState<EmbeddingBackfillState | null>(null)
   const [embeddingLoaded, setEmbeddingLoaded] = useState(false)
   const [embeddingStarting, setEmbeddingStarting] = useState(false)
@@ -143,10 +150,12 @@ export function ManagementPage() {
     if (!failedCount) return
 
     const batch = Math.min(reprocessBatch, failedCount)
+    const overrides = describeJobOverrides(reprocessOverrides)
     const confirmed = window.confirm(
       `Reprocess ${countLabel(batch, 'failed document', 'failed documents')}?\n\n` +
-        `Steps: ${REPROCESS_MODE_LABELS[reprocessMode]}\n\n` +
-        'Existing metadata may be overwritten.',
+        `Steps: ${REPROCESS_MODE_LABELS[reprocessMode]}\n` +
+        (overrides ? `Models: ${overrides}\n` : '') +
+        '\nExisting metadata may be overwritten.',
     )
     if (!confirmed) return
 
@@ -157,6 +166,7 @@ export function ManagementPage() {
       const result = await reprocessFailedDocuments({
         limit: reprocessBatch,
         mode: reprocessMode,
+        overrides: reprocessOverrides,
       })
       setFailedCount(result.remaining)
       const queued = countLabel(result.queued, 'document', 'documents')
@@ -348,6 +358,9 @@ export function ManagementPage() {
                 ? 'Queueing...'
                 : `Reprocess ${Math.min(reprocessBatch, failedCount ?? 0)} failed`}
             </Button>
+          </div>
+          <div className="mt-4">
+            <JobOverrideFields value={reprocessOverrides} onChange={setReprocessOverrides} />
           </div>
           <p className="mt-3 text-xs text-ink-soft">
             {!failedCountLoaded

--- a/frontend/src/routes/search.tsx
+++ b/frontend/src/routes/search.tsx
@@ -9,6 +9,8 @@ import { MarkdownContent } from '../components/MarkdownContent'
 import { runId } from '../lib/runId'
 import { useAsync } from '../hooks/useAsync'
 import { useChatSession, type ChatSendResult } from '../hooks/useChatSession'
+import { BindingOverride } from '../components/BindingOverride'
+import type { ProviderBinding } from '../lib/api/providers'
 import {
   cancelSearchRun,
   searchStream,
@@ -22,6 +24,7 @@ import {
   listChatSessions,
   mergeChatSession,
   renameChatSession,
+  chatSessionBinding,
   type ChatSession,
   type ChatTurn,
   type SearchDocumentHit,
@@ -92,6 +95,9 @@ export function SearchPage() {
   const [justSettled, setJustSettled] = useState<ChatSession | null>(null)
   const [railBusy, setRailBusy] = useState(false)
   const [railError, setRailError] = useState('')
+  // The model the next conversation opens on. Kept across a new chat: having
+  // picked one, the likely next thing is another question for the same model.
+  const [binding, setBinding] = useState<ProviderBinding | undefined>()
   // Live progress of a research run, cleared when it ends.
   const [steps, setSteps] = useState<ResearchStep[]>([])
   const [draft, setDraft] = useState('')
@@ -172,7 +178,12 @@ export function SearchPage() {
    * be hung up on by anything with a read timeout in between.
    */
   const runTurn = useCallback(
-    async (id: string | undefined, content: string, turnMode: SearchMode): Promise<ChatSendResult> => {
+    async (
+      id: string | undefined,
+      content: string,
+      turnMode: SearchMode,
+      turnBinding: ProviderBinding | undefined,
+    ): Promise<ChatSendResult> => {
       const run = { controller: new AbortController(), id: runId() }
       runRef.current = run
 
@@ -188,7 +199,7 @@ export function SearchPage() {
 
       try {
         await searchStream(
-          { sessionId: id, content, mode: turnMode, runId: run.id },
+          { sessionId: id, content, mode: turnMode, runId: run.id, binding: turnBinding },
           (event) => {
             switch (event.type) {
               case 'step':
@@ -291,7 +302,7 @@ export function SearchPage() {
       }
       return detail
     },
-    send: ({ sessionId: id, content }) => runTurn(id, content, mode),
+    send: ({ sessionId: id, content }) => runTurn(id, content, mode, binding),
     onSessionSettled,
   })
 
@@ -317,6 +328,25 @@ export function SearchPage() {
   // the turn still in flight, whose request already carries the mode it was
   // sent under.
   const locked = Boolean(sessionId) || chat.sending
+  // The binding is fixed for a conversation for the same reason mode is: the
+  // transcript replayed to the model was produced by one model, and answering
+  // the next question with another reads that work back as its own. Locked as
+  // soon as a turn exists, not only once the session id lands, so it cannot
+  // change during the send that creates the conversation.
+  //
+  // Keyed on whether the URL names a conversation, not on whether one is
+  // loaded. Those differ in the two cases that matter, in opposite directions:
+  //
+  //   - Opening an existing chat, the session is briefly null while it loads.
+  //     Falling back to the local pick there is what showed the model from the
+  //     *previous* chat on a conversation that never used it, until the page
+  //     was reloaded.
+  //   - During the send that creates a conversation there is no id and no
+  //     session yet, and the local pick is genuinely what is answering, so
+  //     showing nothing would blank the row mid-answer.
+  const inConversation = Boolean(sessionId) || Boolean(chat.session)
+  const shownBinding = inConversation ? chatSessionBinding(chat.session) : binding
+  const bindingLocked = inConversation || chat.sending || chat.turns.length > 0
 
   // A chat opens in the mode its last turn ran in, which is also the path it
   // lives on: continuing a research conversation as a plain search would answer
@@ -492,6 +522,24 @@ export function SearchPage() {
               autoFocus
             />
           </ChatPanel>
+          {/* Directly below the panel rather than inside it: ChatPanel is
+              overflow-hidden -- which is what makes the transcript scroll
+              instead of stretching the box -- and the model dropdown is
+              absolutely positioned, so inside the panel its list was clipped at
+              the panel's edge. border-t-0 butts this strip against the panel's
+              bottom border, so it still reads as part of it. */}
+          <div className="border border-t-0 border-line bg-surface px-4 py-3">
+            <BindingOverride
+              label="Search"
+              purpose="llm"
+              value={shownBinding}
+              onChange={setBinding}
+              locked={bindingLocked}
+              lockedHint="Fixed for this chat. Start a new one to search with a different model."
+              help="Drives the search or research loop. The helper model that reads documents in bulk keeps its own binding in Settings."
+              showConfigured
+            />
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Every AI call ran on one of the six global bindings on the `app_settings` singleton. Changing model meant editing Settings, which is admin-only, applies to every user and every queued job, and is lost as soon as it is changed back. There was no way to retry one failed document on a stronger extractor, or to ask one question of a cheaper model.

Now a reprocess job and a chat each carry their own provider and model, chosen from the providers an admin has already configured. Unset means "use Settings": a request with no picker touched is byte-identical to one sent before this existed.

Overlay branch: `lemmary-dev#worktree-binding-override` (push first, per `AGENTS.md`).

## What you can do

| Surface | Bindings |
|---|---|
| Ask AI, Deep Search | chat / search, under the composer |
| Document reprocess form | OCR, extraction, embedding — inside each step's block |
| Document list bulk bar, Management → Failed processing | the same three, grouped |

Any signed-in user can pick, from providers an admin already configured — so it can spend the operator's credentials but never add a new one.

## Two decisions worth review

**A conversation records the model it opened on, whether or not anyone picked it.** A chat that stored nothing followed Settings for the rest of its life, so changing the chat model moved every existing conversation onto the new one, mid-transcript, with the answers above it produced by a model that was no longer answering. Conversations from before this ships have nothing recorded and do still follow Settings; there is no backfill.

**An embedding override must name the model already bound in Settings.** A chunk row records the model and dimension count it was produced with, and the index only reads rows matching the configured spec (`embed.SpecFrom`, `matchesSpec` in `internal/embed/source.go`). Any other model is paid for, written, and never read — a document silently dropping out of dense retrieval. Refused up front, because there is no way to make that outcome visible afterwards. Re-embedding on the *configured* model is allowed, and is the case worth having.

## Non-admins reading the catalogue

`GET /api/app/providers/{id}/models` is now `bindAuth` — model ids and an SDK name, no key, account or base URL, and a picker is useless without it. `GET /api/app/providers` stays admin-only: it carries `api_key_set` and the signed-in ChatGPT account and plan.

`handleOCRProviders` became purpose-aware behind `GET /api/app/ai/providers?for=`, with `/ocr/providers` kept pointing at it so the OCR test page is untouched. It also reports the configured binding, which is how a chat names the model in use with nothing overridden.

## Shared-component fixes that came out of this

- `ProviderModelFields` renders no model field until a provider is chosen. `ModelSelect` reads an empty catalogue as "this provider has no catalogue" and falls back to a free-text box, so an unbound binding showed a text input where every bound one shows a dropdown — Settings' own unset bindings included.
- It reports a provider change as two calls in one handler, and a caller merging both into one object computed the second from the pre-change value, leaving the picker stuck on "Select a provider".
- `Combobox` flips its list upward when there is less room below than above. A picker under a chat composer sits at the foot of the window, where a downward list opens past the fold.

## Migrations

Two, both add-if-missing with a down: `chat_sessions.provider`/`model`, and one JSON `overrides` column on `processing_jobs`. Neither changes behaviour on its own — empty means the Settings bindings.

## Verification

`./scripts/test-all.sh` — all stages, 105 browser tests. `docker build` succeeds.

Both reported bugs have falsified regression tests: I reintroduced each and confirmed the test fails. Notably `listboxVisibility` hit-tests the open dropdown rather than trusting `toBeVisible`, which passes on a list clipped by an `overflow-hidden` ancestor — Playwright will click an option inside one, so the clipping was invisible to every other assertion. It is asserted at two viewport heights, because at 720px the list flips upward and never reaches the panel border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
