### PR TITLE
Keep files staged on the Files tab when you visit another one

### DIFF
--- a/frontend/src/routes/upload.index.tsx
+++ b/frontend/src/routes/upload.index.tsx
@@ -80,11 +80,20 @@ const INSTANCE_WIDE_LIMITS = new Set<LimitName>([
   'storage_bytes',
 ])
 
-// Files staged but not yet uploaded, kept outside the component: switching to
+// Files chosen but not yet sent, kept outside the component: switching to
 // another upload tab unmounts this page (#47) and a File cannot be serialised
 // into the router or into storage, so the only place it survives is a module
-// variable. Cleared when the upload succeeds or the list is cleared by hand.
+// variable. It holds what has not been submitted -- an upload empties it on the
+// way in -- so a session never inherits a list somebody else already sent.
 let stagedFiles: File[] = []
+
+// Same reason meCache is dropped in lib/auth: a module outlives the app tree,
+// and the next person to sign in on this browser must not find the last one's
+// files staged. Only on the way out -- this also fires when a live token is
+// refreshed, which must not empty the list under someone mid-selection.
+pb.authStore.onChange(() => {
+  if (!pb.authStore.isValid) stagedFiles = []
+})
 
 function formatBytes(size: number) {
   if (size < 1024) return `${size} B`
@@ -109,11 +118,14 @@ export function UploadFilesPage() {
   const [error, setError] = useState('')
   const [fileErrors, setFileErrors] = useState<FileUploadError[]>([])
 
+  // The module is the source of truth and is written first: React discards a
+  // state update aimed at an unmounted component, and a folder walk can finish
+  // after the tab it was dropped on has gone. Functional updates still see the
+  // latest list rather than a stale render, which is what two overlapping drops
+  // need.
   const setFiles = useCallback((next: File[] | ((current: File[]) => File[])) => {
-    setStagedFiles((current) => {
-      stagedFiles = typeof next === 'function' ? next(current) : next
-      return stagedFiles
-    })
+    stagedFiles = typeof next === 'function' ? next(stagedFiles) : next
+    setStagedFiles(stagedFiles)
   }, [])
 
   function resetInput() {
@@ -204,6 +216,10 @@ export function UploadFilesPage() {
       setError('Choose at least one file to upload.')
       return
     }
+
+    // Unstaged on the way in, so a tab switch mid-upload cannot come back to a
+    // second Upload button over the same files. Failures are put back below.
+    stagedFiles = []
 
     try {
       setUploading(true)

--- a/frontend/src/routes/upload.index.tsx
+++ b/frontend/src/routes/upload.index.tsx
@@ -1,4 +1,4 @@
-import { type DragEvent, type SubmitEvent, useRef, useState } from 'react'
+import { type DragEvent, type SubmitEvent, useCallback, useRef, useState } from 'react'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { pb } from '../lib/pb'
 import { ensureAuth } from '../lib/auth'
@@ -80,6 +80,12 @@ const INSTANCE_WIDE_LIMITS = new Set<LimitName>([
   'storage_bytes',
 ])
 
+// Files staged but not yet uploaded, kept outside the component: switching to
+// another upload tab unmounts this page (#47) and a File cannot be serialised
+// into the router or into storage, so the only place it survives is a module
+// variable. Cleared when the upload succeeds or the list is cleared by hand.
+let stagedFiles: File[] = []
+
 function formatBytes(size: number) {
   if (size < 1024) return `${size} B`
   if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
@@ -90,7 +96,7 @@ export function UploadFilesPage() {
   const navigate = useNavigate()
   const inputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)
-  const [files, setFiles] = useState<File[]>([])
+  const [files, setStagedFiles] = useState<File[]>(stagedFiles)
   // A zip is not an unsupported file, it is the wrong page -- so it gets a link
   // rather than the "use PDF, JPEG, ..." message.
   const [zipRejected, setZipRejected] = useState(false)
@@ -102,6 +108,13 @@ export function UploadFilesPage() {
   const [scanning, setScanning] = useState(false)
   const [error, setError] = useState('')
   const [fileErrors, setFileErrors] = useState<FileUploadError[]>([])
+
+  const setFiles = useCallback((next: File[] | ((current: File[]) => File[])) => {
+    setStagedFiles((current) => {
+      stagedFiles = typeof next === 'function' ? next(current) : next
+      return stagedFiles
+    })
+  }, [])
 
   function resetInput() {
     if (inputRef.current) inputRef.current.value = ''
@@ -242,6 +255,7 @@ export function UploadFilesPage() {
       }
 
       if (failures.length === 0) {
+        setFiles([])
         if (uploadedIds.length === 1) {
           navigate({ to: '/document/$documentId', params: { documentId: uploadedIds[0] } })
         } else {


### PR DESCRIPTION
Fixes #47.

Drop three documents on **Upload → Files**, look at *Amazon orders* or *Split documents*, come back, and the list is empty. The router unmounts the tab it leaves, so the component state holding the staged `File` objects goes with it and there is nothing left to press Upload on.

A `File` cannot be serialised into a search param or into `sessionStorage`, so the staged list now lives in a module variable that outlives the mount. The page seeds its `useState` from it, and every write goes through one `setFiles` wrapper that keeps the two in step — including the functional updates the folder walk depends on, where two drops can land before either has re-rendered. It is cleared when an upload succeeds and when the list is cleared by hand; a partial failure keeps the files that failed, as before.

Per-file error messages and the zip notice still reset on a tab switch: they describe the last attempt, not what is staged.

Scan and Split are unaffected — their work already lives server-side behind an upload id.

## Test plan

- Drop files on Files, switch to Amazon orders and Split documents, return to Files: the list is still there and Upload works.
- Upload succeeds → navigating back to Files shows an empty picker.
- Clear all → list empty on return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)